### PR TITLE
Feature: Added debug logs and asserts

### DIFF
--- a/Ludus.Games/Pong/Source/Pong/States/PlayingState.cpp
+++ b/Ludus.Games/Pong/Source/Pong/States/PlayingState.cpp
@@ -1,5 +1,7 @@
 #include <Pong/States/PlayingState.h>
 
+#include <Ludus/Debug/Debug.h>
+
 namespace Pong::States
 {
 
@@ -202,7 +204,7 @@ namespace Pong::States
 
 		if (!(player1Ptr && player2Ptr && ballPtr))
 		{
-			Ludus::Engine::Utilities::WriteLine("[Movement Integration] Missing transform(s).");
+			LUDUS_LOG_DEBUG("[Movement Integration] Missing transform(s).");
 			return GameState::Exit;
 		}
 
@@ -267,7 +269,7 @@ namespace Pong::States
 
 			if (!(colliderAPtr && colliderBPtr))
 			{
-				Ludus::Engine::Utilities::WriteLine("[Collision Handling] Missing transform(s).");
+				LUDUS_LOG_DEBUG("[Collision Handling] Missing transform(s).");
 				continue;
 			}
 
@@ -279,7 +281,7 @@ namespace Pong::States
 
 			if (!(transformAPtr && transformBPtr))
 			{
-				Ludus::Engine::Utilities::WriteLine("[Collision Handling] Missing colliders(s).");
+				LUDUS_LOG_DEBUG("[Collision Handling] Missing colliders(s).");
 				continue;
 			}
 
@@ -305,7 +307,7 @@ namespace Pong::States
 			{
 				if (IsPair(maskA, maskB, m_LayerMaskBall, m_LayerMaskHorizontal))
 				{
-					Ludus::Engine::Utilities::WriteLine("[Collision Handling] Ball <-> Boundary (horizontal)");
+					LUDUS_LOG_DEBUG("[Collision Handling] Ball <-> Boundary (horizontal)");
 
 					const Ludus::Math::Vector2D normal = (ballTransform->Position.Y > m_RenderData.GetHalfHeight() ? Ludus::Math::Vector2D(0.0f, -1.0f) : Ludus::Math::Vector2D(0.0f, 1.0f));
 					if (Ludus::Math::Vector2D::Dot(ballTransform->Forward(), normal) < 0.0f)
@@ -317,12 +319,12 @@ namespace Pong::States
 				}
 				else if (IsPair(maskA, maskB, m_LayerMaskBall, m_LayerMaskPlayer1))
 				{
-					Ludus::Engine::Utilities::WriteLine("[Collision Handling] Ball <-> Player 1");
+					LUDUS_LOG_DEBUG("[Collision Handling] Ball <-> Player 1");
 
 					const auto& player1Transform = m_GameInfo.Scene.Transforms.TryGetByOwner(m_Entities.Player1Handle);
 					if (!player1Transform)
 					{
-						Ludus::Engine::Utilities::WriteLine("[Collision Handling] Missing transform(s).");
+						LUDUS_LOG_DEBUG("[Collision Handling] Missing transform(s).");
 						continue;
 					}
 
@@ -342,12 +344,12 @@ namespace Pong::States
 				}
 				else if (IsPair(maskA, maskB, m_LayerMaskBall, m_LayerMaskPlayer2))
 				{
-					Ludus::Engine::Utilities::WriteLine("[Collision Handling] Ball <-> Player 2");
+					LUDUS_LOG_DEBUG("[Collision Handling] Ball <-> Player 2");
 
 					const auto& player2Transform = m_GameInfo.Scene.Transforms.TryGetByOwner(m_Entities.Player2Handle);
 					if (!player2Transform)
 					{
-						Ludus::Engine::Utilities::WriteLine("[Collision Handling] Missing transform(s).");
+						LUDUS_LOG_DEBUG("[Collision Handling] Missing transform(s).");
 						continue;
 					}
 
@@ -367,7 +369,7 @@ namespace Pong::States
 				}
 				else
 				{
-					Ludus::Engine::Utilities::WriteLine("[Collision Handling] Ball <-> Boundary (vertical)");
+					LUDUS_LOG_DEBUG("[Collision Handling] Ball <-> Boundary (vertical)");
 
 					if (ballTransform->Position.X <= Pong::Core::Configuration::Defaults::WallWidthThickness)
 					{
@@ -387,11 +389,11 @@ namespace Pong::States
 			{
 				if (IsPair(maskA, maskB, m_LayerMaskPlayer1, m_LayerMaskHorizontal))
 				{
-					Ludus::Engine::Utilities::WriteLine("[Collision Handling] Player 1 <-> Boundary (horizontal)");
+					LUDUS_LOG_DEBUG("[Collision Handling] Player 1 <-> Boundary (horizontal)");
 				}
 				else
 				{
-					Ludus::Engine::Utilities::WriteLine("[Collision Handling] Player 2 <-> Boundary (horizontal)");
+					LUDUS_LOG_DEBUG("[Collision Handling] Player 2 <-> Boundary (horizontal)");
 				}
 			}
 		}
@@ -417,7 +419,7 @@ namespace Pong::States
 		const auto* boundaryBottomTransform = m_GameInfo.Scene.Transforms.TryGetByOwnerMutable(m_Entities.BottomWallHandle);
 		if (!(boundaryTopTransform && boundaryBottomTransform))
 		{
-			Ludus::Engine::Utilities::WriteLine("[Rendering] Missing transform(s).");
+			LUDUS_LOG_DEBUG("[Rendering] Missing transform(s).");
 			return;
 		}
 
@@ -430,7 +432,7 @@ namespace Pong::States
 
 		if (!(player1Ptr && player2Ptr && ballPtr))
 		{
-			Ludus::Engine::Utilities::WriteLine("[Rendering] Missing transform(s).");
+			LUDUS_LOG_DEBUG("[Rendering] Missing transform(s).");
 			return;
 		}
 

--- a/Ludus/Include/Ludus/Debug/Debug.h
+++ b/Ludus/Include/Ludus/Debug/Debug.h
@@ -1,0 +1,175 @@
+#pragma once
+
+#include <cstdio>
+#include <source_location>
+#include <string>
+#include <string_view>
+#include <tuple>
+#include <utility>   
+
+
+#pragma region Build-time enable
+
+#ifndef LUDUS_DEBUG_BUILD
+#if defined(_DEBUG) && !defined(NDEBUG)
+#define LUDUS_DEBUG_BUILD 1
+#elif defined(NDEBUG)
+#define LUDUS_DEBUG_BUILD 0
+#else
+#define LUDUS_DEBUG_BUILD 1
+#endif
+#endif
+
+#ifndef LUDUS_RELEASE_BUILD
+#define LUDUS_RELEASE_BUILD (!LUDUS_DEBUG_BUILD)
+#endif
+
+#ifndef LUDUS_ENABLE_ASSERTS
+#define LUDUS_ENABLE_ASSERTS LUDUS_DEBUG_BUILD
+#endif
+
+// 0 = Trace, 1 = Debug, 2 = Info, 3 = Warn, 4 = Error, 5 = Critical, 6 = Off.
+#ifndef LUDUS_LOG_LEVEL
+#if LUDUS_DEBUG_BUILD
+#define LUDUS_LOG_LEVEL 1
+#else
+#define LUDUS_LOG_LEVEL 3
+#endif
+#endif
+
+#pragma endregion
+
+namespace Ludus::Debug
+{
+
+#pragma region Logging and Asserts
+
+	enum class LogLevel : int { Trace = 0, Debug, Info, Warn, Error, Critical, Off };
+
+	inline constexpr const char* ToString(LogLevel level) noexcept
+	{
+		switch (level)
+		{
+			case LogLevel::Trace:		return "TRACE";
+			case LogLevel::Debug:		return "DEBUG";
+			case LogLevel::Info:		return "INFO";
+			case LogLevel::Warn:		return "WARN";
+			case LogLevel::Error:		return "ERROR";
+			case LogLevel::Critical:	return "CRITICAL";
+			default:					return "OFF";
+		}
+	}
+
+	inline void LogLine(
+		LogLevel level,
+		std::string_view message,
+		std::source_location location = std::source_location::current()
+	)
+	{
+		std::fprintf(
+			stderr,
+			"%s(%u): [%s] %.*s\n",
+			location.file_name(),
+			static_cast<unsigned int>(location.line()),
+			ToString(level),
+			static_cast<int>(message.size()),
+			message.data()
+		);
+	}
+
+	inline void LogLineTagged(
+		LogLevel level,
+		std::string_view tag,
+		std::string_view message,
+		std::source_location location = std::source_location::current()
+	)
+	{
+		std::fprintf(
+			stderr,
+			"%s(%u): [%s][%.*s] %.*s\n",
+			location.file_name(),
+			static_cast<unsigned int>(location.line()),
+			ToString(level),
+			static_cast<int>(tag.size()),
+			tag.data(),
+			static_cast<int>(message.size()),
+			message.data()
+		);
+	}
+
+	inline void Fail(
+		std::string_view expression,
+		std::string_view message,
+		std::source_location location = std::source_location::current()
+	)
+	{
+		char buffer[1024];
+		const char* logMessage = message.empty() ? "assertion failed" : message.data();
+
+		std::snprintf(
+			buffer,
+			sizeof(buffer),
+			"%s | expr: %.*s",
+			logMessage,
+			static_cast<int>(expression.size()),
+			expression.data()
+		);
+
+		LogLine(LogLevel::Critical, buffer, location);
+
+		std::terminate();
+	}
+
+#pragma endregion
+
+}
+
+#pragma region Filtering
+
+#if LUDUS_LOG_LEVEL <= 0
+#define LUDUS_LOG_TRACE(message) Ludus::Debug::LogLine(Ludus::Debug::LogLevel::Trace, (message))
+#else
+#define LUDUS_LOG_TRACE(message) ((void)0)
+#endif
+
+#if LUDUS_LOG_LEVEL <= 1
+#define LUDUS_LOG_DEBUG(message) Ludus::Debug::LogLine(Ludus::Debug::LogLevel::Debug, (message))
+#else
+#define LUDUS_LOG_DEBUG(message) ((void)0)
+#endif
+
+#if LUDUS_LOG_LEVEL <= 2
+#define LUDUS_LOG_INFO(message)  Ludus::Debug::LogLine(Ludus::Debug::LogLevel::Info,  (message))
+#else
+#define LUDUS_LOG_INFO(message)  ((void)0)
+#endif
+
+#if LUDUS_LOG_LEVEL <= 3
+#define LUDUS_LOG_WARN(message)  Ludus::Debug::LogLine(Ludus::Debug::LogLevel::Warn,  (message))
+#else
+#define LUDUS_LOG_WARN(message)  ((void)0)
+#endif
+
+#if LUDUS_LOG_LEVEL <= 4
+#define LUDUS_LOG_ERROR(message) Ludus::Debug::LogLine(Ludus::Debug::LogLevel::Error, (message))
+#else
+#define LUDUS_LOG_ERROR(message) ((void)0)
+#endif
+
+#if LUDUS_LOG_LEVEL <= 5
+#define LUDUS_LOG_CRITICAL(message)  Ludus::Debug::LogLine(Ludus::Debug::LogLevel::Critical, (message))
+#else
+#define LUDUS_LOG_CRITICAL(message)  ((void)0)
+#endif
+
+#if LUDUS_ENABLE_ASSERTS
+#define LUDUS_ASSERT(expression, message) \
+      do { if(!(expression)) Ludus::Debug::Fail(#expression, (message)); } while(0)
+#define LUDUS_VERIFY(expression, message) \
+      do { if(!(expression)) Ludus::Debug::Fail(#expression, (message)); } while(0)
+#else
+#define LUDUS_ASSERT(expression, message) ((void)0)
+#define LUDUS_VERIFY(expression, message) ((void)(expression))
+#endif
+
+#pragma endregion

--- a/Ludus/Include/Ludus/Debug/DebugGL.h
+++ b/Ludus/Include/Ludus/Debug/DebugGL.h
@@ -1,0 +1,127 @@
+#pragma once
+
+#include <string>
+#include <tuple>
+
+#include <glad/glad.h>
+
+#include <Ludus/Debug/Debug.h>
+
+namespace Ludus::Debug
+{
+
+#if !defined(NDEBUG)
+
+	inline constexpr const char* GLSourceName(GLenum source) noexcept
+	{
+		switch (source)
+		{
+			case GL_DEBUG_SOURCE_API:             return "API";
+			case GL_DEBUG_SOURCE_WINDOW_SYSTEM:   return "WINDOW";
+			case GL_DEBUG_SOURCE_SHADER_COMPILER: return "SHADER";
+			case GL_DEBUG_SOURCE_THIRD_PARTY:     return "3RD";
+			case GL_DEBUG_SOURCE_APPLICATION:     return "APP";
+			case GL_DEBUG_SOURCE_OTHER:           return "OTHER";
+			default:                              return "UNKNOWN";
+		}
+	}
+
+	inline constexpr const char* GLTypeName(GLenum type) noexcept
+	{
+		switch (type)
+		{
+			case GL_DEBUG_TYPE_ERROR:               return "ERROR";
+			case GL_DEBUG_TYPE_DEPRECATED_BEHAVIOR: return "DEPRECATED";
+			case GL_DEBUG_TYPE_UNDEFINED_BEHAVIOR:  return "UNDEFINED";
+			case GL_DEBUG_TYPE_PORTABILITY:         return "PORTABILITY";
+			case GL_DEBUG_TYPE_PERFORMANCE:         return "PERF";
+			case GL_DEBUG_TYPE_MARKER:              return "MARKER";
+			case GL_DEBUG_TYPE_PUSH_GROUP:          return "PUSH";
+			case GL_DEBUG_TYPE_POP_GROUP:           return "POP";
+			case GL_DEBUG_TYPE_OTHER:               return "OTHER";
+			default:                                return "UNKNOWN";
+		}
+	}
+
+	inline constexpr LogLevel GLSeverityToLevel(GLenum sev) noexcept
+	{
+		switch (sev)
+		{
+			case GL_DEBUG_SEVERITY_HIGH:         return LogLevel::Critical;
+			case GL_DEBUG_SEVERITY_MEDIUM:       return LogLevel::Error;
+			case GL_DEBUG_SEVERITY_LOW:          return LogLevel::Warn;
+			case GL_DEBUG_SEVERITY_NOTIFICATION: return LogLevel::Debug;
+			default:                             return LogLevel::Info;
+		}
+	}
+
+	using CallbackParams = std::tuple<GLenum, GLenum, GLuint, GLenum, std::string>;
+
+	inline CallbackParams g_LastGLCallbackParams {};
+
+	inline void APIENTRY ErrorMessageCallback(
+		GLenum source,
+		GLenum type,
+		GLuint id,
+		GLenum severity,
+		GLsizei length,
+		const GLchar* message,
+		const void* userParams
+	)
+	{
+		// Ignore non-significant spam (from LearnOpenGL).
+		if (id == 131169 || id == 131185 || id == 131218 || id == 131204)
+			return;
+
+		CallbackParams params {
+			source,
+			type,
+			id,
+			severity,
+			std::string(message, static_cast<size_t>(length))
+		};
+
+		if (g_LastGLCallbackParams == params)
+		{
+			return;
+		}
+
+		g_LastGLCallbackParams = std::move(params);
+
+		char buffer[1024];
+
+		std::snprintf(
+			buffer,
+			sizeof(buffer),
+			"Source=%s, Type=%s, Id=%u, Severity=%s, Message=%.*s",
+			GLSourceName(source),
+			GLTypeName(type),
+			id,
+			ToString(GLSeverityToLevel(severity)),
+			static_cast<int>(length),
+			message
+		);
+
+		LogLineTagged(GLSeverityToLevel(severity), "OpenGL", buffer);
+	}
+
+#endif
+
+	inline void EnableOpenGLDebug()
+	{
+
+#if !defined(NDEBUG)
+
+		if (glDebugMessageCallback == nullptr)
+		{
+			return;
+		}
+
+		glEnable(GL_DEBUG_OUTPUT);
+		glEnable(GL_DEBUG_OUTPUT_SYNCHRONOUS);
+
+		glDebugMessageCallback(ErrorMessageCallback, nullptr);
+
+#endif
+	}
+}

--- a/Ludus/Include/Ludus/Engine/LayerMask.h
+++ b/Ludus/Include/Ludus/Engine/LayerMask.h
@@ -1,12 +1,13 @@
 #pragma once
 
-#include <assert.h>
 #include <bit>
 #include <cstdint>
 #include <stdexcept>
 #include <string>
 #include <unordered_map>
 #include <vector>
+
+#include <Ludus/Debug/Debug.h>
 
 namespace Ludus::Engine
 {
@@ -78,7 +79,7 @@ namespace Ludus::Engine
 
 		static LayerMask FromIndex(LayerIndex index)
 		{
-			assert(index < 32u);
+			LUDUS_ASSERT(index < 32u, "Index must be smaller than 32.");
 
 			if (index >= 32u)
 			{
@@ -101,7 +102,7 @@ namespace Ludus::Engine
 
 		static void AddLayer(const std::string& layerName, const LayerIndex layerIndex)
 		{
-			assert(layerIndex > 0u && layerIndex < 32u);
+			LUDUS_ASSERT(layerIndex > 0u && layerIndex < 32u, "Index must be between 1 and 31, inclusive.");
 
 			auto iterName = s_NameToIndex.find(layerName);
 			if (iterName != s_NameToIndex.end())

--- a/Ludus/Include/Ludus/Engine/Utilities.h
+++ b/Ludus/Include/Ludus/Engine/Utilities.h
@@ -7,19 +7,6 @@
 
 namespace Ludus::Engine::Utilities
 {
-#pragma region Error Handling
-
-	void __stdcall ErrorMessageCallback(
-		unsigned int source,
-		unsigned int type,
-		unsigned int id,
-		unsigned int severity,
-		int length,
-		const char* message,
-		const void* userParam
-	);
-#pragma endregion
-
 	std::vector<std::string> GetFileNames(std::string filePath);
 
 	std::string ReadFile(std::filesystem::path path);

--- a/Ludus/Ludus.vcxproj
+++ b/Ludus/Ludus.vcxproj
@@ -26,6 +26,8 @@
     <Font Include="Resources\Fonts\ARIAL.TTF" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="Include\Ludus\Debug\Debug.h" />
+    <ClInclude Include="Include\Ludus\Debug\DebugGL.h" />
     <ClInclude Include="Include\Ludus\Math\Circle.h" />
     <ClInclude Include="Include\Ludus\Engine\GameObjectRegistry.h" />
     <ClInclude Include="Include\Ludus\Math\Constants.h" />

--- a/Ludus/Source/Ludus/Engine/Utilities.cpp
+++ b/Ludus/Source/Ludus/Engine/Utilities.cpp
@@ -1,53 +1,7 @@
-#include <glad/glad.h>
-
 #include <Ludus/Engine/Utilities.h>
 
 namespace Ludus::Engine::Utilities
 {
-#pragma region ErrorMessageCallback
-
-	using CallbackParams = std::tuple<unsigned int, unsigned int, unsigned int, unsigned int, std::string>;
-
-	CallbackParams lastCallbackParameters;
-
-	void APIENTRY ErrorMessageCallback(
-		unsigned int source,
-		unsigned int type,
-		unsigned int id,
-		unsigned int severity,
-		int length,
-		const char* message,
-		const void* userParam
-	)
-	{
-		// Ignore non-significant error/warning codes. See https://learnopengl.com/In-Practice/Debugging.
-		if (id == 131169 || id == 131185 || id == 131218 || id == 131204)
-		{
-			return;
-		}
-
-		CallbackParams callbackParameters = { source, type, id, severity, std::string(message, length) };
-
-		if (lastCallbackParameters == callbackParameters)
-		{
-			return;
-		}
-
-		lastCallbackParameters = std::move(callbackParameters);
-
-		std::string output;
-		output += "[OpenGL Error] ";
-		output += "Source: " + std::to_string(source);
-		output += ", Type: " + std::to_string(type);
-		output += ", Id: " + std::to_string(id);
-		output += ", Severity: " + std::to_string(severity);
-		output += ", Message: " + std::string(message, length);
-
-		WriteLine(output);
-	}
-
-#pragma endregion
-
 	std::vector<std::string> GetFileNames(std::string path)
 	{
 		auto fileNames = std::vector<std::string>();

--- a/Ludus/Source/Ludus/Graphics/ElementBufferObject.cpp
+++ b/Ludus/Source/Ludus/Graphics/ElementBufferObject.cpp
@@ -1,5 +1,6 @@
 #include <glad/glad.h>
 
+#include <Ludus/Debug/Debug.h>
 #include <Ludus/Graphics/ElementBufferObject.h>
 
 namespace Ludus::Graphics
@@ -53,7 +54,8 @@ namespace Ludus::Graphics
 		auto previousCount = m_Count;
 		if (m_Count + count > m_MaxCount)
 		{
-			Ludus::Engine::Utilities::WriteLine("Cannot add dynamic data. The element buffer is full.");
+			LUDUS_LOG_ERROR("Cannot add dynamic data. The element buffer is full.");
+
 			return;
 		}
 

--- a/Ludus/Source/Ludus/Graphics/GLContext.cpp
+++ b/Ludus/Source/Ludus/Graphics/GLContext.cpp
@@ -1,26 +1,39 @@
+#include <format>
+
 #include <glad/glad.h>
 #include <GLFW/glfw3.h>
 
+#include <Ludus/Debug/Debug.h>
+#include <Ludus/Debug/DebugGL.h>
 #include <Ludus/Graphics/GLContext.h>
 
 namespace Ludus::Graphics
 {
-	using Ludus::Engine::Utilities::WriteLine;
-
 	void GLContext::Init()
 	{
 		if (!gladLoadGLLoader((GLADloadproc)glfwGetProcAddress))
 		{
-			WriteLine("Failed to initialize GLAD.");
+			LUDUS_LOG_CRITICAL("Failed to initialize GLAD.");
+
 			return;
 		}
 
-		glEnable(GL_DEBUG_OUTPUT);
-		glEnable(GL_DEBUG_OUTPUT_SYNCHRONOUS);
-		glDebugMessageCallback(Ludus::Engine::Utilities::ErrorMessageCallback, nullptr);
+		Ludus::Debug::EnableOpenGLDebug();
 
-		Ludus::Engine::Utilities::Write("GL version: ");
-		WriteLine((const char*)glGetString(GL_VERSION));
+		auto* version = reinterpret_cast<const char*>(glGetString(GL_VERSION));
+		if (version)
+		{
+			LUDUS_LOG_INFO(
+				std::format(
+					"GL version: {}",
+					version
+				)
+			);
+		}
+		else
+		{
+			LUDUS_LOG_ERROR("Failed to determine OpenGL version.");
+		}
 	}
 
 	void GLContext::EnableBlending()

--- a/Ludus/Source/Ludus/Graphics/Shader.cpp
+++ b/Ludus/Source/Ludus/Graphics/Shader.cpp
@@ -1,13 +1,13 @@
+#include <format>
+
 #include <glad/glad.h>
 
+#include <Ludus/Debug/Debug.h>
 #include <Ludus/Engine/Utilities.h>
 #include <Ludus/Graphics/Shader.h>
 
 namespace Ludus::Graphics
 {
-	using Ludus::Engine::Utilities::WriteLine;
-	using Ludus::Engine::Utilities::ReadFile;
-
 	Shader::Shader(std::filesystem::path path)
 	{
 		m_Handle = LoadShaders(path);
@@ -63,9 +63,11 @@ namespace Ludus::Graphics
 		glGetShaderiv(shaderHandle, GL_COMPILE_STATUS, &status);
 		if (status == GL_FALSE)
 		{
-			WriteLine(
-				"Failed to compile the " +
-				std::string(shaderType == GL_VERTEX_SHADER ? "vertex shader" : "fragment shader")
+			LUDUS_LOG_CRITICAL(
+				std::format(
+					"Failed to compile the {}",
+					(shaderType == GL_VERTEX_SHADER ? "vertex shader" : "fragment shader")
+				)
 			);
 
 			int logLength;
@@ -74,8 +76,15 @@ namespace Ludus::Graphics
 			std::string logMessage(logLength, '\0');
 			glGetShaderInfoLog(shaderHandle, logLength, nullptr, &logMessage[0]);
 
-			WriteLine(logMessage);
+			LUDUS_LOG_INFO(logMessage);
 		}
+
+		LUDUS_LOG_INFO(
+			std::format(
+				"Successfully compiled the {}",
+				(shaderType == GL_VERTEX_SHADER ? "vertex shader" : "fragment shader")
+			)
+		);
 
 		return shaderHandle;
 	}
@@ -98,7 +107,7 @@ namespace Ludus::Graphics
 		glGetProgramiv(programHandle, GL_LINK_STATUS, &status);
 		if (status == GL_FALSE)
 		{
-			WriteLine("Failed to link the program.");
+			LUDUS_LOG_CRITICAL("Failed to link the program.");
 		}
 
 		for (size_t i = 0; i < shaders.size(); i++)
@@ -111,8 +120,8 @@ namespace Ludus::Graphics
 
 	unsigned int Shader::LoadShaders(std::filesystem::path path)
 	{
-		auto vertexSource = ReadFile((path / "shader.vert").string().data());
-		auto fragmentSource = ReadFile((path / "shader.frag").string().data());
+		auto vertexSource = Ludus::Engine::Utilities::ReadFile((path / "shader.vert").string().data());
+		auto fragmentSource = Ludus::Engine::Utilities::ReadFile((path / "shader.frag").string().data());
 
 		auto shaders = std::vector<std::tuple<unsigned int, std::string>>();
 		shaders.push_back({ GL_VERTEX_SHADER, std::string(vertexSource) });

--- a/Ludus/Source/Ludus/Graphics/Texture.cpp
+++ b/Ludus/Source/Ludus/Graphics/Texture.cpp
@@ -1,6 +1,9 @@
+#include <format>
+
 #include <glad/glad.h>
 #include <stb_image/stb_image.h>
 
+#include <Ludus/Debug/Debug.h>
 #include <Ludus/Engine/Utilities.h>
 #include <Ludus/Graphics/Texture.h>
 
@@ -46,7 +49,10 @@ namespace Ludus::Graphics
 		auto m_Data = stbi_load(path.c_str(), &width, &height, &_, 4);
 		if (!m_Data)
 		{
-			Ludus::Engine::Utilities::WriteLine("Failed to load texture: " + std::string(path));
+			LUDUS_LOG_ERROR(
+				std::format("Failed to load texture: {}", path)
+			);
+
 			return Texture::White();
 		}
 

--- a/Ludus/Source/Ludus/Graphics/VertexBufferObject.cpp
+++ b/Ludus/Source/Ludus/Graphics/VertexBufferObject.cpp
@@ -1,5 +1,6 @@
 #include <glad/glad.h>
 
+#include <Ludus/Debug/Debug.h>
 #include <Ludus/Graphics/VertexBufferObject.h>
 
 namespace Ludus::Graphics
@@ -53,7 +54,8 @@ namespace Ludus::Graphics
 		auto previousCount = m_Count;
 		if (m_Count + count > m_MaxCount)
 		{
-			Ludus::Engine::Utilities::WriteLine("Cannot add dynamic data. The vertex buffer is full.");
+			LUDUS_LOG_ERROR("Cannot add dynamic data. The vertex buffer is full.");
+
 			return;
 		}
 

--- a/Ludus/Source/Ludus/Platform/Window.cpp
+++ b/Ludus/Source/Ludus/Platform/Window.cpp
@@ -1,5 +1,6 @@
 #include <glad/glad.h>
 
+#include <Ludus/Debug/Debug.h>
 #include <Ludus/Platform/Window.h>
 
 namespace Ludus::Platform
@@ -26,7 +27,7 @@ namespace Ludus::Platform
 	{
 		if (!glfwInit())
 		{
-			Ludus::Engine::Utilities::WriteLine("Failed to initialize GLFW.");
+			LUDUS_LOG_CRITICAL("Failed to initialize GLFW.");
 			return;
 		}
 
@@ -38,7 +39,8 @@ namespace Ludus::Platform
 		m_Handle = glfwCreateWindow(m_Width, m_Height, m_Title.data(), NULL, NULL);
 		if (!m_Handle)
 		{
-			Ludus::Engine::Utilities::WriteLine("Failed to create a GLFW window.");
+			LUDUS_LOG_CRITICAL("Failed to create a GLFW window.");
+
 			glfwTerminate();
 			return;
 		}


### PR DESCRIPTION
# Summary
Added `Ludus::Debug` namespace. Asserts and debug logs macros were created for different debug levels. OpenGL error handling was moved to a `DebugGL` header to avoid including `glad.h` when logging normally.

# Linked
- Closes #19 
- Story: #31  

