### PR TITLE
Story: Added pass-based rendering pipeline architecture

### DIFF
--- a/Editor/Include/Ludus/Editor/Core/EditorApplicationBuilder.h
+++ b/Editor/Include/Ludus/Editor/Core/EditorApplicationBuilder.h
@@ -5,8 +5,9 @@
 #include <Ludus/Editor/Core/EditorConfiguration.h>
 #include <Ludus/Engine/Core/Application.h>
 #include <Ludus/Engine/Core/ApplicationBuilder.h>
+#include <Ludus/Engine/Graphics/RenderingConfiguration2D.h>
 #include <Ludus/Engine/Graphics/RenderingOptions.h>
-#include <Ludus/Engine/Physics/Core/PhysicsContext2D.h>
+#include <Ludus/Engine/Physics/Core/PhysicsConfiguration2D.h>
 #include <Ludus/Engine/Platform/WindowOptions.h>
 
 namespace Ludus::Editor::Core
@@ -18,7 +19,8 @@ namespace Ludus::Editor::Core
 
 		Ludus::Engine::Platform::WindowOptions m_WindowOptions;
 		Ludus::Engine::Graphics::RenderingOptions m_RenderingOptions;
-		Ludus::Engine::Physics::Core::PhysicsContext2D m_PhysicsContext;
+		Ludus::Engine::Physics::Core::PhysicsConfiguration2D m_PhysicsConfiguration;
+		Ludus::Engine::Graphics::RenderingConfiguration2D m_RenderingConfiguration;
 
 		Ludus::Editor::Core::EditorConfiguration m_EditorConfiguration = Ludus::Editor::Core::EditorConfiguration::Default();
 

--- a/Editor/Source/Ludus/Editor/Core/EditorApplicationBuilder.cpp
+++ b/Editor/Source/Ludus/Editor/Core/EditorApplicationBuilder.cpp
@@ -4,6 +4,12 @@
 #include <Ludus/Editor/Core/EditorConfiguration.h>
 #include <Ludus/Editor/Core/EditorSystem.h>
 #include <Ludus/Editor/Core/Scene.h>
+#include <Ludus/Engine/Core/Application.h>
+#include <Ludus/Engine/Core/ApplicationBuilder.h>
+#include <Ludus/Engine/Graphics/RenderingConfiguration2D.h>
+#include <Ludus/Engine/Graphics/RenderingOptions.h>
+#include <Ludus/Engine/Physics/Core/PhysicsConfiguration2D.h>
+#include <Ludus/Engine/Platform/WindowOptions.h>
 #include <Ludus/UI/Systems/ImGuiModule.h>
 
 namespace Ludus::Editor::Core
@@ -29,14 +35,16 @@ namespace Ludus::Editor::Core
 	{
 		m_WindowOptions = Ludus::Engine::Platform::WindowOptions(1920, 1080, "Ludus Editor", true);
 		m_RenderingOptions = Ludus::Engine::Graphics::RenderingOptions(Ludus::Engine::Graphics::Colors::DarkGray);
-		m_PhysicsContext = Ludus::Engine::Physics::Core::PhysicsContext2D();
+		m_PhysicsConfiguration = Ludus::Engine::Physics::Core::PhysicsConfiguration2D();
+		m_RenderingConfiguration = Ludus::Engine::Graphics::RenderingConfiguration2D();
 
 		Ludus::UI::Systems::RegisterImGui(m_ApplicationBuilder);
 
 		m_ApplicationBuilder
 			.WithWindowOptions(m_WindowOptions)
 			.WithRenderingOptions(m_RenderingOptions)
-			.WithPhysicsContext(std::move(m_PhysicsContext))
+			.WithPhysicsConfiguration(std::move(m_PhysicsConfiguration))
+			.WithRenderingConfiguration(std::move(m_RenderingConfiguration))
 			.UseDefaultPhysics2D()
 			.UseDefaultRendering2D();
 

--- a/Editor/Source/Ludus/Editor/Panels/ViewportPanel.cpp
+++ b/Editor/Source/Ludus/Editor/Panels/ViewportPanel.cpp
@@ -104,9 +104,5 @@ namespace Ludus::Editor::Panels
 
 			context.SystemContext.RenderViews.Register(renderView);
 		}
-		else
-		{
-			LUDUS_LOG_INFO("Viewport window body NOT executing");
-		}
 	}
 }

--- a/Engine/Engine.vcxproj
+++ b/Engine/Engine.vcxproj
@@ -54,9 +54,14 @@
     <ClInclude Include="Include\Ludus\Engine\Events\WindowEvents.h" />
     <ClInclude Include="Include\Ludus\Engine\Geometries\Queries.h" />
     <ClInclude Include="Include\Ludus\Engine\Graphics\HorizontalTextAlignment.h" />
+    <ClInclude Include="Include\Ludus\Engine\Graphics\IRenderPass.h" />
+    <ClInclude Include="Include\Ludus\Engine\Graphics\RenderingConfiguration2D.h" />
+    <ClInclude Include="Include\Ludus\Engine\Graphics\RenderContext2D.h" />
     <ClInclude Include="Include\Ludus\Engine\Graphics\RenderingSystem2D.h" />
+    <ClInclude Include="Include\Ludus\Engine\Graphics\RenderPhaseOrder.h" />
     <ClInclude Include="Include\Ludus\Engine\Graphics\RenderTarget.h" />
     <ClInclude Include="Include\Ludus\Engine\Graphics\RenderView2D.h" />
+    <ClInclude Include="Include\Ludus\Engine\Graphics\SceneRenderPass.h" />
     <ClInclude Include="Include\Ludus\Engine\Graphics\Shape.h" />
     <ClInclude Include="Include\Ludus\Engine\Components\Sprite2DComponent.h" />
     <ClInclude Include="Include\Ludus\Engine\Components\Text2DComponent.h" />
@@ -97,7 +102,7 @@
     <ClInclude Include="Include\Ludus\Engine\Physics\Core\BodyType.h" />
     <ClInclude Include="Include\Ludus\Engine\Components\Collider2DComponent.h" />
     <ClInclude Include="Include\Ludus\Engine\Physics\Core\Constants.h" />
-    <ClInclude Include="Include\Ludus\Engine\Physics\Core\PhysicsContext2D.h" />
+    <ClInclude Include="Include\Ludus\Engine\Physics\Core\PhysicsConfiguration2D.h" />
     <ClInclude Include="Include\Ludus\Engine\Physics\Core\PhysicsPipeline2D.h" />
     <ClInclude Include="Include\Ludus\Engine\Physics\Core\PhysicsSystem2D.h" />
     <ClInclude Include="Include\Ludus\Engine\Physics\Core\PhysicsWorld2D.h" />
@@ -122,6 +127,7 @@
     <ClInclude Include="Include\Ludus\Engine\Core\ISystem.h" />
     <ClInclude Include="Include\Ludus\Engine\Core\Scheduler.h" />
     <ClInclude Include="Include\Ludus\Engine\Platform\WindowUserData.h" />
+    <ClInclude Include="Include\Ludus\Engine\Graphics\RenderingPipeline2D.h" />
     <ClInclude Include="Source\Ludus\Engine\pch.h" />
     <ClInclude Include="Vendors\glad\include\glad\glad.h" />
     <ClInclude Include="Vendors\glad\include\KHR\khrplatform.h" />

--- a/Engine/Include/Ludus/Engine/Core/Application.h
+++ b/Engine/Include/Ludus/Engine/Core/Application.h
@@ -17,8 +17,9 @@
 #include <Ludus/Engine/Events/EventHandler.h>
 #include <Ludus/Engine/Events/WindowEvents.h>
 #include <Ludus/Engine/Graphics/GLContext.h>
+#include <Ludus/Engine/Graphics/RenderingConfiguration2D.h>
 #include <Ludus/Engine/Graphics/RenderingOptions.h>
-#include <Ludus/Engine/Physics/Core/PhysicsContext2D.h>
+#include <Ludus/Engine/Physics/Core/PhysicsConfiguration2D.h>
 #include <Ludus/Engine/Platform/Input.h>
 #include <Ludus/Engine/Platform/Window.h>
 
@@ -27,14 +28,15 @@ namespace Ludus::Engine::Core
 	class Application : public Ludus::Engine::Events::Eventhandler
 	{
 	private:
+		std::unique_ptr<Ludus::Engine::Core::EntityComponentSystem> m_EntityComponentSystem;
 		std::unique_ptr<Ludus::Engine::Events::EventBus> m_EventBus;
 		std::unique_ptr<Ludus::Engine::Platform::Input> m_Input;
 		std::unique_ptr<Ludus::Engine::Platform::Window> m_Window;
 		std::unique_ptr<Ludus::Engine::Graphics::GLContext> m_GLContext;
-		std::unique_ptr<Ludus::Engine::Physics::Core::PhysicsContext2D> m_PhysicsContext;
+		std::unique_ptr<Ludus::Engine::Graphics::RenderingConfiguration2D> m_RenderingConfiguration;
+		std::unique_ptr<Ludus::Engine::Physics::Core::PhysicsConfiguration2D> m_PhysicsConfiguration;
 		std::unique_ptr<Ludus::Engine::Core::ResourceRegistry> m_Resources;
 		std::unique_ptr<Ludus::Engine::Core::RenderViewRegistry> m_RenderViewRegistry;
-		std::unique_ptr<Ludus::Engine::Core::EntityComponentSystem> m_EntityComponentSystem;
 		std::unique_ptr<Ludus::Engine::Core::Time> m_Time;
 		Ludus::Engine::Core::SystemContext m_SystemContext;
 		std::unique_ptr<Ludus::Engine::Core::Scheduler> m_Scheduler;
@@ -43,14 +45,16 @@ namespace Ludus::Engine::Core
 		Application(
 			Ludus::Engine::Platform::WindowOptions windowOptions = Ludus::Engine::Platform::WindowOptions(),
 			Ludus::Engine::Graphics::RenderingOptions renderingOptions = Ludus::Engine::Graphics::RenderingOptions(),
-			Ludus::Engine::Physics::Core::PhysicsContext2D physicsContext = Ludus::Engine::Physics::Core::PhysicsContext2D()
+			Ludus::Engine::Graphics::RenderingConfiguration2D renderingConfiguration = Ludus::Engine::Graphics::RenderingConfiguration2D(),
+			Ludus::Engine::Physics::Core::PhysicsConfiguration2D physicsConfiguration = Ludus::Engine::Physics::Core::PhysicsConfiguration2D()
 		);
 		~Application() = default;
 
 		static std::unique_ptr<Application> Create(
 			Ludus::Engine::Platform::WindowOptions windowOptions = Ludus::Engine::Platform::WindowOptions(),
 			Ludus::Engine::Graphics::RenderingOptions renderingOptions = Ludus::Engine::Graphics::RenderingOptions(),
-			Ludus::Engine::Physics::Core::PhysicsContext2D physicsContext = Ludus::Engine::Physics::Core::PhysicsContext2D()
+			Ludus::Engine::Graphics::RenderingConfiguration2D renderingConfiguration = Ludus::Engine::Graphics::RenderingConfiguration2D(),
+			Ludus::Engine::Physics::Core::PhysicsConfiguration2D physicsConfiguration = Ludus::Engine::Physics::Core::PhysicsConfiguration2D()
 		);
 
 		void AddSystem(SystemPhaseInfo info, std::unique_ptr<ISystem> system);
@@ -61,8 +65,11 @@ namespace Ludus::Engine::Core
 		SystemContext& GetSystemContext() { return m_SystemContext; }
 		const SystemContext& GetSystemContext() const { return m_SystemContext; }
 
-		Ludus::Engine::Physics::Core::PhysicsContext2D& GetPhysicsContext() { return *m_PhysicsContext; }
-		const Ludus::Engine::Physics::Core::PhysicsContext2D& GetPhysicsContext() const { return *m_PhysicsContext; }
+		Ludus::Engine::Physics::Core::PhysicsConfiguration2D& GetPhysicsConfiguration() { return *m_PhysicsConfiguration; }
+		const Ludus::Engine::Physics::Core::PhysicsConfiguration2D& GetPhysicsConfiguration() const { return *m_PhysicsConfiguration; }
+
+		Ludus::Engine::Graphics::RenderingConfiguration2D& GetRenderingConfiguration() { return *m_RenderingConfiguration; }
+		const Ludus::Engine::Graphics::RenderingConfiguration2D& GetRenderingConfiguration() const { return *m_RenderingConfiguration; }
 
 		void SubscribeToEvents();
 		virtual bool ProcessEvent(const Ludus::Engine::Events::Event& event) override;

--- a/Engine/Include/Ludus/Engine/Core/ApplicationBuilder.h
+++ b/Engine/Include/Ludus/Engine/Core/ApplicationBuilder.h
@@ -7,9 +7,10 @@
 #include <Ludus/Engine/Core/Application.h>
 #include <Ludus/Engine/Core/SystemPhase.h>
 #include <Ludus/Engine/Core/SystemPhaseInfo.h>
+#include <Ludus/Engine/Graphics/RenderingConfiguration2D.h>
 #include <Ludus/Engine/Graphics/RenderingOptions.h>
 #include <Ludus/Engine/Graphics/RenderingSystem2D.h>
-#include <Ludus/Engine/Physics/Core/PhysicsContext2D.h>
+#include <Ludus/Engine/Physics/Core/PhysicsConfiguration2D.h>
 #include <Ludus/Engine/Physics/Core/PhysicsSystem2D.h>
 #include <Ludus/Engine/Platform/WindowOptions.h>
 
@@ -22,7 +23,8 @@ namespace Ludus::Engine::Core
 	private:
 		Ludus::Engine::Platform::WindowOptions m_WindowOptions;
 		Ludus::Engine::Graphics::RenderingOptions m_RenderingOptions;
-		Ludus::Engine::Physics::Core::PhysicsContext2D m_PhysicsContext;
+		Ludus::Engine::Graphics::RenderingConfiguration2D m_RenderingConfiguration;
+		Ludus::Engine::Physics::Core::PhysicsConfiguration2D m_PhysicsConfiguration;
 
 		std::vector<BuilderCommand> m_BuilderCommands;
 
@@ -36,7 +38,8 @@ namespace Ludus::Engine::Core
 
 		ApplicationBuilder& WithWindowOptions(Ludus::Engine::Platform::WindowOptions windowOptions);
 		ApplicationBuilder& WithRenderingOptions(Ludus::Engine::Graphics::RenderingOptions renderingOptions);
-		ApplicationBuilder& WithPhysicsContext(Ludus::Engine::Physics::Core::PhysicsContext2D physicsContext);
+		ApplicationBuilder& WithRenderingConfiguration(Ludus::Engine::Graphics::RenderingConfiguration2D renderingConfiguration);
+		ApplicationBuilder& WithPhysicsConfiguration(Ludus::Engine::Physics::Core::PhysicsConfiguration2D physicsConfiguration);
 
 		ApplicationBuilder& UseDefaultRendering2D();
 		ApplicationBuilder& UseDefaultPhysics2D();

--- a/Engine/Include/Ludus/Engine/Graphics/IRenderPass.h
+++ b/Engine/Include/Ludus/Engine/Graphics/IRenderPass.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+#include <Ludus/Engine/Graphics/RenderContext2D.h>
+#include <Ludus/Engine/Graphics/Renderer2D.h>
+#include <Ludus/Engine/Graphics/RenderPhaseOrder.h>
+
+namespace Ludus::Engine::Graphics
+{
+	struct IRenderPass
+	{
+		std::string Name;
+		uint32_t Id = 0;
+		Ludus::Engine::Graphics::RenderPhaseOrder Order = Ludus::Engine::Graphics::RenderPhaseOrder::Normal;
+
+		virtual bool Enabled(Ludus::Engine::Graphics::RenderContext2D& context) = 0;
+		virtual void Execute(Ludus::Engine::Graphics::RenderContext2D& context, Ludus::Engine::Graphics::Renderer2D& renderer) = 0;
+	};
+}

--- a/Engine/Include/Ludus/Engine/Graphics/RenderContext2D.h
+++ b/Engine/Include/Ludus/Engine/Graphics/RenderContext2D.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <Ludus/Engine/Core/SystemContext.h>
+#include <Ludus/Engine/Graphics/RenderView2D.h>
+
+namespace Ludus::Engine::Graphics
+{
+	struct RenderContext2D
+	{
+		Ludus::Engine::Core::SystemContext* SystemContext;
+		const Ludus::Engine::Graphics::RenderView2D& RenderView;
+		void* UserData = nullptr;
+	};
+}

--- a/Engine/Include/Ludus/Engine/Graphics/RenderPhaseOrder.h
+++ b/Engine/Include/Ludus/Engine/Graphics/RenderPhaseOrder.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <cstdint>
+
+namespace Ludus::Engine::Graphics
+{
+	enum class RenderPhaseOrder : uint8_t { Before = 0, Normal = 1, After = 2 };
+}

--- a/Engine/Include/Ludus/Engine/Graphics/RenderingConfiguration2D.h
+++ b/Engine/Include/Ludus/Engine/Graphics/RenderingConfiguration2D.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include <Ludus/Engine/Graphics/IRenderPass.h>
+#include <Ludus/Engine/Graphics/SceneRenderPass.h>
+
+namespace Ludus::Engine::Graphics
+{
+	struct RenderingConfiguration2D
+	{
+	private:
+		std::vector<std::unique_ptr<Ludus::Engine::Graphics::IRenderPass>> m_RenderPasses;
+
+		void SortPasses()
+		{
+			std::sort(
+				m_RenderPasses.begin(),
+				m_RenderPasses.end(),
+				[](const auto& a, const auto& b) { return a->Order < b->Order; }
+			);
+		}
+
+	public:
+		RenderingConfiguration2D(std::vector<std::unique_ptr<IRenderPass>> passes)
+			: m_RenderPasses(std::move(passes))
+		{
+			SortPasses();
+		}
+
+		RenderingConfiguration2D()
+			: m_RenderPasses()
+		{
+			m_RenderPasses.push_back(std::make_unique<SceneRenderPass>());
+
+			SortPasses();
+		}
+
+		void AddPass(std::unique_ptr<Ludus::Engine::Graphics::IRenderPass> renderPass)
+		{
+			m_RenderPasses.push_back(std::move(renderPass));
+		}
+
+		const std::vector<std::unique_ptr<Ludus::Engine::Graphics::IRenderPass>>& GetRenderPasses() const
+		{
+			return m_RenderPasses;
+		}
+	};
+}

--- a/Engine/Include/Ludus/Engine/Graphics/RenderingPipeline2D.h
+++ b/Engine/Include/Ludus/Engine/Graphics/RenderingPipeline2D.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <algorithm>
+#include <memory>
+#include <vector>
+
+#include <Ludus/Engine/Graphics/IRenderPass.h>
+#include <Ludus/Engine/Graphics/Renderer2D.h>
+#include <Ludus/Engine/Graphics/RenderView2D.h>
+
+namespace Ludus::Engine::Graphics
+{
+	struct RenderingPipeline2D
+	{
+	private:
+		const std::vector<std::unique_ptr<Ludus::Engine::Graphics::IRenderPass>>& m_RenderPasses;
+
+	public:
+		RenderingPipeline2D(const std::vector<std::unique_ptr<IRenderPass>>& renderPasses)
+			: m_RenderPasses(renderPasses)
+		{ }
+
+		~RenderingPipeline2D() = default;
+
+		void Execute(Ludus::Engine::Graphics::RenderContext2D renderContext, Ludus::Engine::Graphics::Renderer2D& renderer)
+		{
+			for (auto& pass : m_RenderPasses)
+			{
+				if (pass->Enabled(renderContext))
+				{
+					pass->Execute(renderContext, renderer);
+				}
+			}
+		}
+	};
+}

--- a/Engine/Include/Ludus/Engine/Graphics/RenderingSystem2D.h
+++ b/Engine/Include/Ludus/Engine/Graphics/RenderingSystem2D.h
@@ -4,7 +4,10 @@
 
 #include <Ludus/Engine/Core/EntityComponentSystem.h>
 #include <Ludus/Engine/Core/SystemContext.h>
+#include <Ludus/Engine/Graphics/RenderContext2D.h>
 #include <Ludus/Engine/Graphics/Renderer2D.h>
+#include <Ludus/Engine/Graphics/RenderingConfiguration2D.h>
+#include <Ludus/Engine/Graphics/RenderingPipeline2D.h>
 #include <Ludus/Engine/Graphics/RenderTarget.h>
 #include <Ludus/Engine/Graphics/RenderView2D.h>
 #include <Ludus/Engine/Graphics/Shader.h>
@@ -14,13 +17,15 @@ namespace Ludus::Engine::Graphics
 {
 	class RenderingSystem2D final : public Ludus::Engine::Core::ISystem
 	{
+		std::unique_ptr<RenderingPipeline2D> m_RenderingPipeline;
 		std::unique_ptr<Renderer2D> m_Renderer;
 		std::unique_ptr<Shader> m_Shader;
 		RenderingOptions m_RenderingOptions;
+		RenderingConfiguration2D& m_RenderingConfiguration;
 
 	public:
-		RenderingSystem2D(RenderingOptions renderingOptions)
-			: m_Renderer(nullptr), m_RenderingOptions(renderingOptions)
+		RenderingSystem2D(RenderingOptions renderingOptions, RenderingConfiguration2D& renderingConfiguration)
+			: m_RenderingPipeline(nullptr), m_Renderer(nullptr), m_RenderingOptions(renderingOptions), m_RenderingConfiguration(renderingConfiguration)
 		{ }
 		~RenderingSystem2D() = default;
 
@@ -30,6 +35,7 @@ namespace Ludus::Engine::Graphics
 			m_Shader = std::make_unique<Shader>();
 			m_Renderer = std::make_unique<Renderer2D>(*m_Shader);
 			m_Renderer->SetClearColor(m_RenderingOptions.ClearColor);
+			m_RenderingPipeline = std::make_unique<RenderingPipeline2D>(m_RenderingConfiguration.GetRenderPasses());
 		}
 
 		virtual void RenderImpl() override
@@ -43,41 +49,13 @@ namespace Ludus::Engine::Graphics
 					return;
 				}
 
-				// Render pass.
+				// Execute render passes.
 				targetPtr->Framebuffer.Bind();
 
 				m_Renderer->BeginScene(renderView.Camera);
 				m_Renderer->Clear();
 
-				auto& ecs = m_SystemContext->EntityComponentSystem;
-
-				for (const auto& sprite : ecs.Sprites.View())
-				{
-					const auto* transform = ecs.Transforms.TryGetByOwner(sprite.OwnerHandle);
-					if (!transform)
-					{
-						continue;
-					}
-
-					switch (sprite.Shape)
-					{
-						case Ludus::Engine::Graphics::Shape::Rect:
-							m_Renderer->DrawQuad(*transform, sprite.Color, sprite.Texture, sprite.Fill);
-							break;
-						case Ludus::Engine::Graphics::Shape::Circle:
-							m_Renderer->DrawCircle(*transform, sprite.Color, sprite.Fill);
-							break;
-					}
-				}
-
-				for (const auto& text : ecs.Texts.View())
-				{
-					const auto* transform = ecs.Transforms.TryGetByOwner(text.OwnerHandle);
-					if (transform)
-					{
-						m_Renderer->DrawText(*transform, text.Text, text.Color, text.HorizontalAlignment);
-					}
-				}
+				m_RenderingPipeline->Execute({ m_SystemContext, renderView }, *m_Renderer);
 
 				m_Renderer->EndScene();
 

--- a/Engine/Include/Ludus/Engine/Graphics/SceneRenderPass.h
+++ b/Engine/Include/Ludus/Engine/Graphics/SceneRenderPass.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <Ludus/Engine/Graphics/IRenderPass.h>
+#include <Ludus/Engine/Graphics/RenderContext2D.h>
+#include <Ludus/Engine/Graphics/Renderer2D.h>
+#include <Ludus/Engine/Graphics/RenderPhaseOrder.h>
+
+namespace Ludus::Engine::Graphics
+{
+	struct SceneRenderPass final : public IRenderPass
+	{
+		SceneRenderPass()
+		{
+			Name = "Scene Render Pass";
+			Id = 1;
+			Order = RenderPhaseOrder::Normal;
+		}
+
+		virtual bool Enabled(Ludus::Engine::Graphics::RenderContext2D& context) override
+		{
+			return true;
+		};
+
+		virtual void Execute(Ludus::Engine::Graphics::RenderContext2D& context, Ludus::Engine::Graphics::Renderer2D& renderer) override
+		{
+			auto& ecs = context.SystemContext->EntityComponentSystem;
+
+			for (const auto& sprite : ecs.Sprites.View())
+			{
+				const auto* transform = ecs.Transforms.TryGetByOwner(sprite.OwnerHandle);
+				if (!transform)
+				{
+					continue;
+				}
+
+				switch (sprite.Shape)
+				{
+					case Ludus::Engine::Graphics::Shape::Rect:
+						renderer.DrawQuad(*transform, sprite.Color, sprite.Texture, sprite.Fill);
+						break;
+					case Ludus::Engine::Graphics::Shape::Circle:
+						renderer.DrawCircle(*transform, sprite.Color, sprite.Fill);
+						break;
+				}
+			}
+
+			for (const auto& text : ecs.Texts.View())
+			{
+				const auto* transform = ecs.Transforms.TryGetByOwner(text.OwnerHandle);
+				if (transform)
+				{
+					renderer.DrawText(*transform, text.Text, text.Color, text.HorizontalAlignment);
+				}
+			}
+		};
+	};
+}

--- a/Engine/Include/Ludus/Engine/Physics/Core/PhysicsConfiguration2D.h
+++ b/Engine/Include/Ludus/Engine/Physics/Core/PhysicsConfiguration2D.h
@@ -13,7 +13,7 @@
 
 namespace Ludus::Engine::Physics::Core
 {
-	struct PhysicsContext2D
+	struct PhysicsConfiguration2D
 	{
 		std::unique_ptr<Ludus::Engine::Physics::Broadphase::IBroadphase2D> Broadphase;
 		std::unique_ptr<Ludus::Engine::Physics::Narrowphase::INarrowphase2D> Narrowphase;
@@ -22,7 +22,7 @@ namespace Ludus::Engine::Physics::Core
 		std::unique_ptr<Ludus::Engine::Physics::Integrators::IPhysicsIntegrator> Integrator;
 		int SubSteps;
 
-		PhysicsContext2D()
+		PhysicsConfiguration2D()
 			: Broadphase(std::make_unique<Ludus::Engine::Physics::Broadphase::NaiveBroadphase2D>()),
 			Narrowphase(std::make_unique<Ludus::Engine::Physics::Narrowphase::NaiveNarrowphase2D>()),
 			QueryCache(std::make_unique<Ludus::Engine::Physics::Queries::PhysicsQueryCache2D>()),
@@ -31,7 +31,7 @@ namespace Ludus::Engine::Physics::Core
 			SubSteps(8)
 		{ }
 
-		PhysicsContext2D(
+		PhysicsConfiguration2D(
 			std::unique_ptr<Ludus::Engine::Physics::Broadphase::IBroadphase2D> broadphase,
 			std::unique_ptr<Ludus::Engine::Physics::Narrowphase::INarrowphase2D> narrowphase,
 			std::unique_ptr<Ludus::Engine::Physics::Queries::IPhysicsQueryCache2D> queryCache,

--- a/Engine/Include/Ludus/Engine/Physics/Core/PhysicsSystem2D.h
+++ b/Engine/Include/Ludus/Engine/Physics/Core/PhysicsSystem2D.h
@@ -3,7 +3,7 @@
 #include <Ludus/Engine/Core/ISystem.h>
 #include <Ludus/Engine/Physics/Broadphase/IBroadphase2D.h>
 #include <Ludus/Engine/Physics/Broadphase/NaiveBroadphase2D.h>
-#include <Ludus/Engine/Physics/Core/PhysicsContext2D.h>
+#include <Ludus/Engine/Physics/Core/PhysicsConfiguration2D.h>
 #include <Ludus/Engine/Physics/Core/PhysicsPipeline2D.h>
 #include <Ludus/Engine/Physics/Core/PhysicsWorld2D.h>
 #include <Ludus/Engine/Physics/Narrowphase/INarrowphase2D.h>
@@ -22,16 +22,16 @@ namespace Ludus::Engine::Physics::Core
 		Ludus::Engine::Physics::Queries::IPhysicsQueryCache2D* m_Queries = nullptr;
 
 	public:
-		PhysicsSystem2D(PhysicsContext2D& context)
+		PhysicsSystem2D(PhysicsConfiguration2D& physicsConfiguration)
 			: m_PhysicsWorld(),
 			m_PhysicsPipeline(
-				*context.Broadphase,
-				*context.Narrowphase,
-				*context.ContactSolver,
-				*context.Integrator
+				*physicsConfiguration.Broadphase,
+				*physicsConfiguration.Narrowphase,
+				*physicsConfiguration.ContactSolver,
+				*physicsConfiguration.Integrator
 			),
-			m_Queries(context.QueryCache.get()),
-			m_SubSteps(context.SubSteps)
+			m_Queries(physicsConfiguration.QueryCache.get()),
+			m_SubSteps(physicsConfiguration.SubSteps)
 		{ }
 
 		void PullEntityComponents()

--- a/Engine/Include/Ludus/Engine/Platform/Input.h
+++ b/Engine/Include/Ludus/Engine/Platform/Input.h
@@ -61,6 +61,7 @@ namespace Ludus::Engine::Platform
 		bool GetMouseButtonUp(MouseButton mouseButton) { return m_JustReleasedMouseButtons.contains(mouseButton); }
 
 		const Ludus::Engine::Math::Vector2D GetMousePosition() { return { m_MouseXPosition, m_MouseYPosition }; }
+		const Ludus::Engine::Math::Vector2D GetMouseScrollOffset() { return { m_MouseScrollXOffset, m_MouseScrollYOffset }; }
 
 		virtual bool ProcessEvent(const Ludus::Engine::Events::Event& event) override;
 	};

--- a/Engine/Source/Ludus/Engine/Core/Application.cpp
+++ b/Engine/Source/Ludus/Engine/Core/Application.cpp
@@ -4,21 +4,24 @@
 #include <memory>
 
 #include <Ludus/Engine/Core/Application.h>
+#include <Ludus/Engine/Graphics/RenderingConfiguration2D.h>
 
 namespace Ludus::Engine::Core
 {
 	Application::Application(
 		Ludus::Engine::Platform::WindowOptions windowOptions,
 		Ludus::Engine::Graphics::RenderingOptions renderingOptions,
-		Ludus::Engine::Physics::Core::PhysicsContext2D physicsContext
-	) : m_EventBus(std::make_unique<Ludus::Engine::Events::EventBus>()),
+		Ludus::Engine::Graphics::RenderingConfiguration2D renderingConfiguration,
+		Ludus::Engine::Physics::Core::PhysicsConfiguration2D physicsConfiguration
+	) : m_EntityComponentSystem(std::make_unique<Ludus::Engine::Core::EntityComponentSystem>()),
+		m_EventBus(std::make_unique<Ludus::Engine::Events::EventBus>()),
 		m_Input(std::make_unique<Ludus::Engine::Platform::Input>()),
 		m_Window(std::make_unique<Ludus::Engine::Platform::Window>(windowOptions, *m_EventBus)),
 		m_GLContext(std::make_unique<Ludus::Engine::Graphics::GLContext>()),
-		m_PhysicsContext(std::make_unique<Ludus::Engine::Physics::Core::PhysicsContext2D>(std::move(physicsContext))),
+		m_RenderingConfiguration(std::make_unique<Ludus::Engine::Graphics::RenderingConfiguration2D>(std::move(renderingConfiguration))),
+		m_PhysicsConfiguration(std::make_unique<Ludus::Engine::Physics::Core::PhysicsConfiguration2D>(std::move(physicsConfiguration))),
 		m_Resources(std::make_unique<Ludus::Engine::Core::ResourceRegistry>()),
 		m_RenderViewRegistry(std::make_unique<Ludus::Engine::Core::RenderViewRegistry>()),
-		m_EntityComponentSystem(std::make_unique<Ludus::Engine::Core::EntityComponentSystem>()),
 		m_Time(std::make_unique<Ludus::Engine::Core::Time>()),
 		m_SystemContext(
 			*m_EntityComponentSystem,
@@ -28,7 +31,7 @@ namespace Ludus::Engine::Core
 			*m_RenderViewRegistry,
 			*m_Window,
 			std::make_shared<Ludus::Engine::Graphics::RenderTarget>(windowOptions.Width, windowOptions.Height),
-			m_PhysicsContext ? m_PhysicsContext->QueryCache.get() : nullptr
+			m_PhysicsConfiguration ? m_PhysicsConfiguration->QueryCache.get() : nullptr
 		),
 		m_Scheduler(std::make_unique<Ludus::Engine::Core::Scheduler>(m_SystemContext))
 	{
@@ -40,9 +43,14 @@ namespace Ludus::Engine::Core
 		SubscribeToEvents();
 	}
 
-	std::unique_ptr<Application> Application::Create(Ludus::Engine::Platform::WindowOptions windowOptions, Ludus::Engine::Graphics::RenderingOptions renderingOptions, Ludus::Engine::Physics::Core::PhysicsContext2D physicsContext)
+	std::unique_ptr<Application> Application::Create(
+		Ludus::Engine::Platform::WindowOptions windowOptions,
+		Ludus::Engine::Graphics::RenderingOptions renderingOptions,
+		Ludus::Engine::Graphics::RenderingConfiguration2D renderingConfiguration,
+		Ludus::Engine::Physics::Core::PhysicsConfiguration2D physicsConfiguration
+	)
 	{
-		auto application = std::make_unique<Application>(windowOptions, renderingOptions, std::move(physicsContext));
+		auto application = std::make_unique<Application>(windowOptions, renderingOptions, std::move(renderingConfiguration), std::move(physicsConfiguration));
 		return application;
 	}
 

--- a/Engine/Source/Ludus/Engine/Core/ApplicationBuilder.cpp
+++ b/Engine/Source/Ludus/Engine/Core/ApplicationBuilder.cpp
@@ -13,7 +13,8 @@ namespace Ludus::Engine::Core
 		auto application = std::make_unique<Ludus::Engine::Core::Application>(
 			m_WindowOptions,
 			m_RenderingOptions,
-			std::move(m_PhysicsContext)
+			std::move(m_RenderingConfiguration),
+			std::move(m_PhysicsConfiguration)
 		);
 
 		for (auto& command : m_BuilderCommands)
@@ -42,9 +43,15 @@ namespace Ludus::Engine::Core
 		return *this;
 	}
 
-	ApplicationBuilder& ApplicationBuilder::WithPhysicsContext(Ludus::Engine::Physics::Core::PhysicsContext2D physicsContext)
+	ApplicationBuilder& ApplicationBuilder::WithRenderingConfiguration(Ludus::Engine::Graphics::RenderingConfiguration2D renderingConfiguration)
 	{
-		m_PhysicsContext = std::move(physicsContext);
+		m_RenderingConfiguration = std::move(renderingConfiguration);
+		return *this;
+	}
+
+	ApplicationBuilder& ApplicationBuilder::WithPhysicsConfiguration(Ludus::Engine::Physics::Core::PhysicsConfiguration2D physicsConfiguration)
+	{
+		m_PhysicsConfiguration = std::move(physicsConfiguration);
 		return *this;
 	}
 
@@ -55,7 +62,8 @@ namespace Ludus::Engine::Core
 			m_BuilderCommands.emplace_back(
 				[renderingOptions = m_RenderingOptions](Ludus::Engine::Core::Application& application)
 				{
-					auto renderingSystem = std::make_unique<Ludus::Engine::Graphics::RenderingSystem2D>(renderingOptions);
+					auto& renderingConfiguration = application.GetRenderingConfiguration();
+					auto renderingSystem = std::make_unique<Ludus::Engine::Graphics::RenderingSystem2D>(renderingOptions, renderingConfiguration);
 
 					application.AddSystem({ SystemPhase::Render, nullptr, SystemPhaseOrder::Before }, std::move(renderingSystem));
 				}
@@ -79,8 +87,8 @@ namespace Ludus::Engine::Core
 				[](Ludus::Engine::Core::Application& application)
 				{
 					// A physics context will already have been created when this build command is invoked.
-					auto& physicsContext = application.GetPhysicsContext();
-					auto physicsSystem = std::make_unique<Ludus::Engine::Physics::Core::PhysicsSystem2D>(physicsContext);
+					auto& physicsConfiguration = application.GetPhysicsConfiguration();
+					auto physicsSystem = std::make_unique<Ludus::Engine::Physics::Core::PhysicsSystem2D>(physicsConfiguration);
 
 					application.AddSystem({ SystemPhase::FixedUpdate, nullptr, SystemPhaseOrder::Before }, std::move(physicsSystem));
 				}

--- a/Games/Pong/main.cpp
+++ b/Games/Pong/main.cpp
@@ -4,7 +4,7 @@
 #include <Ludus/Engine/Core/State.h>
 #include <Ludus/Engine/Core/SystemPhase.h>
 #include <Ludus/Engine/Graphics/Color.h>
-#include <Ludus/Engine/Physics/Core/PhysicsContext2D.h>
+#include <Ludus/Engine/Physics/Core/PhysicsConfiguration2D.h>
 #include <Ludus/Engine/Platform/Window.h>
 #include <Ludus/Engine/Platform/WindowOptions.h>
 
@@ -20,7 +20,7 @@ int main()
 {
 	auto windowOptions = Ludus::Engine::Platform::WindowOptions(1024, 768, "Pong (1972)", false);
 	auto renderingOptions = Ludus::Engine::Graphics::RenderingOptions(Ludus::Engine::Graphics::Colors::Black);
-	auto physicsContext = Ludus::Engine::Physics::Core::PhysicsContext2D();
+	auto physicsConfiguration = Ludus::Engine::Physics::Core::PhysicsConfiguration2D();
 
 	auto gameInfo = std::make_shared<Ludus::Pong::Core::GameInfo>();
 	auto pongInfo = std::make_shared<Ludus::Pong::Core::PongInfo>();
@@ -29,7 +29,7 @@ int main()
 	auto application = Ludus::Engine::Core::ApplicationBuilder::Create()
 		.WithWindowOptions(windowOptions)
 		.WithRenderingOptions(renderingOptions)
-		.WithPhysicsContext(std::move(physicsContext))
+		.WithPhysicsConfiguration(std::move(physicsConfiguration))
 		.UseDefaultPhysics2D()
 		.UseDefaultRendering2D()
 		.AddSystem<Ludus::Pong::Systems::MainMenuSystem>(

--- a/Lab/main.cpp
+++ b/Lab/main.cpp
@@ -12,7 +12,7 @@ int main()
 {
 	auto windowOptions = Ludus::Engine::Platform::WindowOptions(1920, 1080, "Ludus Lab", true);
 	auto renderingOptions = Ludus::Engine::Graphics::RenderingOptions(Ludus::Engine::Graphics::Colors::White);
-	auto physicsContext = Ludus::Engine::Physics::Core::PhysicsContext2D();
+	auto physicsContext = Ludus::Engine::Physics::Core::PhysicsConfiguration2D();
 
 	auto applicationBuilder = Ludus::Engine::Core::ApplicationBuilder::Create();
 
@@ -21,7 +21,7 @@ int main()
 	auto application = applicationBuilder
 		.WithWindowOptions(windowOptions)
 		.WithRenderingOptions(renderingOptions)
-		.WithPhysicsContext(std::move(physicsContext))
+		.WithPhysicsConfiguration(std::move(physicsContext))
 		.UseDefaultPhysics2D()
 		.UseDefaultRendering2D()
 		.AddUpdateSystem<Ludus::Lab::Core::Scene>()


### PR DESCRIPTION
# Summary
Added IRenderPass interface that the new rendering pipeline consumes. These passes are added via a rendering configuration, and the default render pass is the SceneRenderPass, which was previously hardcoded using the ECS in the rendering system. 

# Linked
- Closes #172 
