### PR TITLE
Chore: Removed 'Status' from issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/chore.yml
+++ b/.github/ISSUE_TEMPLATE/chore.yml
@@ -4,7 +4,6 @@ description: Maintenance, cleanup, or non-functional changes.
 title: "[Chore]: "
 labels:
   - "Type: Chore"
-  - "Status: Planned"
 assignees:
   - TordLoefgren
 

--- a/.github/ISSUE_TEMPLATE/docs.yml
+++ b/.github/ISSUE_TEMPLATE/docs.yml
@@ -4,7 +4,6 @@ description: Documentation-only change.
 title: "[Docs]: "
 labels:
   - "Type: Docs"
-  - "Status: Planned"
 assignees:
   - TordLoefgren
 

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -4,7 +4,6 @@ description: Add or improve functionality.
 title: "[Feature]: "
 labels:
   - "Type: Feature"
-  - "Status: Planned"
 assignees:
   - TordLoefgren
 

--- a/.github/ISSUE_TEMPLATE/fix.yml
+++ b/.github/ISSUE_TEMPLATE/fix.yml
@@ -4,7 +4,6 @@ description: Something isn't working as expected.
 title: "[Fix]: "
 labels:
   - "Type: Fix"
-  - "Status: Planned"
 assignees:
   - TordLoefgren
 
@@ -22,8 +21,3 @@ body:
     attributes:
       label: Reproduction Steps
       description: Step-by-step with expected vs. actual result.
-      value: |
-        1. …
-        2. …
-        **Expected:** …
-        **Actual:** …

--- a/.github/ISSUE_TEMPLATE/refactor.yml
+++ b/.github/ISSUE_TEMPLATE/refactor.yml
@@ -4,7 +4,6 @@ description: Improve structure/clarity without changing behavior.
 title: "[Refactor]: "
 labels:
   - "Type: Refactor"
-  - "Status: Planned"
 assignees:
   - TordLoefgren
 

--- a/.github/ISSUE_TEMPLATE/story.yml
+++ b/.github/ISSUE_TEMPLATE/story.yml
@@ -4,7 +4,6 @@ description: Broad goal made up of multiple issues.
 title: "[Story]: "
 labels:
   - "Type: Story"
-  - "Status: Planned"
 assignees:
   - TordLoefgren
 
@@ -16,16 +15,6 @@ body:
       description: One-paragraph overview of the goal and scope.
     validations:
       required: true
-
-  - type: textarea
-    id: acceptance
-    attributes:
-      label: Acceptance Criteria
-      description: Definition of done.
-      value: |
-        - [ ] All linked issues closed
-        - [ ] Code compiles and runs
-        - [ ] Minimal docs updated
 
   - type: textarea
     id: links

--- a/.github/ISSUE_TEMPLATE/test.yml
+++ b/.github/ISSUE_TEMPLATE/test.yml
@@ -4,7 +4,6 @@ description: Creating unit tests.
 title: "[Test]: "
 labels:
   - "Type: Test"
-  - "Status: Planned"
 assignees:
   - TordLoefgren
 


### PR DESCRIPTION
# Summary
The 'Status' label was not being used. GitHub already has similar functionality that can be used in the Projects overview.

# Linked
- Closes #179 

