### PR TITLE
Refactor: Hierarchy panel scene selection and display name component

### DIFF
--- a/Editor/Editor.vcxproj
+++ b/Editor/Editor.vcxproj
@@ -60,7 +60,6 @@
     <ClInclude Include="Include\Ludus\Editor\Panels\PanelRegistry.h" />
     <ClInclude Include="Include\Ludus\Editor\Core\Constants.h" />
     <ClInclude Include="Include\Ludus\Editor\Panels\DockPanel.h" />
-    <ClInclude Include="Include\Ludus\Editor\Core\InspectorHelpers.h" />
     <ClInclude Include="Include\Ludus\Editor\Panels\IPanel.h" />
     <ClInclude Include="Include\Ludus\Editor\Core\Utilities.h" />
     <ClInclude Include="Include\Ludus\Editor\Panels\ConsolePanel.h" />

--- a/Editor/Include/Ludus/Editor/Core/ActivePanelState.h
+++ b/Editor/Include/Ludus/Editor/Core/ActivePanelState.h
@@ -5,7 +5,7 @@ namespace Ludus::Editor::Core
 	struct ActivePanelState
 	{
 		bool ShowConsolePanel = true;
-		bool ShowHierachyPanel = true;
+		bool ShowHierarchyPanel = true;
 		bool ShowInspectorPanel = true;
 		bool ShowImGuiDemoPanel = true;
 	};

--- a/Editor/Include/Ludus/Editor/Core/EditorSelection.h
+++ b/Editor/Include/Ludus/Editor/Core/EditorSelection.h
@@ -21,12 +21,7 @@ namespace Ludus::Editor::Core
 		void SelectScene(Ludus::Engine::Core::SceneHandle scene)
 		{
 			SelectedScene = scene;
-		}
-
-		void DeselectAll()
-		{
 			SelectedEntity = std::nullopt;
-			SelectedScene = std::nullopt;
 		}
 
 		void DeselectEntity()
@@ -37,6 +32,7 @@ namespace Ludus::Editor::Core
 		void DeselectScene()
 		{
 			SelectedScene = std::nullopt;
+			SelectedEntity = std::nullopt;
 		}
 
 		bool HasEntity() const { return SelectedEntity.has_value(); }

--- a/Editor/Include/Ludus/Editor/Panels/HierarchyPanel.h
+++ b/Editor/Include/Ludus/Editor/Panels/HierarchyPanel.h
@@ -1,14 +1,34 @@
 #pragma once
 
+#include <Ludus/Editor/Core/EditorSelection.h>
 #include <Ludus/Editor/Panels/IPanel.h>
 #include <Ludus/Editor/Panels/PanelContext.h>
+#include <Ludus/Engine/Core/Scene.h>
 
 namespace Ludus::Editor::Panels
 {
+	struct SceneToolBarActions;
+	struct SceneContextMenuActions;
+	struct EntityRowActions;
+	struct EntityRowCommands;
+
 	class HierarchyPanel final : public Ludus::Editor::Panels::IPanel
 	{
+	private:
+		std::optional<Ludus::Engine::Core::SceneHandle> m_SelectedSceneHandle = std::nullopt;
+
+		const static SceneToolBarActions DrawSceneToolBar(std::span<const Ludus::Engine::Core::Scene> scenes, std::optional<Ludus::Engine::Core::SceneHandle> sceneHandle);
+		static std::optional<Ludus::Engine::Core::SceneHandle> ApplySceneToolBarActions(const SceneToolBarActions& actions, Ludus::Editor::Panels::PanelContext& context);
+
+		const static SceneContextMenuActions DrawSceneContextMenu(Ludus::Editor::Panels::PanelContext& context, Ludus::Engine::Core::Scene& scene);
+		static void ApplySceneContextMenuActions(const SceneContextMenuActions& actions, Ludus::Editor::Panels::PanelContext& context, Ludus::Engine::Core::Scene& scene);
+
+		static const EntityRowActions DrawEntityRow(Ludus::Editor::Panels::PanelContext& context, Ludus::Engine::Core::Scene& scene, Ludus::Engine::Core::EntityHandle entityHandle);
+		void AddToEntityRowCommands(EntityRowCommands& commands, const EntityRowActions& actions, Ludus::Engine::Core::EntityHandle entityHandle);
+		static void ApplyEntityRowCommands(const EntityRowCommands& commands, Ludus::Editor::Panels::PanelContext& context, Ludus::Engine::Core::Scene& scene);
+
 	public:
-		virtual bool* GetOpenFlag(Ludus::Editor::Panels::PanelContext& context) override { return &context.ActivePanelState.ShowHierachyPanel; }
+		virtual bool* GetOpenFlag(Ludus::Editor::Panels::PanelContext& context) override { return &context.ActivePanelState.ShowHierarchyPanel; }
 
 		virtual bool UpdateImpl(Ludus::Editor::Panels::PanelContext& context) override;
 	};

--- a/Editor/Include/Ludus/Editor/Panels/InspectorPanel.h
+++ b/Editor/Include/Ludus/Editor/Panels/InspectorPanel.h
@@ -2,11 +2,29 @@
 
 #include <Ludus/Editor/Panels/IPanel.h>
 #include <Ludus/Editor/Panels/PanelContext.h>
+#include <Ludus/Engine/Components/Camera2DComponent.h>
+#include <Ludus/Engine/Components/Collider2DComponent.h>
+#include <Ludus/Engine/Components/DisplayNameComponent.h>
+#include <Ludus/Engine/Components/RigidBody2DComponent.h>
+#include <Ludus/Engine/Components/Sprite2DComponent.h>
+#include <Ludus/Engine/Components/Text2DComponent.h>
+#include <Ludus/Engine/Components/Transform2DComponent.h>
+#include <Ludus/Engine/Core/Entity.h>
 
 namespace Ludus::Editor::Panels
 {
 	class InspectorPanel final : public Ludus::Editor::Panels::IPanel
 	{
+	private:
+		static void DrawEntityHandle(Ludus::Engine::Core::EntityHandle handle);
+		static void DrawDisplayName(Ludus::Engine::Components::DisplayNameComponent& component);
+		static void DrawTransform2D(Ludus::Engine::Components::Transform2DComponent& component);
+		static void DrawCollider2D(Ludus::Engine::Components::Collider2DComponent& component);
+		static void DrawRigidBody2D(Ludus::Engine::Components::RigidBody2DComponent& component);
+		static void DrawSprite2D(Ludus::Engine::Components::Sprite2DComponent& component);
+		static void DrawText2D(Ludus::Engine::Components::Text2DComponent& component);
+		static void DrawCamera2D(Ludus::Engine::Components::Camera2DComponent& component);
+
 	public:
 		virtual bool* GetOpenFlag(Ludus::Editor::Panels::PanelContext& context) override { return &context.ActivePanelState.ShowInspectorPanel; }
 

--- a/Editor/Source/Ludus/Editor/Panels/DockPanel.cpp
+++ b/Editor/Source/Ludus/Editor/Panels/DockPanel.cpp
@@ -49,7 +49,7 @@ namespace Ludus::Editor::Panels
 				if (Ludus::UI::Scope::MenuScope panelsMenu("Panels"); panelsMenu)
 				{
 					Ludus::UI::Widgets::Checkbox("Console", &context.ActivePanelState.ShowConsolePanel);
-					Ludus::UI::Widgets::Checkbox("Hierarchy", &context.ActivePanelState.ShowHierachyPanel);
+					Ludus::UI::Widgets::Checkbox("Hierarchy", &context.ActivePanelState.ShowHierarchyPanel);
 					Ludus::UI::Widgets::Checkbox("ImGuiDemo", &context.ActivePanelState.ShowImGuiDemoPanel);
 					Ludus::UI::Widgets::Checkbox("Inspector", &context.ActivePanelState.ShowInspectorPanel);
 				}

--- a/Editor/Source/Ludus/Editor/Panels/HierarchyPanel.cpp
+++ b/Editor/Source/Ludus/Editor/Panels/HierarchyPanel.cpp
@@ -3,176 +3,433 @@
 #include <format>
 
 #include <Ludus/Editor/Core/Constants.h>
+#include <Ludus/Editor/Core/EditorSelection.h>
 #include <Ludus/Editor/Panels/HierarchyPanel.h>
+#include <Ludus/Engine/Core/Scene.h>
 #include <Ludus/Engine/Graphics/Shape.h>
 #include <Ludus/UI/Context/InputContext.h>
+#include <Ludus/UI/Context/LayoutContext.h>
+#include <Ludus/UI/Context/SelectionContext.h>
+#include <Ludus/UI/Context/WindowContext.h>
 #include <Ludus/UI/Flags/Flags.h>
+#include <Ludus/UI/Icons/FontAwesome.h>
 #include <Ludus/UI/Labels.h>
+#include <Ludus/UI/Scope/ComboScope.h>
 #include <Ludus/UI/Scope/MenuScope.h>
 #include <Ludus/UI/Scope/PopupScope.h>
 #include <Ludus/UI/Scope/TreeNodeScope.h>
 #include <Ludus/UI/Scope/WindowScope.h>
+#include <Ludus/UI/Widgets/Buttons.h>
 #include <Ludus/UI/Widgets/Menu.h>
 #include <Ludus/UI/Widgets/Selection.h>
 
 namespace Ludus::Editor::Panels
 {
+
+#pragma region Scene Tool Bar
+
+	struct SceneToolBarActions
+	{
+		std::optional<Ludus::Engine::Core::SceneHandle> SelectedSceneHandle = std::nullopt;
+		bool IsSceneAdded = false;
+		bool IsSceneRemoved = false;
+		bool IsSceneSetActive = false;
+	};
+
+	const SceneToolBarActions HierarchyPanel::DrawSceneToolBar(
+		std::span<const Ludus::Engine::Core::Scene> scenes,
+		std::optional<Ludus::Engine::Core::SceneHandle> sceneHandle
+	)
+	{
+		SceneToolBarActions actions;
+
+		actions.SelectedSceneHandle = sceneHandle;
+
+		const auto comboLabel = Ludus::UI::CreateLabel("", "ActiveScene");
+		const auto preview = sceneHandle.has_value() ? std::format("Scene {}", sceneHandle.value()) : "None";
+
+		if (Ludus::UI::Scope::ComboScope combo(comboLabel.c_str(), preview.c_str()); combo)
+		{
+			if (scenes.empty())
+			{
+				const auto _ = Ludus::UI::Widgets::Selectable("None", false);
+			}
+			else
+			{
+				for (const auto& scene : scenes)
+				{
+					const bool isSelected = sceneHandle == scene.Handle;
+					const auto itemLabel = std::format("Scene {}", scene.Handle);
+					if (Ludus::UI::Widgets::Selectable(itemLabel.c_str(), isSelected))
+					{
+						actions.SelectedSceneHandle = scene.Handle;
+					}
+
+					if (isSelected)
+					{
+						Ludus::UI::Context::SelectionContext::SetItemDefaultFocus();
+					}
+				}
+			}
+		}
+
+		const auto spacing = 6.0f;
+
+		Ludus::UI::Context::LayoutContext::SameLine(0.0f, spacing);
+
+		auto plusLabel = Ludus::UI::CreateLabel(ICON_PLUS, "Plus");
+		if (Ludus::UI::Widgets::Button(plusLabel.c_str()))
+		{
+			actions.IsSceneAdded = true;
+		}
+
+		Ludus::UI::Context::LayoutContext::SameLine(0.0f, spacing);
+
+		const char* popupId = "SceneOptionsPopup";
+
+		const auto ellipsisLabel = Ludus::UI::CreateLabel(ICON_ELLIPSIS_V, "Ellipsis");
+		if (Ludus::UI::Widgets::Button(ellipsisLabel.c_str()))
+		{
+			Ludus::UI::Scope::OpenPopup(popupId);
+		}
+
+		if (Ludus::UI::Scope::PopupScope popupScope(popupId); popupScope)
+		{
+			if (Ludus::UI::Widgets::MenuItem("Set active scene"))
+			{
+				actions.IsSceneSetActive = true;
+			}
+
+			if (Ludus::UI::Widgets::MenuItem("Remove scene"))
+			{
+				actions.IsSceneRemoved = true;
+			}
+		}
+
+		return actions;
+	}
+
+	std::optional<Ludus::Engine::Core::SceneHandle> HierarchyPanel::ApplySceneToolBarActions(const SceneToolBarActions& actions, Ludus::Editor::Panels::PanelContext& context)
+	{
+		auto& sceneManager = context.SystemContext.SceneManager;
+		auto& selection = context.EditorContext.State.Selection;
+
+		if (actions.IsSceneAdded)
+		{
+			const auto sceneHandle = sceneManager.AddScene();
+			selection.SelectScene(sceneHandle);
+
+			return sceneHandle;
+		}
+
+		if (actions.SelectedSceneHandle.has_value())
+		{
+			const auto sceneHandle = actions.SelectedSceneHandle.value();
+			if (actions.IsSceneRemoved)
+			{
+				sceneManager.RemoveScene(sceneHandle);
+				selection.DeselectScene();
+
+				return sceneManager.GetActiveSceneHandle();
+			}
+
+			if (actions.IsSceneSetActive)
+			{
+				sceneManager.SetActiveScene(sceneHandle);
+			}
+		}
+
+		return actions.SelectedSceneHandle;
+	}
+
+#pragma endregion
+
+#pragma region Scene Context Menu
+
+	struct SceneContextMenuActions
+	{
+		bool IsEntityAdded = false;
+		bool IsCamera = false;
+		bool IsSprite = false;
+
+		std::string DisplayName;
+		Ludus::Engine::Graphics::Shape SpriteShape;
+	};
+
+	const SceneContextMenuActions HierarchyPanel::DrawSceneContextMenu(Ludus::Editor::Panels::PanelContext& context, Ludus::Engine::Core::Scene& scene)
+	{
+		SceneContextMenuActions actions;
+
+		auto& selection = context.EditorContext.State.Selection;
+		auto& ecs = scene.EntityComponentSystem;
+
+		auto flags = Ludus::UI::Flags::Popup::MouseButtonRight | Ludus::UI::Flags::Popup::NoOpenOverItems;
+		if (Ludus::UI::Scope::PopupContextWindowScope contextWindow("HierarchyWindowContext", flags); contextWindow)
+		{
+			if (Ludus::UI::Widgets::MenuItem("Add empty"))
+			{
+				actions.IsEntityAdded = true;
+				actions.DisplayName = "Empty";
+			}
+
+			if (Ludus::UI::Widgets::MenuItem("Add camera"))
+			{
+				actions.IsEntityAdded = true;
+				actions.DisplayName = "Camera";
+				actions.IsCamera = true;
+			}
+
+			if (Ludus::UI::Scope::MenuScope menu("Add sprite"); menu)
+			{
+				auto isSprite = false;
+
+				if (Ludus::UI::Widgets::MenuItem("Circle"))
+				{
+					actions.DisplayName = "Circle";
+					actions.SpriteShape = Ludus::Engine::Graphics::Shape::Circle;
+
+					isSprite = true;
+				}
+
+				if (Ludus::UI::Widgets::MenuItem("Quad"))
+				{
+					actions.DisplayName = "Quad";
+					actions.SpriteShape = Ludus::Engine::Graphics::Shape::Quad;
+
+					isSprite = true;
+				}
+
+				if (isSprite)
+				{
+					actions.IsEntityAdded = true;
+					actions.IsSprite = true;
+				}
+			}
+		}
+
+		return actions;
+	}
+
+	void HierarchyPanel::ApplySceneContextMenuActions(const SceneContextMenuActions& actions, Ludus::Editor::Panels::PanelContext& context, Ludus::Engine::Core::Scene& scene)
+	{
+		auto& selection = context.EditorContext.State.Selection;
+		auto& ecs = scene.EntityComponentSystem;
+
+		if (!actions.IsEntityAdded)
+		{
+			return;
+		}
+
+		const auto handle = ecs.AddEntity();
+		ecs.AttachTransform(handle);
+		ecs.AttachDisplayName(handle, actions.DisplayName);
+
+		if (actions.IsCamera)
+		{
+			ecs.AttachCamera(handle);
+		}
+		else if (actions.IsSprite)
+		{
+			ecs.AttachSprite(handle, actions.SpriteShape);
+		}
+
+		selection.SelectEntity(handle, scene.Handle);
+	}
+
+#pragma endregion
+
+#pragma region Entity Rows
+
+	enum class ComponentKind { Camera2D, Collider2D, RigidBody2D, Sprite2D, Text2D };
+
+	struct EntityRowActions
+	{
+		bool IsEntityRemoved = false;
+		bool IsEntitySelected = false;
+		std::optional<ComponentKind> AddedComponent = std::nullopt;
+	};
+
+	struct EntityRowCommands
+	{
+		std::vector<Ludus::Engine::Core::EntityHandle> EntitiesToRemove;
+		std::optional<Ludus::Engine::Core::EntityHandle> EntityToSelect = std::nullopt;
+		std::vector<std::pair<ComponentKind, Ludus::Engine::Core::EntityHandle>> ComponentsToAdd;
+	};
+
+	const EntityRowActions HierarchyPanel::DrawEntityRow(Ludus::Editor::Panels::PanelContext& context, Ludus::Engine::Core::Scene& scene, Ludus::Engine::Core::EntityHandle entityHandle)
+	{
+		EntityRowActions actions;
+
+		auto& selection = context.EditorContext.State.Selection;
+		auto& ecs = scene.EntityComponentSystem;
+		const auto sceneHandle = scene.Handle;
+
+		const auto* displayNamePtr = ecs.DisplayNames.TryGetByOwner(entityHandle);
+		const auto entityLabel = displayNamePtr != nullptr
+			? Ludus::UI::CreateLabel(displayNamePtr->Value, entityHandle)
+			: Ludus::UI::CreateLabel(std::format("Entity {}", entityHandle), entityHandle);
+
+		if (Ludus::UI::Widgets::Selectable(entityLabel.c_str(), selection.IsSelected(entityHandle, scene.Handle)))
+		{
+			actions.IsEntitySelected = true;
+		}
+
+		if (Ludus::UI::Scope::PopupContextItemScope contextItem; contextItem)
+		{
+			if (Ludus::UI::Widgets::MenuItem("Select"))
+			{
+				actions.IsEntitySelected = true;
+			}
+
+			Ludus::UI::Context::LayoutContext::Separator();
+
+			if (Ludus::UI::Widgets::MenuItem("Remove"))
+			{
+				actions.IsEntityRemoved = true;
+			}
+
+			Ludus::UI::Context::LayoutContext::Separator();
+
+			if (Ludus::UI::Scope::MenuScope componentMenu("Add component"); componentMenu)
+			{
+				if (!ecs.Cameras.ContainsOwner(entityHandle) && Ludus::UI::Widgets::MenuItem("Camera 2D"))
+				{
+					actions.AddedComponent = ComponentKind::Camera2D;
+				}
+
+				if (!ecs.Colliders.ContainsOwner(entityHandle) && Ludus::UI::Widgets::MenuItem("Collider 2D"))
+				{
+					actions.AddedComponent = ComponentKind::Collider2D;
+				}
+
+				if (!ecs.RigidBodies.ContainsOwner(entityHandle) && Ludus::UI::Widgets::MenuItem("Rigid Body 2D"))
+				{
+					actions.AddedComponent = ComponentKind::RigidBody2D;
+
+				}
+
+				if (!ecs.Sprites.ContainsOwner(entityHandle) && Ludus::UI::Widgets::MenuItem("Sprite 2D"))
+				{
+					actions.AddedComponent = ComponentKind::Sprite2D;
+
+				}
+
+				if (!ecs.Texts.ContainsOwner(entityHandle) && Ludus::UI::Widgets::MenuItem("Text 2D"))
+				{
+					actions.AddedComponent = ComponentKind::Text2D;
+
+				}
+
+				if (actions.AddedComponent.has_value())
+				{
+					actions.IsEntitySelected = true;
+				}
+			}
+		}
+
+		return actions;
+	}
+
+	void HierarchyPanel::AddToEntityRowCommands(EntityRowCommands& commands, const EntityRowActions& actions, Ludus::Engine::Core::EntityHandle entityHandle)
+	{
+		if (actions.IsEntityRemoved)
+		{
+			commands.EntitiesToRemove.push_back(entityHandle);
+		}
+
+		if (actions.IsEntitySelected)
+		{
+			commands.EntityToSelect = entityHandle;
+		}
+
+		if (actions.AddedComponent.has_value())
+		{
+			commands.ComponentsToAdd.push_back({ *actions.AddedComponent, entityHandle });
+		}
+	}
+
+	void HierarchyPanel::ApplyEntityRowCommands(const EntityRowCommands& commands, Ludus::Editor::Panels::PanelContext& context, Ludus::Engine::Core::Scene& scene)
+	{
+		auto& ecs = scene.EntityComponentSystem;
+		auto& selection = context.EditorContext.State.Selection;
+
+		for (auto [kind, handle] : commands.ComponentsToAdd)
+		{
+			switch (kind)
+			{
+			case ComponentKind::Camera2D:		ecs.AttachCamera(handle);		break;
+			case ComponentKind::Collider2D:		ecs.AttachCollider(handle);		break;
+			case ComponentKind::RigidBody2D:	ecs.AttachRigidBody(handle);	break;
+			case ComponentKind::Sprite2D:		ecs.AttachSprite(handle);		break;
+			case ComponentKind::Text2D:			ecs.AttachText(handle, "");		break;
+			}
+		}
+
+		for (auto handle : commands.EntitiesToRemove)
+		{
+			ecs.DestroyEntity(handle);
+			if (selection.IsSelected(handle, scene.Handle))
+			{
+				selection.DeselectEntity();
+			}
+		}
+
+		if (commands.EntityToSelect.has_value())
+		{
+			selection.SelectEntity(commands.EntityToSelect.value(), scene.Handle);
+		}
+	}
+
+#pragma endregion
+
 	bool HierarchyPanel::UpdateImpl(Ludus::Editor::Panels::PanelContext& context)
 	{
 		auto windowTitle = CreateWindowTitle("Hierarchy");
 		if (Ludus::UI::Scope::WindowScope window(windowTitle.c_str(), &m_Open, Ludus::Editor::Core::Constants::PanelFlags); window)
 		{
+			auto& sceneManager = context.SystemContext.SceneManager;
 			auto& selection = context.EditorContext.State.Selection;
 
-			for (auto& scene : context.SystemContext.SceneManager.ViewMutable())
+			if (!m_SelectedSceneHandle.has_value() || !sceneManager.Contains(m_SelectedSceneHandle.value()))
 			{
-				const auto sceneHandle = scene.Handle;
-				const auto sceneLabel = Ludus::UI::CreateLabel(std::format("Scene {}", sceneHandle), sceneHandle);
-
-				if (Ludus::UI::Scope::TreeNodeScope treeNode(sceneLabel.c_str()); treeNode)
-				{
-					auto& ecs = scene.EntityComponentSystem;
-					const auto& entities = ecs.View();
-
-					if (Ludus::UI::Scope::PopupContextItemScope scenePopup; scenePopup)
-					{
-						if (Ludus::UI::Widgets::MenuItem("Create empty"))
-						{
-							auto handle = ecs.AddEntity();
-							ecs.AttachTransform(handle);
-
-							selection.SelectEntity(handle, sceneHandle);
-						}
-
-						auto hasSprite = false;
-
-						if (Ludus::UI::Scope::MenuScope menu("2D Sprite"); menu)
-						{
-							Ludus::Engine::Graphics::Shape shape;
-							std::string displayName;
-
-							if (Ludus::UI::Widgets::MenuItem("Quad"))
-							{
-								shape = Ludus::Engine::Graphics::Shape::Quad;
-								displayName = "Quad";
-								hasSprite = true;
-							}
-
-							if (Ludus::UI::Widgets::MenuItem("Circle"))
-							{
-								shape = Ludus::Engine::Graphics::Shape::Circle;
-								displayName = "Circle";
-								hasSprite = true;
-							}
-
-							if (hasSprite)
-							{
-								auto handle = ecs.AddEntity();
-								ecs.AttachTransform(handle);
-								ecs.AttachSprite(handle, shape);
-
-								selection.SelectEntity(handle, sceneHandle);
-							}
-						}
-
-						if (Ludus::UI::Widgets::MenuItem("Set active scene"))
-						{
-							context.SystemContext.SceneManager.SetActiveScene(sceneHandle);
-							selection.SelectScene(sceneHandle);
-						}
-
-						if (Ludus::UI::Widgets::MenuItem("Remove scene"))
-						{
-							context.SystemContext.SceneManager.RemoveScene(sceneHandle);
-							selection.DeselectAll();
-						}
-					}
-
-					for (auto& entity : entities)
-					{
-						const auto entityHandle = entity.Handle;
-						const auto entityLabel = Ludus::UI::CreateLabel(std::format("Entity {}", entityHandle), entityHandle);
-
-						if (Ludus::UI::Widgets::Selectable(entityLabel.c_str(), selection.IsSelected(entityHandle, sceneHandle)))
-						{
-							selection.SelectEntity(entityHandle, sceneHandle);
-						}
-
-						if (Ludus::UI::Scope::PopupContextItemScope contextItem; contextItem)
-						{
-							if (Ludus::UI::Widgets::MenuItem("Select"))
-							{
-								selection.SelectEntity(entityHandle, sceneHandle);
-							}
-
-							if (Ludus::UI::Widgets::MenuItem("Remove"))
-							{
-								ecs.DestroyEntity(entityHandle);
-								if (selection.IsSelected(entityHandle, sceneHandle))
-								{
-									selection.DeselectAll();
-								}
-							}
-
-							if (Ludus::UI::Scope::MenuScope componentMenu("Add Component"); componentMenu)
-							{
-								auto isComponentAdded = false;
-
-								if (!ecs.Cameras.ContainsOwner(entityHandle) && Ludus::UI::Widgets::MenuItem("Camera 2D"))
-								{
-									ecs.AttachCamera(entityHandle);
-									isComponentAdded = true;
-								}
-
-								if (!ecs.Colliders.ContainsOwner(entityHandle) && Ludus::UI::Widgets::MenuItem("Collider 2D"))
-								{
-									ecs.AttachCollider(entityHandle);
-									isComponentAdded = true;
-								}
-
-								if (!ecs.RigidBodies.ContainsOwner(entityHandle) && Ludus::UI::Widgets::MenuItem("Rigid Body 2D"))
-								{
-									ecs.AttachRigidBody(entityHandle);
-									isComponentAdded = true;
-								}
-
-								if (!ecs.Sprites.ContainsOwner(entityHandle) && Ludus::UI::Widgets::MenuItem("Sprite 2D"))
-								{
-									ecs.AttachSprite(entityHandle);
-									isComponentAdded = true;
-								}
-
-								if (!ecs.Texts.ContainsOwner(entityHandle) && Ludus::UI::Widgets::MenuItem("Text 2D"))
-								{
-									ecs.AttachText(entityHandle, "");
-									isComponentAdded = true;
-								}
-
-								if (isComponentAdded)
-								{
-									selection.SelectEntity(entityHandle, sceneHandle);
-								}
-							}
-						}
-					}
-				}
+				m_SelectedSceneHandle = sceneManager.GetActiveSceneHandle();
 			}
 
-			auto flags = Ludus::UI::Flags::Popup::MouseButtonRight | Ludus::UI::Flags::Popup::NoOpenOverItems;
-			if (Ludus::UI::Scope::PopupContextWindowScope contextWindow("HierarchyWindowContext", flags); contextWindow)
+			const auto& toolBarActions = DrawSceneToolBar(sceneManager.View(), m_SelectedSceneHandle);
+			m_SelectedSceneHandle = ApplySceneToolBarActions(toolBarActions, context);
+			if (!m_SelectedSceneHandle.has_value())
 			{
-				if (Ludus::UI::Widgets::MenuItem("Create scene"))
-				{
-					auto sceneHandle = context.SystemContext.SceneManager.AddScene();
-					selection.SelectScene(sceneHandle);
-				}
+				return true;
 			}
+
+			const auto sceneHandle = m_SelectedSceneHandle.value();
+			auto* scene = context.SystemContext.SceneManager.TryGetScene(sceneHandle);
+
+			if (!scene)
+			{
+				return true;
+			}
+
+			Ludus::UI::Context::LayoutContext::Separator();
+
+			const auto& contextMenuActions = DrawSceneContextMenu(context, *scene);
+			ApplySceneContextMenuActions(contextMenuActions, context, *scene);
+
+			EntityRowCommands commands;
+
+			for (const auto& entity : scene->EntityComponentSystem.View())
+			{
+				const auto entityRowActions = DrawEntityRow(context, *scene, entity.Handle);
+				AddToEntityRowCommands(commands, entityRowActions, entity.Handle);
+			}
+
+			ApplyEntityRowCommands(commands, context, *scene);
 
 			if (Ludus::UI::Context::InputContext::IsMouseClicked(Ludus::Engine::Platform::MouseButton::Left) &&
 				Ludus::UI::Context::InputContext::IsWindowHovered(Ludus::UI::Flags::Hovered::AllowWhenBlockedByActiveItem) &&
 				!Ludus::UI::Context::InputContext::IsAnyItemHovered())
 			{
-				selection.DeselectAll();
+				selection.DeselectEntity();
 			}
 		}
 

--- a/Editor/Source/Ludus/Editor/Panels/InspectorPanel.cpp
+++ b/Editor/Source/Ludus/Editor/Panels/InspectorPanel.cpp
@@ -1,14 +1,271 @@
 #include "pch.h"
 
 #include <Ludus/Editor/Core/Constants.h>
-#include <Ludus/Editor/Core/InspectorHelpers.h>
+#include <Ludus/Editor/Core/Utilities.h>
 #include <Ludus/Editor/Panels/InspectorPanel.h>
+#include <Ludus/Engine/Components/Camera2DComponent.h>
+#include <Ludus/Engine/Components/Collider2DComponent.h>
+#include <Ludus/Engine/Components/DisplayNameComponent.h>
+#include <Ludus/Engine/Components/RigidBody2DComponent.h>
+#include <Ludus/Engine/Components/Sprite2DComponent.h>
+#include <Ludus/Engine/Components/Text2DComponent.h>
+#include <Ludus/Engine/Components/Transform2DComponent.h>
+#include <Ludus/Engine/Core/Entity.h>
+#include <Ludus/Engine/Core/Enums.h>
+#include <Ludus/Engine/Graphics/Color.h>
+#include <Ludus/Engine/Graphics/HorizontalTextAlignment.h>
+#include <Ludus/Engine/Graphics/Shape.h>
+#include <Ludus/Engine/Physics/Core/LayerMask.h>
+#include <Ludus/UI/Context/LayoutContext.h>
+#include <Ludus/UI/Context/TableContext.h>
+#include <Ludus/UI/Context/WindowContext.h>
 #include <Ludus/UI/Scope/MenuScope.h>
+#include <Ludus/UI/Scope/TableScope.h>
+#include <Ludus/UI/Scope/TreeNodeScope.h>
 #include <Ludus/UI/Scope/WindowScope.h>
+#include <Ludus/UI/Widgets/Color.h>
+#include <Ludus/UI/Widgets/Headers.h>
+#include <Ludus/UI/Widgets/Input.h>
 #include <Ludus/UI/Widgets/Menu.h>
+#include <Ludus/UI/Widgets/Text.h>
+#include <Ludus/UI/Widgets/Toggle.h>
 
 namespace Ludus::Editor::Panels
 {
+
+#pragma region Draw calls
+
+	void InspectorPanel::DrawEntityHandle(Ludus::Engine::Core::EntityHandle handle)
+	{
+		if (Ludus::UI::Scope::TreeNodeScope treeNode("Id"); treeNode)
+		{
+			if (Ludus::UI::Scope::TableScope table("Id_Panel", 2); table)
+			{
+				Ludus::UI::Context::TableContext::TableNextRowFirstColumn();
+				Ludus::UI::Widgets::TextUnformatted("Value");
+				Ludus::UI::Context::TableContext::TableSetColumnIndex(1);
+				Ludus::UI::Widgets::TextUnformatted(std::to_string(handle));
+			}
+		}
+	}
+
+	void InspectorPanel::DrawDisplayName(Ludus::Engine::Components::DisplayNameComponent& component)
+	{
+		if (Ludus::UI::Scope::TreeNodeScope treeNode("Display Name"); treeNode)
+		{
+			if (Ludus::UI::Scope::TableScope table("DisplayName_Panel", 2); table)
+			{
+				Ludus::UI::Context::TableContext::TableNextRowFirstColumn();
+				Ludus::UI::Widgets::TextUnformatted("Value");
+				Ludus::UI::Context::TableContext::TableSetColumnIndex(1);
+				Ludus::UI::Widgets::InputText("##DisplayName_Panel_Value", component.Value);
+			}
+		}
+	}
+
+	void InspectorPanel::DrawTransform2D(Ludus::Engine::Components::Transform2DComponent& component)
+	{
+		if (Ludus::UI::Scope::TreeNodeScope treeNode("Transform 2D"); treeNode)
+		{
+			if (Ludus::UI::Scope::TableScope table("Transform2D_Panel", 3); table)
+			{
+				Ludus::UI::Context::TableContext::TableNextRowFirstColumn();
+				Ludus::UI::Widgets::TextUnformatted("Position");
+				Ludus::UI::Context::TableContext::TableSetColumnIndex(1);
+				Ludus::UI::Widgets::DragFloatLabelButton("X##Transform2D_Panel_Position_X", &component.Position.X);
+				Ludus::UI::Context::LayoutContext::SameLine();
+				Ludus::UI::Widgets::InputFloat("##Transform2D_Panel_Input_Position_X", &component.Position.X);
+
+				Ludus::UI::Context::TableContext::TableSetColumnIndex(2);
+				Ludus::UI::Widgets::DragFloatLabelButton("Y##Transform2D_Panel_Position_Y", &component.Position.Y);
+				Ludus::UI::Context::LayoutContext::SameLine();
+				Ludus::UI::Widgets::InputFloat("##Transform2D_Panel_Input_Position_Y", &component.Position.Y);
+
+				Ludus::UI::Context::TableContext::TableNextRowFirstColumn();
+				Ludus::UI::Widgets::TextUnformatted("Scale");
+				Ludus::UI::Context::TableContext::TableSetColumnIndex(1);
+				Ludus::UI::Widgets::DragFloatLabelButton("X##Transform2D_Panel_Scale_X", &component.Scale.X);
+				Ludus::UI::Context::LayoutContext::SameLine();
+				Ludus::UI::Widgets::InputFloat("##Transform2D_Panel_Input_Scale_X", &component.Scale.X);
+
+				Ludus::UI::Context::TableContext::TableSetColumnIndex(2);
+				Ludus::UI::Widgets::DragFloatLabelButton("Y##Transform2D_Panel_Scale_Y", &component.Scale.Y);
+				Ludus::UI::Context::LayoutContext::SameLine();
+				Ludus::UI::Widgets::InputFloat("##Transform2D_Panel_Input_Scale_Y", &component.Scale.Y);
+
+				Ludus::UI::Context::TableContext::TableNextRowFirstColumn();
+				Ludus::UI::Widgets::TextUnformatted("Rotation");
+				Ludus::UI::Context::TableContext::TableSetColumnIndex(1);
+				Ludus::UI::Widgets::DragFloatLabelButton("Z##Transform2D_Panel_DragFloat_Rotation", &component.Rotation);
+				Ludus::UI::Context::LayoutContext::SameLine();
+				Ludus::UI::Widgets::InputFloat("##Transform2D_Panel_InputFloat_Rotation_Z", &component.Rotation);
+			}
+		}
+	}
+
+	void InspectorPanel::DrawCollider2D(Ludus::Engine::Components::Collider2DComponent& component)
+	{
+		if (Ludus::UI::Scope::TreeNodeScope treeNode("Collider 2D"); treeNode)
+		{
+			if (Ludus::UI::Scope::TableScope table("##Collider2D_Panel", 3); table)
+			{
+				Ludus::UI::Context::TableContext::TableNextRowFirstColumn();
+				Ludus::UI::Widgets::TextUnformatted("Layer Index");
+				Ludus::UI::Context::TableContext::TableSetColumnIndex(1);
+				Ludus::UI::Widgets::InputUInt8("##Collider2D_Panel_LayerIndex", &component.LayerIndex);
+				Ludus::UI::Context::TableContext::TableSetColumnIndex(2);
+				Ludus::UI::Widgets::TextUnformatted(Ludus::Engine::Physics::Core::LayerMask::LayerIndexToName(component.LayerIndex));
+
+				Ludus::UI::Context::TableContext::TableNextRowFirstColumn();
+				Ludus::UI::Widgets::TextUnformatted("Collides With");
+				Ludus::UI::Context::TableContext::TableSetColumnIndex(1);
+
+				const auto count = Ludus::Engine::Physics::Core::LayerMask::GetLayerCount();
+				if (Ludus::UI::Widgets::CollapsingHeader("##Collider2D_Panel_CollidesWith"))
+				{
+					auto newMask = component.CollidesWith;
+					auto hasChanges = false;
+
+					for (size_t i = 0; i < count; i++)
+					{
+						auto layer = Ludus::Engine::Physics::Core::LayerMask::FromIndex((uint8_t)i);
+						auto label = Ludus::Engine::Physics::Core::LayerMask::LayerIndexToName((uint8_t)i);
+						auto isChecked = component.CollidesWith.Contains(layer);
+
+						auto item = Ludus::UI::Widgets::CheckboxItem(std::format("{} {}", i, label), isChecked);
+						if (Ludus::UI::Widgets::Checkbox(item))
+						{
+							hasChanges = true;
+							newMask = item.IsChecked ? newMask |= layer : newMask &= ~layer;
+						}
+					}
+
+					if (hasChanges)
+					{
+						component.CollidesWith = newMask;
+					}
+				}
+
+				Ludus::UI::Context::TableContext::TableNextRowFirstColumn();
+				Ludus::UI::Widgets::TextUnformatted("Is Trigger");
+				Ludus::UI::Context::TableContext::TableSetColumnIndex(1);
+				Ludus::UI::Widgets::Checkbox("##IsTrigger", &component.IsTrigger);
+				Ludus::UI::Context::TableContext::TableSetColumnIndex(1);
+			}
+		}
+	}
+
+	void InspectorPanel::DrawRigidBody2D(Ludus::Engine::Components::RigidBody2DComponent& component)
+	{
+		if (Ludus::UI::Scope::TreeNodeScope treeNode("Rigid Body 2D"); treeNode)
+		{
+			if (Ludus::UI::Scope::TableScope table("RigidBody2D_Panel", 3); table)
+			{
+				Ludus::UI::Context::TableContext::TableNextRowFirstColumn();
+				Ludus::UI::Widgets::TextUnformatted("Velocity");
+				Ludus::UI::Context::TableContext::TableSetColumnIndex(1);
+				Ludus::UI::Widgets::DragFloatLabelButton("X##RigidBody2D_Panel_Velocity_X", &component.Velocity.X);
+				Ludus::UI::Context::LayoutContext::SameLine();
+				Ludus::UI::Widgets::InputFloat("##RigidBody2D_Panel_Input_Velocity_X", &component.Velocity.X);
+
+				Ludus::UI::Context::TableContext::TableSetColumnIndex(2);
+				Ludus::UI::Widgets::DragFloatLabelButton("Y##RigidBody2D_Panel_Velocity_Y", &component.Velocity.Y);
+				Ludus::UI::Context::LayoutContext::SameLine();
+				Ludus::UI::Widgets::InputFloat("##RigidBody2D_Panel_Input_Velocity_Y", &component.Velocity.Y);
+
+				Ludus::UI::Context::TableContext::TableNextRowFirstColumn();
+				Ludus::UI::Widgets::TextUnformatted("Body Type");
+				Ludus::UI::Context::TableContext::TableSetColumnIndex(1);
+
+				auto _ = Ludus::Editor::Core::Utilities::ComboEnum("##RigidBody2D_Combo", component.Type);
+
+				Ludus::UI::Context::TableContext::TableNextRowFirstColumn();
+				Ludus::UI::Widgets::TextUnformatted("Gravity Scale");
+				Ludus::UI::Context::TableContext::TableSetColumnIndex(1);
+				Ludus::UI::Widgets::InputFloat("##RigidBody2D_Panel_GravityScale", &component.GravityScale);
+
+				Ludus::UI::Context::TableContext::TableNextRowFirstColumn();
+				Ludus::UI::Widgets::TextUnformatted("Mass");
+				Ludus::UI::Context::TableContext::TableSetColumnIndex(1);
+				Ludus::UI::Widgets::InputFloat("##RigidBody2D_Panel_Mass", &component.Mass);
+			}
+		}
+	}
+
+	void InspectorPanel::DrawSprite2D(Ludus::Engine::Components::Sprite2DComponent& component)
+	{
+		if (Ludus::UI::Scope::TreeNodeScope treeNode("Sprite 2D"); treeNode)
+		{
+			if (Ludus::UI::Scope::TableScope table("Sprite2D_Panel", 3); table)
+			{
+				Ludus::UI::Context::TableContext::TableNextRowFirstColumn();
+				Ludus::UI::Widgets::TextUnformatted("Shape");
+				Ludus::UI::Context::TableContext::TableSetColumnIndex(1);
+
+				auto _ = Ludus::Editor::Core::Utilities::ComboEnum("##Sprite2D_Panel_Combo", component.Shape);
+
+				Ludus::UI::Context::TableContext::TableNextRowFirstColumn();
+				Ludus::UI::Widgets::TextUnformatted("Color");
+				Ludus::UI::Context::TableContext::TableSetColumnIndex(1);
+				Ludus::UI::Widgets::ColorEdit4("##Sprite2D_Panel_Color", component.Color.GetData());
+
+				Ludus::UI::Context::TableContext::TableNextRowFirstColumn();
+				Ludus::UI::Widgets::TextUnformatted("Texture");
+				Ludus::UI::Context::TableContext::TableSetColumnIndex(1);
+				Ludus::UI::Widgets::TextUnformatted("N/A");
+
+				Ludus::UI::Context::TableContext::TableNextRowFirstColumn();
+				Ludus::UI::Widgets::TextUnformatted("Fill");
+				Ludus::UI::Context::TableContext::TableSetColumnIndex(1);
+				Ludus::UI::Widgets::Checkbox("##Fill", &component.Fill);
+				Ludus::UI::Context::TableContext::TableSetColumnIndex(1);
+			}
+		}
+	}
+
+	void InspectorPanel::DrawText2D(Ludus::Engine::Components::Text2DComponent& component)
+	{
+		if (Ludus::UI::Scope::TreeNodeScope treeNode("Text 2D"); treeNode)
+		{
+			if (Ludus::UI::Scope::TableScope table("Text2D_Panel", 3); table)
+			{
+				Ludus::UI::Context::TableContext::TableNextRowFirstColumn();
+				Ludus::UI::Widgets::TextUnformatted("Text");
+				Ludus::UI::Context::TableContext::TableSetColumnIndex(1);
+				Ludus::UI::Widgets::InputText("##Text2D_Panel_Text", component.Text);
+
+				Ludus::UI::Context::TableContext::TableNextRowFirstColumn();
+				Ludus::UI::Widgets::TextUnformatted("Color");
+				Ludus::UI::Context::TableContext::TableSetColumnIndex(1);
+				Ludus::UI::Widgets::ColorEdit4("##Text2D_Panel_Color", component.Color.GetData());
+
+				Ludus::UI::Context::TableContext::TableNextRowFirstColumn();
+				Ludus::UI::Widgets::TextUnformatted("Horizontal Alignment");
+				Ludus::UI::Context::TableContext::TableSetColumnIndex(1);
+
+				auto _ = Ludus::Editor::Core::Utilities::ComboEnum("##Text2D_Panel_Combo", component.HorizontalAlignment);
+			}
+		}
+	}
+
+	void InspectorPanel::DrawCamera2D(Ludus::Engine::Components::Camera2DComponent& component)
+	{
+		if (Ludus::UI::Scope::TreeNodeScope treeNode("Camera 2D"); treeNode)
+		{
+			if (Ludus::UI::Scope::TableScope table("Camera2D_Panel", 2); table)
+			{
+				Ludus::UI::Context::TableContext::TableNextRowFirstColumn();
+				Ludus::UI::Widgets::TextUnformatted("Orthographic Size");
+				Ludus::UI::Context::TableContext::TableSetColumnIndex(1);
+				Ludus::UI::Widgets::DragFloatLabelButton("Z##Camera2D_OrthographicSize_DragFloat_Rotation", &component.OrthographicSize);
+				Ludus::UI::Context::LayoutContext::SameLine();
+				Ludus::UI::Widgets::InputFloat("##Camera2D_OrthographicSize_InputFloat_Rotation_Z", &component.OrthographicSize);
+			}
+		}
+	}
+
+#pragma endregion
+
 	bool InspectorPanel::UpdateImpl(Ludus::Editor::Panels::PanelContext& context)
 	{
 		auto windowTitle = CreateWindowTitle("Inspector");
@@ -31,42 +288,48 @@ namespace Ludus::Editor::Panels
 			auto handle = selection.SelectedEntity.value();
 
 			auto* transformPtr = ecs.Transforms.TryGetByOwnerMutable(handle);
+			auto* displayNamePtr = ecs.DisplayNames.TryGetByOwnerMutable(handle);
 			auto* colliderPtr = ecs.Colliders.TryGetByOwnerMutable(handle);
 			auto* rigidBodyPtr = ecs.RigidBodies.TryGetByOwnerMutable(handle);
 			auto* spritePtr = ecs.Sprites.TryGetByOwnerMutable(handle);
 			auto* textPtr = ecs.Texts.TryGetByOwnerMutable(handle);
 			auto* cameraPtr = ecs.Cameras.TryGetByOwnerMutable(handle);
 
-			Ludus::Editor::Core::EntityPanel(handle);
+			DrawEntityHandle(handle);
+
+			if (displayNamePtr)
+			{
+				DrawDisplayName(*displayNamePtr);
+			}
 
 			if (transformPtr)
 			{
-				Ludus::Editor::Core::Transform2DPanel(*transformPtr);
+				DrawTransform2D(*transformPtr);
 			}
 
 			if (colliderPtr)
 			{
-				Ludus::Editor::Core::Collider2DPanel(*colliderPtr);
+				DrawCollider2D(*colliderPtr);
 			}
 
 			if (rigidBodyPtr)
 			{
-				Ludus::Editor::Core::RigidBody2DPanel(*rigidBodyPtr);
+				DrawRigidBody2D(*rigidBodyPtr);
 			}
 
 			if (spritePtr)
 			{
-				Ludus::Editor::Core::Sprite2DPanel(*spritePtr);
+				DrawSprite2D(*spritePtr);
 			}
 
 			if (textPtr)
 			{
-				Ludus::Editor::Core::Text2DPanel(*textPtr);
+				DrawText2D(*textPtr);
 			}
 
 			if (cameraPtr)
 			{
-				Ludus::Editor::Core::Camera2DPanel(*cameraPtr);
+				DrawCamera2D(*cameraPtr);
 			}
 		}
 

--- a/Engine/Engine.vcxproj
+++ b/Engine/Engine.vcxproj
@@ -26,6 +26,7 @@
     <Font Include="Resources\Fonts\ARIAL.TTF" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="Include\Ludus\Engine\Components\DisplayNameComponent.h" />
     <ClInclude Include="Include\Ludus\Engine\Core\ApplicationBuilder.h" />
     <ClInclude Include="Include\Ludus\Engine\Core\ApplicationOptions.h" />
     <ClInclude Include="Include\Ludus\Engine\Core\ExecutionFlags.h" />

--- a/Engine/Include/Ludus/Engine/Components/DisplayNameComponent.h
+++ b/Engine/Include/Ludus/Engine/Components/DisplayNameComponent.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <string>
+
+#include <Ludus/Engine/Core/Entity.h>
+
+namespace Ludus::Engine::Components
+{
+	struct DisplayNameComponent
+	{
+	public:
+		Ludus::Engine::Core::EntityHandle OwnerHandle;
+		std::string Value;
+
+		DisplayNameComponent(
+			Ludus::Engine::Core::EntityHandle owner,
+			std::string value
+		) :
+			OwnerHandle(owner),
+			Value(value)
+		{ }
+
+		~DisplayNameComponent() = default;
+
+		bool operator==(const DisplayNameComponent& other) const { return OwnerHandle == other.OwnerHandle; }
+	};
+}

--- a/Engine/Include/Ludus/Engine/Core/EntityComponentSystem.h
+++ b/Engine/Include/Ludus/Engine/Core/EntityComponentSystem.h
@@ -1,7 +1,10 @@
 #pragma once
 
+#include <string>
+
 #include <Ludus/Engine/Components/Camera2DComponent.h>
 #include <Ludus/Engine/Components/Collider2DComponent.h>
+#include <Ludus/Engine/Components/DisplayNameComponent.h>
 #include <Ludus/Engine/Components/RigidBody2DComponent.h>
 #include <Ludus/Engine/Components/Sprite2DComponent.h>
 #include <Ludus/Engine/Components/Text2DComponent.h>
@@ -24,6 +27,7 @@ namespace Ludus::Engine::Core
 	public:
 		Ludus::Engine::Core::ComponentRegistry <Ludus::Engine::Components::Camera2DComponent> Cameras;
 		Ludus::Engine::Core::ComponentRegistry <Ludus::Engine::Components::Collider2DComponent> Colliders;
+		Ludus::Engine::Core::ComponentRegistry <Ludus::Engine::Components::DisplayNameComponent> DisplayNames;
 		Ludus::Engine::Core::ComponentRegistry <Ludus::Engine::Components::RigidBody2DComponent> RigidBodies;
 		Ludus::Engine::Core::ComponentRegistry <Ludus::Engine::Components::Sprite2DComponent> Sprites;
 		Ludus::Engine::Core::ComponentRegistry <Ludus::Engine::Components::Text2DComponent> Texts;
@@ -38,6 +42,7 @@ namespace Ludus::Engine::Core
 		{
 			Cameras.RemoveByOwner(handle);
 			Colliders.RemoveByOwner(handle);
+			DisplayNames.RemoveByOwner(handle);
 			RigidBodies.RemoveByOwner(handle);
 			Sprites.RemoveByOwner(handle);
 			Texts.RemoveByOwner(handle);
@@ -63,6 +68,14 @@ namespace Ludus::Engine::Core
 		)
 		{
 			Colliders.Add(handle, layer, collidesWith, isTrigger);
+		}
+
+		void AttachDisplayName(
+			EntityHandle handle,
+			std::string value
+		)
+		{
+			DisplayNames.Add(handle, value);
 		}
 
 		void AttachRigidBody(

--- a/UI/Include/Ludus/UI/Context/LayoutContext.h
+++ b/UI/Include/Ludus/UI/Context/LayoutContext.h
@@ -5,4 +5,6 @@ namespace Ludus::UI::Context::LayoutContext
 	void SameLine(float offsetFromStart = 0.0f, float spacing = 0.0f);
 
 	void SetNextItemWidth(float width);
+
+	void Separator();
 }

--- a/UI/Include/Ludus/UI/Icons/FontAwesome.h
+++ b/UI/Include/Ludus/UI/Icons/FontAwesome.h
@@ -6,4 +6,6 @@ namespace Ludus::UI::Icons
 #define ICON_STOP reinterpret_cast<const char*>(u8"\uEF68")
 #define ICON_PAUSE reinterpret_cast<const char*>(u8"\uEDD1")
 #define ICON_STEP reinterpret_cast<const char*>(u8"\uEF64")
+#define ICON_PLUS reinterpret_cast<const char*>(u8"\uEE41")
+#define ICON_ELLIPSIS_V reinterpret_cast<const char*>(u8"\uEB47")
 }

--- a/UI/Include/Ludus/UI/Scope/PopupScope.h
+++ b/UI/Include/Ludus/UI/Scope/PopupScope.h
@@ -5,6 +5,22 @@
 namespace Ludus::UI::Scope
 {
 	constexpr Ludus::UI::Flags::Popup DefaultPopupContextItemFlags = Ludus::UI::Flags::Popup::MouseButtonRight;
+	constexpr Ludus::UI::Flags::Window DefaultPopupFlags = Ludus::UI::Flags::Window::None;
+
+	void OpenPopup(const char* id, Ludus::UI::Flags::Popup flags = DefaultPopupContextItemFlags);
+
+	class PopupScope
+	{
+	private:
+		bool m_Open = false;
+
+	public:
+		explicit PopupScope(const char* label = nullptr, Ludus::UI::Flags::Window flags = DefaultPopupFlags);
+
+		~PopupScope();
+
+		explicit operator bool() const { return m_Open; }
+	};
 
 	class PopupContextItemScope
 	{

--- a/UI/Source/Ludus/UI/Context/LayoutContext.cpp
+++ b/UI/Source/Ludus/UI/Context/LayoutContext.cpp
@@ -15,4 +15,9 @@ namespace Ludus::UI::Context::LayoutContext
 	{
 		ImGui::SetNextItemWidth(width);
 	}
+
+	void Separator()
+	{
+		ImGui::Separator();
+	}
 }

--- a/UI/Source/Ludus/UI/Scope/PopupScope.cpp
+++ b/UI/Source/Ludus/UI/Scope/PopupScope.cpp
@@ -5,6 +5,24 @@
 
 namespace Ludus::UI::Scope
 {
+	void OpenPopup(const char* id, Ludus::UI::Flags::Popup flags)
+	{
+		ImGui::OpenPopup(id, static_cast<int>(flags));
+	}
+
+	PopupScope::PopupScope(const char* id, Ludus::UI::Flags::Window flags)
+	{
+		m_Open = ImGui::BeginPopup(id, static_cast<int>(flags));
+	}
+
+	PopupScope::~PopupScope()
+	{
+		if (m_Open)
+		{
+			ImGui::EndPopup();
+		}
+	}
+
 	PopupContextItemScope::PopupContextItemScope(const char* label, Ludus::UI::Flags::Popup flags)
 	{
 		m_Open = ImGui::BeginPopupContextItem(label, static_cast<int>(flags));


### PR DESCRIPTION
# Summary
Refactored hierarchy panel to use scene selection instead of always displaying all scenes. A more robust way to handle context menu intents were added: Draw calls produce actions, which can then be applied afterwards. This pattern makes it much easier to read the code, as we can now see what is the actuall draw call and what are the effects.

Added DisplayNameComponent to the entity component system. This name is now used for the enties in the hierarchy panel.


# Linked
- Closes #193
- Closes #194  