### PR TITLE
Feature:  Added editor grid render pass

### DIFF
--- a/Editor/Editor.vcxproj
+++ b/Editor/Editor.vcxproj
@@ -49,6 +49,7 @@
     <ClInclude Include="Include\Ludus\Editor\Core\EditorSystem.h" />
     <ClInclude Include="Include\Ludus\Editor\Core\CameraControllerSystem.h" />
     <ClInclude Include="Include\Ludus\Editor\Core\EditorApplicationBuilder.h" />
+    <ClInclude Include="Include\Ludus\Editor\Core\EditorGridRenderPass.h" />
     <ClInclude Include="Include\Ludus\Editor\Panels\PanelContext.h" />
     <ClInclude Include="Include\Ludus\Editor\Panels\PanelRegistry.h" />
     <ClInclude Include="Include\Ludus\Editor\Core\Constants.h" />

--- a/Editor/Include/Ludus/Editor/Core/EditorGridRenderPass.h
+++ b/Editor/Include/Ludus/Editor/Core/EditorGridRenderPass.h
@@ -1,0 +1,73 @@
+#pragma once
+
+#include <cmath>
+
+#include <Ludus/Engine/Graphics/Color.h>
+#include <Ludus/Engine/Graphics/IRenderPass.h>
+#include <Ludus/Engine/Graphics/RenderContext2D.h>
+#include <Ludus/Engine/Graphics/Renderer2D.h>
+#include <Ludus/Engine/Graphics/RenderPhaseOrder.h>
+
+namespace Ludus::Editor::Core
+{
+	struct EditorGridRenderPass final : public Ludus::Engine::Graphics::IRenderPass
+	{
+	private:
+		Ludus::Engine::Graphics::Color m_OuterGridColor = Ludus::Engine::Graphics::Colors::White.WithAlpha(0.20f);
+		Ludus::Engine::Graphics::Color m_InnerGridColor = Ludus::Engine::Graphics::Colors::White.WithAlpha(0.10f);
+		int m_Margin = 1;
+
+	public:
+		EditorGridRenderPass()
+		{
+			Name = "Editor Grid Render Pass";
+			Id = 2;
+			Order = Ludus::Engine::Graphics::RenderPhaseOrder::After;
+		}
+
+		virtual bool Enabled(Ludus::Engine::Graphics::RenderContext2D& context) override
+		{
+			return true;
+		};
+
+		virtual void Execute(Ludus::Engine::Graphics::RenderContext2D& context, Ludus::Engine::Graphics::Renderer2D& renderer) override
+		{
+			const auto worldRect = context.RenderView.Camera.GetWorldRect();
+
+			const auto [xPosition, yPosition] = worldRect.Position;
+			const auto [width, height] = worldRect.Size;
+
+			const auto left = xPosition - width * 0.5f;
+			const auto right = xPosition + width * 0.5f;
+			const auto bottom = yPosition - height * 0.5f;
+			const auto top = yPosition + height * 0.5f;
+
+			const auto xStart = static_cast<int>(std::floor(left)) - m_Margin;
+			const auto xStop = static_cast<int>(std::ceil(right)) + m_Margin;
+			const auto yStart = static_cast<int>(std::floor(bottom)) - m_Margin;
+			const auto yStop = static_cast<int>(std::ceil(top)) + m_Margin;
+
+			for (int x = xStart; x <= xStop; x++)
+			{
+				renderer.DrawLine(
+					static_cast<float>(x),
+					static_cast<float>(yStart),
+					static_cast<float>(x),
+					static_cast<float>(yStop),
+					x % 10 == 0 ? m_OuterGridColor : m_InnerGridColor
+				);
+			}
+
+			for (int y = yStart; y <= yStop; y++)
+			{
+				renderer.DrawLine(
+					static_cast<float>(xStart),
+					static_cast<float>(y),
+					static_cast<float>(xStop),
+					static_cast<float>(y),
+					y % 10 == 0 ? m_OuterGridColor : m_InnerGridColor
+				);
+			}
+		};
+	};
+}

--- a/Editor/Source/Ludus/Editor/Core/EditorApplicationBuilder.cpp
+++ b/Editor/Source/Ludus/Editor/Core/EditorApplicationBuilder.cpp
@@ -2,6 +2,7 @@
 
 #include <Ludus/Editor/Core/EditorApplicationBuilder.h>
 #include <Ludus/Editor/Core/EditorConfiguration.h>
+#include <Ludus/Editor/Core/EditorGridRenderPass.h>
 #include <Ludus/Editor/Core/EditorSystem.h>
 #include <Ludus/Editor/Core/Scene.h>
 #include <Ludus/Engine/Core/Application.h>
@@ -35,8 +36,9 @@ namespace Ludus::Editor::Core
 	{
 		m_WindowOptions = Ludus::Engine::Platform::WindowOptions(1920, 1080, "Ludus Editor", true);
 		m_RenderingOptions = Ludus::Engine::Graphics::RenderingOptions(Ludus::Engine::Graphics::Colors::DarkGray);
-		m_PhysicsConfiguration = Ludus::Engine::Physics::Core::PhysicsConfiguration2D();
 		m_RenderingConfiguration = Ludus::Engine::Graphics::RenderingConfiguration2D();
+		m_RenderingConfiguration.AddPass(std::make_unique<EditorGridRenderPass>());
+		m_PhysicsConfiguration = Ludus::Engine::Physics::Core::PhysicsConfiguration2D();
 
 		Ludus::UI::Systems::RegisterImGui(m_ApplicationBuilder);
 


### PR DESCRIPTION
# Summary
Added a render pass for displaying the editor grid overlay. The grid does not currently downscale when zooming out. This should be handled when adding editor camera zoom functionality.

# Linked
- Closes #173 
