### PR TITLE
Feature: Added editor state singleton panels

### DIFF
--- a/Editor/Editor.vcxproj
+++ b/Editor/Editor.vcxproj
@@ -42,10 +42,12 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="Include\Ludus\Editor\Core\ActivePanelState.h" />
     <ClInclude Include="Include\Ludus\Editor\Core\EditorContext.h" />
     <ClInclude Include="Include\Ludus\Editor\Core\EditorConfiguration.h" />
     <ClInclude Include="Include\Ludus\Editor\Core\EditorExecutionFlags.h" />
     <ClInclude Include="Include\Ludus\Editor\Core\EditorExecutionManager.h" />
+    <ClInclude Include="Include\Ludus\Editor\Core\EditorRequests.h" />
     <ClInclude Include="Include\Ludus\Editor\Core\EditorSelection.h" />
     <ClInclude Include="Include\Ludus\Editor\Core\EditorState.h" />
     <ClInclude Include="Include\Ludus\Editor\Core\EditorSystem.h" />

--- a/Editor/Include/Ludus/Editor/Core/ActivePanelState.h
+++ b/Editor/Include/Ludus/Editor/Core/ActivePanelState.h
@@ -1,0 +1,12 @@
+#pragma once
+
+namespace Ludus::Editor::Core
+{
+	struct ActivePanelState
+	{
+		bool ShowConsolePanel = true;
+		bool ShowHierachyPanel = true;
+		bool ShowInspectorPanel = true;
+		bool ShowImGuiDemoPanel = true;
+	};
+}

--- a/Editor/Include/Ludus/Editor/Core/EditorRequests.h
+++ b/Editor/Include/Ludus/Editor/Core/EditorRequests.h
@@ -1,0 +1,14 @@
+#pragma once
+
+namespace Ludus::Editor::Core
+{
+	struct EditorRequests
+	{
+		bool AddViewport = false;
+
+		void Clear()
+		{
+			AddViewport = false;
+		}
+	};
+}

--- a/Editor/Include/Ludus/Editor/Core/EditorState.h
+++ b/Editor/Include/Ludus/Editor/Core/EditorState.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Ludus/Editor/Core/EditorExecutionManager.h>
+#include <Ludus/Editor/Core/EditorRequests.h>
 #include <Ludus/Editor/Core/EditorSelection.h>
 
 namespace Ludus::Editor::Core
@@ -8,6 +9,7 @@ namespace Ludus::Editor::Core
 	struct EditorState
 	{
 		Ludus::Editor::Core::EditorExecutionManager ExecutionManager;
+		Ludus::Editor::Core::EditorRequests Requests;
 		Ludus::Editor::Core::EditorSelection Selection;
 	};
 }

--- a/Editor/Include/Ludus/Editor/Core/EditorSystem.h
+++ b/Editor/Include/Ludus/Editor/Core/EditorSystem.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <Ludus/Editor/Core/ActivePanelState.h>
 #include <Ludus/Editor/Core/EditorConfiguration.h>
 #include <Ludus/Editor/Core/EditorContext.h>
 #include <Ludus/Editor/Panels/PanelRegistry.h>
@@ -11,8 +12,12 @@ namespace Ludus::Editor::Core
 	{
 	private:
 		EditorContext m_EditorContext;
+		ActivePanelState m_ActivePanelState;
 		EditorConfiguration m_EditorConfiguration;
 		Ludus::Editor::Panels::PanelRegistry m_PanelRegistry;
+
+		void AddViewport();
+		void HandleRequests();
 
 	public:
 		EditorSystem(EditorConfiguration editorConfiguration);

--- a/Editor/Include/Ludus/Editor/Panels/ConsolePanel.h
+++ b/Editor/Include/Ludus/Editor/Panels/ConsolePanel.h
@@ -26,6 +26,8 @@ namespace Ludus::Editor::Panels
 		std::vector<AggregateText> m_AggregateText;
 		std::unordered_map<std::string, size_t> m_TextToIndex;
 
-		virtual void UpdateImpl(Ludus::Editor::Panels::PanelContext& context) override;
+		virtual bool* GetOpenFlag(Ludus::Editor::Panels::PanelContext& context) override { return &context.ActivePanelState.ShowConsolePanel; }
+
+		virtual bool UpdateImpl(Ludus::Editor::Panels::PanelContext& context) override;
 	};
 }

--- a/Editor/Include/Ludus/Editor/Panels/DockPanel.h
+++ b/Editor/Include/Ludus/Editor/Panels/DockPanel.h
@@ -8,7 +8,10 @@ namespace Ludus::Editor::Panels
 {
 	class DockPanel final : public Ludus::Editor::Panels::IPanel
 	{
+	private:
+		void DrawMenuBar(Ludus::Editor::Panels::PanelContext& context);
+
 	public:
-		virtual void UpdateImpl(Ludus::Editor::Panels::PanelContext& context) override;
+		virtual bool UpdateImpl(Ludus::Editor::Panels::PanelContext& context) override;
 	};
 }

--- a/Editor/Include/Ludus/Editor/Panels/HierarchyPanel.h
+++ b/Editor/Include/Ludus/Editor/Panels/HierarchyPanel.h
@@ -8,6 +8,8 @@ namespace Ludus::Editor::Panels
 	class HierarchyPanel final : public Ludus::Editor::Panels::IPanel
 	{
 	public:
-		virtual void UpdateImpl(Ludus::Editor::Panels::PanelContext& context) override;
+		virtual bool* GetOpenFlag(Ludus::Editor::Panels::PanelContext& context) override { return &context.ActivePanelState.ShowHierachyPanel; }
+
+		virtual bool UpdateImpl(Ludus::Editor::Panels::PanelContext& context) override;
 	};
 }

--- a/Editor/Include/Ludus/Editor/Panels/IPanel.h
+++ b/Editor/Include/Ludus/Editor/Panels/IPanel.h
@@ -9,21 +9,48 @@
 
 namespace Ludus::Editor::Panels
 {
+	using PanelHandle = uint32_t;
+
 	class IPanel
 	{
 	public:
 		virtual ~IPanel() = default;
 
-		void Update(PanelContext& context) { UpdateImpl(context); }
+		PanelHandle GetHandle() const { return m_Handle; }
+
+		bool Update(PanelContext& context)
+		{
+			// Singleton panels can use this hook to be toggled on and off.
+			auto* external = GetOpenFlag(context);
+			if (external)
+			{
+				m_Open = *external;
+			}
+
+			if (!m_Open)
+			{
+				return true;
+			}
+
+			auto active = UpdateImpl(context);
+
+			if (external)
+			{
+				*external = m_Open;
+			}
+
+			return active;
+		}
 
 	protected:
-		using PanelHandle = uint32_t;
 		inline static PanelHandle s_NextHandle = 1;
 
 		PanelHandle m_Handle = s_NextHandle++;
 		bool m_Open = true;
 
-		virtual void UpdateImpl(PanelContext& context) = 0;
+		virtual bool* GetOpenFlag(PanelContext&) { return nullptr; }
+
+		virtual bool UpdateImpl(PanelContext& context) = 0;
 
 		std::string CreateWindowTitle(std::string_view visibleTitle)
 		{

--- a/Editor/Include/Ludus/Editor/Panels/ImGuiDemoPanel.h
+++ b/Editor/Include/Ludus/Editor/Panels/ImGuiDemoPanel.h
@@ -8,6 +8,8 @@ namespace Ludus::Editor::Panels
 	class ImGuiDemoPanel final : public Ludus::Editor::Panels::IPanel
 	{
 	public:
-		virtual void UpdateImpl(Ludus::Editor::Panels::PanelContext& context) override;
+		virtual bool* GetOpenFlag(Ludus::Editor::Panels::PanelContext& context) override { return &context.ActivePanelState.ShowImGuiDemoPanel; }
+
+		virtual bool UpdateImpl(Ludus::Editor::Panels::PanelContext& context) override;
 	};
 }

--- a/Editor/Include/Ludus/Editor/Panels/InspectorPanel.h
+++ b/Editor/Include/Ludus/Editor/Panels/InspectorPanel.h
@@ -8,6 +8,8 @@ namespace Ludus::Editor::Panels
 	class InspectorPanel final : public Ludus::Editor::Panels::IPanel
 	{
 	public:
-		virtual void UpdateImpl(Ludus::Editor::Panels::PanelContext& context) override;
+		virtual bool* GetOpenFlag(Ludus::Editor::Panels::PanelContext& context) override { return &context.ActivePanelState.ShowInspectorPanel; }
+
+		virtual bool UpdateImpl(Ludus::Editor::Panels::PanelContext& context) override;
 	};
 }

--- a/Editor/Include/Ludus/Editor/Panels/PanelContext.h
+++ b/Editor/Include/Ludus/Editor/Panels/PanelContext.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <Ludus/Editor/Core/ActivePanelState.h>
 #include <Ludus/Editor/Core/EditorContext.h>
 #include <Ludus/Engine/Core/SystemContext.h>
 
@@ -9,6 +10,7 @@ namespace Ludus::Editor::Panels
 	{
 		Ludus::Engine::Core::SystemContext& SystemContext;
 		Ludus::Editor::Core::EditorContext& EditorContext;
+		Ludus::Editor::Core::ActivePanelState& ActivePanelState;
 		float DeltaTime;
 	};
 }

--- a/Editor/Include/Ludus/Editor/Panels/PanelRegistry.h
+++ b/Editor/Include/Ludus/Editor/Panels/PanelRegistry.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <memory>
 #include <span>
 #include <vector>
@@ -12,6 +13,7 @@ namespace Ludus::Editor::Panels
 	{
 	private:
 		std::vector<std::unique_ptr<IPanel>> m_Panels;
+		std::vector<PanelHandle> m_ScheduledRemovals;
 
 	public:
 		std::span<const std::unique_ptr<IPanel>> View() const
@@ -28,6 +30,33 @@ namespace Ludus::Editor::Panels
 		{
 			m_Panels.clear();
 		}
+
+		void ScheduleRemove(PanelHandle handle)
+		{
+			m_ScheduledRemovals.emplace_back(handle);
+		}
+
+		bool ApplyRemovals()
+		{
+			if (m_ScheduledRemovals.empty())
+			{
+				return false;
+			}
+
+			const auto previousSize = m_Panels.size();
+
+			std::erase_if(
+				m_Panels,
+				[this](const std::unique_ptr<IPanel>& panel)
+				{
+					return std::ranges::find(m_ScheduledRemovals, panel->GetHandle()) != m_ScheduledRemovals.end();
+				}
+			);
+
+			m_ScheduledRemovals.clear();
+			return m_Panels.size() != previousSize;
+		}
+
 
 		size_t GetSize() const { return m_Panels.size(); }
 	};

--- a/Editor/Include/Ludus/Editor/Panels/ViewportPanel.h
+++ b/Editor/Include/Ludus/Editor/Panels/ViewportPanel.h
@@ -40,6 +40,6 @@ namespace Ludus::Editor::Panels
 	public:
 		ViewportPanel(std::string title = "Viewport");
 
-		virtual void UpdateImpl(Ludus::Editor::Panels::PanelContext& context) override;
+		virtual bool UpdateImpl(Ludus::Editor::Panels::PanelContext& context) override;
 	};
 }

--- a/Editor/Source/Ludus/Editor/Core/EditorSystem.cpp
+++ b/Editor/Source/Ludus/Editor/Core/EditorSystem.cpp
@@ -3,12 +3,28 @@
 #include <memory>
 
 #include <Ludus/Editor/Core/EditorSystem.h>
+#include <Ludus/Editor/Panels/ViewportPanel.h>
 
 namespace Ludus::Editor::Core
 {
 	EditorSystem::EditorSystem(Ludus::Editor::Core::EditorConfiguration editorOptions)
 		: m_EditorContext(), m_EditorConfiguration(editorOptions), m_PanelRegistry()
 	{ }
+
+	void EditorSystem::AddViewport()
+	{
+		m_PanelRegistry.Register(std::make_unique<Ludus::Editor::Panels::ViewportPanel>());
+	}
+
+	void EditorSystem::HandleRequests()
+	{
+		if (m_EditorContext.State.Requests.AddViewport)
+		{
+			AddViewport();
+		}
+
+		m_EditorContext.State.Requests.Clear();
+	}
 
 	void Ludus::Editor::Core::EditorSystem::OnAttachImpl()
 	{
@@ -25,11 +41,18 @@ namespace Ludus::Editor::Core
 
 	void Ludus::Editor::Core::EditorSystem::UpdateImpl(float deltaTime)
 	{
-		Ludus::Editor::Panels::PanelContext context { *m_SystemContext, m_EditorContext, deltaTime };
+		Ludus::Editor::Panels::PanelContext context { *m_SystemContext, m_EditorContext, m_ActivePanelState, deltaTime };
 
 		for (auto& panel : m_PanelRegistry.View())
 		{
-			panel->Update(context);
+			if (!panel->Update(context))
+			{
+				m_PanelRegistry.ScheduleRemove(panel->GetHandle());
+			}
 		}
+
+		m_PanelRegistry.ApplyRemovals();
+
+		HandleRequests();
 	}
 }

--- a/Editor/Source/Ludus/Editor/Panels/ConsolePanel.cpp
+++ b/Editor/Source/Ludus/Editor/Panels/ConsolePanel.cpp
@@ -10,7 +10,7 @@
 
 namespace Ludus::Editor::Panels
 {
-	void ConsolePanel::UpdateImpl(Ludus::Editor::Panels::PanelContext& context)
+	bool ConsolePanel::UpdateImpl(Ludus::Editor::Panels::PanelContext& context)
 	{
 		const auto flags = Ludus::Editor::Core::Constants::PanelFlags | Ludus::UI::Flags::Window::HorizontalScrollbar;
 		auto windowTitle = CreateWindowTitle("Console");
@@ -52,6 +52,8 @@ namespace Ludus::Editor::Panels
 
 			logEntries.clear();
 		}
+
+		return true;
 	}
 
 	std::string ConsolePanel::FormatEntry(const Ludus::Engine::Debug::LogEntry& entry)

--- a/Editor/Source/Ludus/Editor/Panels/DockPanel.cpp
+++ b/Editor/Source/Ludus/Editor/Panels/DockPanel.cpp
@@ -9,6 +9,8 @@
 #include <Ludus/UI/Context/ViewportContext.h>
 #include <Ludus/UI/Context/WindowContext.h>
 #include <Ludus/UI/Labels.h>
+#include <Ludus/UI/Scope/MenuBarScope.h>
+#include <Ludus/UI/Scope/MenuScope.h>
 #include <Ludus/UI/Scope/StyleScope.h>
 #include <Ludus/UI/Scope/WindowScope.h>
 #include <Ludus/UI/Widgets/Menu.h>
@@ -17,7 +19,42 @@
 
 namespace Ludus::Editor::Panels
 {
-	void DockPanel::UpdateImpl(Ludus::Editor::Panels::PanelContext& context)
+	void DockPanel::DrawMenuBar(Ludus::Editor::Panels::PanelContext& context)
+	{
+		if (Ludus::UI::Scope::MenuBarScope menuBar; menuBar)
+		{
+			if (Ludus::UI::Scope::MenuScope fileMenu("File"); fileMenu)
+			{
+				if (Ludus::UI::Widgets::MenuItem("New"))
+				{
+					// Not implemented.
+				}
+
+				if (Ludus::UI::Widgets::MenuItem("Open"))
+				{
+					// Not implemented.
+				}
+			}
+
+			if (Ludus::UI::Scope::MenuScope viewMenu("View"); viewMenu)
+			{
+				if (Ludus::UI::Widgets::MenuItem("Add viewport"))
+				{
+					context.EditorContext.State.Requests.AddViewport = true;
+				}
+
+				if (Ludus::UI::Scope::MenuScope panelsMenu("Panels"); panelsMenu)
+				{
+					Ludus::UI::Widgets::Checkbox("Console", &context.ActivePanelState.ShowConsolePanel);
+					Ludus::UI::Widgets::Checkbox("Hierarchy", &context.ActivePanelState.ShowHierachyPanel);
+					Ludus::UI::Widgets::Checkbox("ImGuiDemo", &context.ActivePanelState.ShowImGuiDemoPanel);
+					Ludus::UI::Widgets::Checkbox("Inspector", &context.ActivePanelState.ShowInspectorPanel);
+				}
+			}
+		}
+	}
+
+	bool DockPanel::UpdateImpl(Ludus::Editor::Panels::PanelContext& context)
 	{
 		const auto viewport = Ludus::UI::Context::ViewportContext::GetMainViewport();
 		Ludus::UI::Context::WindowContext::SetNextWindowPosition(viewport.WorkPosition);
@@ -37,7 +74,11 @@ namespace Ludus::Editor::Panels
 
 		if (Ludus::UI::Scope::WindowScope window(windowTitle.c_str(), nullptr, Ludus::Editor::Core::Constants::DockPanelWindowFlags); window)
 		{
+			DrawMenuBar(context);
+
 			Ludus::UI::Context::DockingContext::CreateDockSpace(windowTitle.c_str(), { 0.0f, 0.0f }, Ludus::UI::Flags::DockNode::None | Ludus::UI::Flags::DockNodeInternal::NoWindowMenuButton);
 		}
+
+		return true;
 	}
 }

--- a/Editor/Source/Ludus/Editor/Panels/HierarchyPanel.cpp
+++ b/Editor/Source/Ludus/Editor/Panels/HierarchyPanel.cpp
@@ -17,7 +17,7 @@
 
 namespace Ludus::Editor::Panels
 {
-	void HierarchyPanel::UpdateImpl(Ludus::Editor::Panels::PanelContext& context)
+	bool HierarchyPanel::UpdateImpl(Ludus::Editor::Panels::PanelContext& context)
 	{
 		auto windowTitle = CreateWindowTitle("Hierarchy");
 		if (Ludus::UI::Scope::WindowScope window(windowTitle.c_str(), &m_Open, Ludus::Editor::Core::Constants::PanelFlags); window)
@@ -175,5 +175,7 @@ namespace Ludus::Editor::Panels
 				selection.DeselectAll();
 			}
 		}
+
+		return true;
 	}
 }

--- a/Editor/Source/Ludus/Editor/Panels/ImGuiDemoPanel.cpp
+++ b/Editor/Source/Ludus/Editor/Panels/ImGuiDemoPanel.cpp
@@ -5,8 +5,10 @@
 
 namespace Ludus::Editor::Panels
 {
-	void ImGuiDemoPanel::UpdateImpl(Ludus::Editor::Panels::PanelContext& context)
+	bool ImGuiDemoPanel::UpdateImpl(Ludus::Editor::Panels::PanelContext& context)
 	{
-		Ludus::UI::Widgets::ShowDemoWindow();
+		Ludus::UI::Widgets::ShowDemoWindow(&m_Open);
+
+		return true;
 	}
 }

--- a/Editor/Source/Ludus/Editor/Panels/InspectorPanel.cpp
+++ b/Editor/Source/Ludus/Editor/Panels/InspectorPanel.cpp
@@ -9,7 +9,7 @@
 
 namespace Ludus::Editor::Panels
 {
-	void InspectorPanel::UpdateImpl(Ludus::Editor::Panels::PanelContext& context)
+	bool InspectorPanel::UpdateImpl(Ludus::Editor::Panels::PanelContext& context)
 	{
 		auto windowTitle = CreateWindowTitle("Inspector");
 		if (Ludus::UI::Scope::WindowScope window(windowTitle.c_str(), &m_Open, Ludus::Editor::Core::Constants::PanelFlags); window)
@@ -17,14 +17,14 @@ namespace Ludus::Editor::Panels
 			auto& selection = context.EditorContext.State.Selection;
 			if (!selection.HasScene() || !selection.HasEntity())
 			{
-				return;
+				return true;
 			}
 
 			auto* scene = context.SystemContext.SceneManager.TryGetScene(selection.SelectedScene.value());
 
 			if (!scene)
 			{
-				return;
+				return true;
 			}
 
 			auto& ecs = scene->EntityComponentSystem;
@@ -69,5 +69,7 @@ namespace Ludus::Editor::Panels
 				Ludus::Editor::Core::Camera2DPanel(*cameraPtr);
 			}
 		}
+
+		return true;
 	}
 }

--- a/Editor/Source/Ludus/Editor/Panels/ViewportPanel.cpp
+++ b/Editor/Source/Ludus/Editor/Panels/ViewportPanel.cpp
@@ -120,7 +120,7 @@ namespace Ludus::Editor::Panels
 		}
 	}
 
-	void ViewportPanel::UpdateImpl(Ludus::Editor::Panels::PanelContext& context)
+	bool ViewportPanel::UpdateImpl(Ludus::Editor::Panels::PanelContext& context)
 	{
 		const auto flags = Ludus::Editor::Core::Constants::PanelFlags
 			| Ludus::UI::Flags::Window::NoScrollbar
@@ -176,7 +176,7 @@ namespace Ludus::Editor::Panels
 
 			if (desiredSize.Width <= 0 || desiredSize.Height <= 0)
 			{
-				return;
+				return true;
 			}
 
 			if (!m_Target)
@@ -221,5 +221,7 @@ namespace Ludus::Editor::Panels
 
 			context.SystemContext.RenderViewRequests.Register(renderViewRequest);
 		}
+
+		return m_Open;
 	}
 }

--- a/UI/Include/Ludus/UI/Scope/ComboScope.h
+++ b/UI/Include/Ludus/UI/Scope/ComboScope.h
@@ -4,13 +4,15 @@
 
 namespace Ludus::UI::Scope
 {
+	constexpr Ludus::UI::Flags::Combo DefaultComboFlags = Ludus::UI::Flags::Combo::None;
+
 	class ComboScope
 	{
 	private:
 		bool m_Open = false;
 
 	public:
-		explicit ComboScope(const char* label, const char* previewValue, Ludus::UI::Flags::Combo flags = Ludus::UI::Flags::Combo::None);
+		explicit ComboScope(const char* label, const char* previewValue, Ludus::UI::Flags::Combo flags = DefaultComboFlags);
 
 		~ComboScope();
 

--- a/UI/Include/Ludus/UI/Scope/MenuBarScope.h
+++ b/UI/Include/Ludus/UI/Scope/MenuBarScope.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <Ludus/Engine/Math/Vector2D.h>
+
+namespace Ludus::UI::Scope
+{
+	class MenuBarScope
+	{
+	private:
+		bool m_Open = false;
+
+	public:
+		explicit MenuBarScope();
+
+		~MenuBarScope();
+
+		explicit operator bool() const { return m_Open; }
+	};
+}

--- a/UI/Include/Ludus/UI/Widgets/Demo.h
+++ b/UI/Include/Ludus/UI/Widgets/Demo.h
@@ -2,5 +2,5 @@
 
 namespace Ludus::UI::Widgets
 {
-	void ShowDemoWindow();
+	void ShowDemoWindow(bool* open);
 }

--- a/UI/Source/Ludus/UI/Scope/MenuBarScope.cpp
+++ b/UI/Source/Ludus/UI/Scope/MenuBarScope.cpp
@@ -1,0 +1,19 @@
+#include "pch.h"
+
+#include <Ludus/UI/Scope/MenuBarScope.h>
+
+namespace Ludus::UI::Scope
+{
+	MenuBarScope::MenuBarScope()
+	{
+		m_Open = ImGui::BeginMenuBar();
+	}
+
+	MenuBarScope::~MenuBarScope()
+	{
+		if (m_Open)
+		{
+			ImGui::EndMenuBar();
+		}
+	}
+}

--- a/UI/Source/Ludus/UI/Widgets/Demo.cpp
+++ b/UI/Source/Ludus/UI/Widgets/Demo.cpp
@@ -4,5 +4,5 @@
 
 namespace Ludus::UI::Widgets
 {
-	void ShowDemoWindow() { ImGui::ShowDemoWindow(); }
+	void ShowDemoWindow(bool* open) { ImGui::ShowDemoWindow(open); }
 }

--- a/UI/UI.vcxproj
+++ b/UI/UI.vcxproj
@@ -40,6 +40,7 @@
     <ClInclude Include="Include\Ludus\UI\Context\InputContext.h" />
     <ClInclude Include="Include\Ludus\UI\Context\ScrollContext.h" />
     <ClInclude Include="Include\Ludus\UI\Context\LayoutContext.h" />
+    <ClInclude Include="Include\Ludus\UI\Scope\MenuBarScope.h" />
     <ClInclude Include="Source\Ludus\UI\pch.h" />
     <ClInclude Include="Include\Ludus\UI\Flags\Flags.h" />
     <ClInclude Include="Include\Ludus\UI\Systems\ImGuiSystem.h" />
@@ -67,6 +68,7 @@
     <ClInclude Include="Include\Ludus\UI\Context\ViewportContext.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="Source\Ludus\UI\Scope\MenuBarScope.cpp" />
     <ClCompile Include="Source\Ludus\UI\Context\LayoutContext.cpp" />
     <ClCompile Include="Source\Ludus\UI\Context\DockingContext.cpp" />
     <ClCompile Include="Source\Ludus\UI\Context\ImageContext.cpp" />


### PR DESCRIPTION
# Summary
Added `ActivePanelState` to the editor context that keeps track of singleton panels like the inspector panel and the hierarchy panel. The `IPanel` now has a virtual `GetOpenFlag` method that can bind the toggle of the viewport to the active panel state. 

All `UpdateImpl` methods now return a boolean that indicates to the `EditorSystem` whether it is open or it should be removed.
Multi-instance panels (ViewportPanel exclusively at the moment) are removed from the panels if the user click on the exit symbol.

A new viewport can be added via a new menu bar: **View** -> **Add Viewport**.

# Linked
- Closes #133 
