### PR TITLE
Feature: Added startup project flag and builder refactors

### DIFF
--- a/Editor/Editor.vcxproj
+++ b/Editor/Editor.vcxproj
@@ -127,6 +127,7 @@
     <ClInclude Include="Include\Ludus\Editor\Core\EditorGridRenderPass.h" />
     <ClInclude Include="Include\Ludus\Editor\Core\ExecutionMode.h" />
     <ClInclude Include="Include\Ludus\Editor\Core\ProjectManifest.h" />
+    <ClInclude Include="Include\Ludus\Editor\Core\EditorStartupOptions.h" />
     <ClInclude Include="Include\Ludus\Editor\Core\ViewportDisplayMode.h" />
     <ClInclude Include="Include\Ludus\Editor\Dialogs\AddScriptDialog.h" />
     <ClInclude Include="Include\Ludus\Editor\Dialogs\CreateProjectDialog.h" />

--- a/Editor/Include/Ludus/Editor/Core/EditorConfiguration.h
+++ b/Editor/Include/Ludus/Editor/Core/EditorConfiguration.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <filesystem>
 #include <functional>
 #include <memory>
 #include <vector>
@@ -22,19 +23,26 @@ namespace Ludus::Editor::Core
 	{
 		std::vector<PanelFactory> PanelFactories;
 
+		EditorConfiguration() = default;
+
 		static EditorConfiguration Default()
 		{
-			EditorConfiguration options;
-			options.PanelFactories.push_back([] { return std::make_unique<Ludus::Editor::Panels::DockPanel>(); });
-			options.PanelFactories.push_back([] { return std::make_unique<Ludus::Editor::Panels::ImGuiDemoPanel>(); });
-			options.PanelFactories.push_back([] { return std::make_unique<Ludus::Editor::Panels::HierarchyPanel>(); });
-			options.PanelFactories.push_back([] { return std::make_unique<Ludus::Editor::Panels::InspectorPanel>(); });
-			options.PanelFactories.push_back([] { return std::make_unique<Ludus::Editor::Panels::ConsolePanel>(); });
-			options.PanelFactories.push_back([] { return std::make_unique<Ludus::Editor::Panels::ContentPanel>(); });
-			options.PanelFactories.push_back([] { return std::make_unique<Ludus::Editor::Panels::ViewportPanel>("Viewport", Ludus::Editor::Core::ViewportDisplayMode::Simulation); });
-			options.PanelFactories.push_back([] { return std::make_unique<Ludus::Editor::Panels::ViewportPanel>("Viewport", Ludus::Editor::Core::ViewportDisplayMode::Editor); });
+			EditorConfiguration configuration;
+			configuration.PanelFactories.push_back([] { return std::make_unique<Ludus::Editor::Panels::DockPanel>(); });
+			configuration.PanelFactories.push_back([] { return std::make_unique<Ludus::Editor::Panels::ImGuiDemoPanel>(); });
+			configuration.PanelFactories.push_back([] { return std::make_unique<Ludus::Editor::Panels::HierarchyPanel>(); });
+			configuration.PanelFactories.push_back([] { return std::make_unique<Ludus::Editor::Panels::InspectorPanel>(); });
+			configuration.PanelFactories.push_back([] { return std::make_unique<Ludus::Editor::Panels::ConsolePanel>(); });
+			configuration.PanelFactories.push_back([] { return std::make_unique<Ludus::Editor::Panels::ContentPanel>(); });
+			configuration.PanelFactories.push_back([] { return std::make_unique<Ludus::Editor::Panels::ViewportPanel>("Viewport", Ludus::Editor::Core::ViewportDisplayMode::Simulation); });
+			configuration.PanelFactories.push_back([] { return std::make_unique<Ludus::Editor::Panels::ViewportPanel>("Viewport", Ludus::Editor::Core::ViewportDisplayMode::Editor); });
 
-			return options;
+			return configuration;
 		}
+
+		EditorConfiguration(const EditorConfiguration&) = delete;
+		EditorConfiguration& operator=(const EditorConfiguration&) = delete;
+		EditorConfiguration(EditorConfiguration&&) = default;
+		EditorConfiguration& operator=(EditorConfiguration&&) = default;
 	};
 }

--- a/Editor/Include/Ludus/Editor/Core/EditorHostBuilder.h
+++ b/Editor/Include/Ludus/Editor/Core/EditorHostBuilder.h
@@ -1,12 +1,10 @@
 #pragma once
 
 #include <memory>
+#include <optional>
 
 #include <Ludus/Editor/Core/EditorConfiguration.h>
-#include <Ludus/Engine/Graphics/RenderingConfiguration2D.h>
-#include <Ludus/Engine/Graphics/RenderingOptions.h>
-#include <Ludus/Engine/Graphics/RenderViewConfiguration.h>
-#include <Ludus/Engine/Physics/Core/PhysicsConfiguration2D.h>
+#include <Ludus/Editor/Core/EditorStartupOptions.h>
 #include <Ludus/Engine/Runtime/ApplicationHostBuilder.h>
 #include <Ludus/Engine/Runtime/RuntimeOptions.h>
 #include <Ludus/Engine/Windowing/WindowOptions.h>
@@ -17,15 +15,14 @@ namespace Ludus::Editor::Core
 	{
 	private:
 		Ludus::Engine::Runtime::ApplicationHostBuilder m_ApplicationHostBuilder;
-
-		Ludus::Engine::Graphics::RenderingConfiguration2D m_RenderingConfiguration;
-		Ludus::Engine::Graphics::RenderingOptions m_RenderingOptions;
-		Ludus::Engine::Graphics::RenderViewConfiguration m_RenderViewConfiguration;
-		Ludus::Engine::Runtime::RuntimeOptions m_RuntimeOptions;
-		Ludus::Engine::Physics::Core::PhysicsConfiguration2D m_PhysicsConfiguration;
-		Ludus::Engine::Windowing::WindowOptions m_WindowOptions;
-
 		Ludus::Editor::Core::EditorConfiguration m_EditorConfiguration = Ludus::Editor::Core::EditorConfiguration::Default();
+		Ludus::Editor::Core::EditorStartupOptions m_StartupOptions;
+
+		std::optional<Ludus::Engine::Runtime::RuntimeOptions> m_RuntimeOptions;
+		std::optional<Ludus::Engine::Windowing::WindowOptions> m_WindowOptions;
+
+		bool m_UseEditor = false;
+		bool m_UseImGui = false;
 
 	public:
 		static EditorHostBuilder Create();
@@ -33,8 +30,11 @@ namespace Ludus::Editor::Core
 		std::unique_ptr<Ludus::Engine::Runtime::ApplicationHost> Build();
 
 		EditorHostBuilder& WithEditorConfiguration(Ludus::Editor::Core::EditorConfiguration editorConfiguration);
+		EditorHostBuilder& WithRuntimeOptions(Ludus::Engine::Runtime::RuntimeOptions runtimeOptions);
+		EditorHostBuilder& WithStartupOptions(EditorStartupOptions startupOptions);
+		EditorHostBuilder& WithWindowOptions(Ludus::Engine::Windowing::WindowOptions windowOptions);
 
-		EditorHostBuilder& AddDefaultEngine();
-		EditorHostBuilder& AddEditorSystem();
+		EditorHostBuilder& UseEditor();
+		EditorHostBuilder& UseEditorHostDefaults();
 	};
 }

--- a/Editor/Include/Ludus/Editor/Core/EditorStartupOptions.h
+++ b/Editor/Include/Ludus/Editor/Core/EditorStartupOptions.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <filesystem>
+#include <optional>
+
+#include <Ludus/Engine/Debug/Debug.h>
+
+namespace Ludus::Editor::Core
+{
+	struct EditorStartupOptions
+	{
+		std::optional<std::filesystem::path> StartupProjectPath;
+
+		static EditorStartupOptions FromCommandLineArgs(int argc, char* argv[])
+		{
+			EditorStartupOptions options { };
+
+			for (int i = 1; i < argc; ++i)
+			{
+				std::string_view arg = argv[i];
+
+				if (arg == "--project")
+				{
+					if (i + 1 >= argc)
+					{
+						LUDUS_LOG_WARN("Missing value for --project.");
+						continue;
+					}
+
+					std::filesystem::path startupProjectPath = argv[++i];
+
+					if (std::filesystem::exists(startupProjectPath))
+					{
+						options.StartupProjectPath = std::move(startupProjectPath);
+					}
+					else
+					{
+						LUDUS_LOG_WARN("Startup project path does not exist: " + startupProjectPath.string());
+					}
+				}
+			}
+
+			return options;
+		}
+	};
+}

--- a/Editor/Include/Ludus/Editor/Core/EditorSystem.h
+++ b/Editor/Include/Ludus/Editor/Core/EditorSystem.h
@@ -7,6 +7,7 @@
 #include <Ludus/Editor/Core/EditorConfiguration.h>
 #include <Ludus/Editor/Core/EditorSession.h>
 #include <Ludus/Editor/Core/EditorShell.h>
+#include <Ludus/Editor/Core/EditorStartupOptions.h>
 #include <Ludus/Editor/Core/ProjectSession.h>
 #include <Ludus/Editor/Core/WelcomeWindow.h>
 #include <Ludus/Editor/Panels/PanelRegistry.h>
@@ -35,6 +36,7 @@ namespace Ludus::Editor::Core
 		WelcomeWindow m_WelcomeWindow;
 
 		EditorConfiguration m_EditorConfiguration;
+		EditorStartupOptions m_EditorStartupOptions;
 
 		Ludus::Editor::Commands::StartupCommandContext CreateStartupCommandContext();
 		Ludus::Editor::Commands::ProjectSessionCommandContext CreateProjectSessionCommandContext();
@@ -53,7 +55,8 @@ namespace Ludus::Editor::Core
 	public:
 		EditorSystem(
 			Ludus::Engine::Runtime::IHostContext& hostContext,
-			EditorConfiguration editorConfiguration
+			EditorConfiguration editorConfiguration,
+			EditorStartupOptions editorStartupOptions
 		);
 		~EditorSystem() = default;
 

--- a/Editor/Source/Ludus/Editor/Build/MSBuild/MSBuildContext.cpp
+++ b/Editor/Source/Ludus/Editor/Build/MSBuild/MSBuildContext.cpp
@@ -85,7 +85,7 @@ namespace Ludus::Editor::Build::MSBuild
 	void MSBuildContext::Initialize()
 	{
 		// MSBuildPath can be cached when editor configuration persistence is implemented.
-		if (!MSBuildPath || !std::filesystem::exists(MSBuildPath.value()))
+		if (!MSBuildPath || !std::filesystem::exists(*MSBuildPath))
 		{
 			MSBuildPath = LocateMSBuild();
 			if (MSBuildPath)

--- a/Editor/Source/Ludus/Editor/Build/MSBuild/MSBuildRuntimeHostPipeline.cpp
+++ b/Editor/Source/Ludus/Editor/Build/MSBuild/MSBuildRuntimeHostPipeline.cpp
@@ -176,7 +176,7 @@ namespace Ludus::Editor::Build::MSBuild
 			Ludus::Editor::Persistence::BuildPaths::EnsureProjectRuntimeHostBuildLayoutExists(projectRoot);
 		}
 
-		if (!m_Context.MSBuildPath.has_value())
+		if (!m_Context.MSBuildPath)
 		{
 			throw std::runtime_error("MSBuild path not found.");
 		}
@@ -197,7 +197,7 @@ namespace Ludus::Editor::Build::MSBuild
 			"/p:Platform=" + std::string(platformStr) + " "
 			"/nologo";
 
-		const auto expected = Ludus::Engine::Platform::Process::Run(m_Context.MSBuildPath.value(), args);
+		const auto expected = Ludus::Engine::Platform::Process::Run(*m_Context.MSBuildPath, args);
 		if (!expected.HasValue())
 		{
 			LUDUS_LOG_ERROR("Process error: " + std::string(expected.GetError().what()));

--- a/Editor/Source/Ludus/Editor/Build/MSBuild/MSBuildScriptPipeline.cpp
+++ b/Editor/Source/Ludus/Editor/Build/MSBuild/MSBuildScriptPipeline.cpp
@@ -188,7 +188,7 @@ namespace Ludus::Editor::Build::MSBuild
 			Ludus::Editor::Persistence::BuildPaths::EnsureProjectScriptsBuildLayoutExists(projectRoot);
 		}
 
-		if (!m_Context.MSBuildPath.has_value())
+		if (!m_Context.MSBuildPath)
 		{
 			throw std::runtime_error("MSBuild path not found.");
 		}
@@ -209,7 +209,7 @@ namespace Ludus::Editor::Build::MSBuild
 			"/p:Platform=" + std::string(platformStr) + " "
 			"/nologo";
 
-		const auto expected = Ludus::Engine::Platform::Process::Run(m_Context.MSBuildPath.value(), args);
+		const auto expected = Ludus::Engine::Platform::Process::Run(*m_Context.MSBuildPath, args);
 		if (!expected.HasValue())
 		{
 			LUDUS_LOG_ERROR("Process error: " + std::string(expected.GetError().what()));

--- a/Editor/Source/Ludus/Editor/Commands/Requests/Scenes.cpp
+++ b/Editor/Source/Ludus/Editor/Commands/Requests/Scenes.cpp
@@ -25,12 +25,12 @@ namespace Ludus::Editor::Commands::Requests::Scenes
 		)
 		{
 			const auto scenePath = context.ProjectSession.TryGetEditorScenePath(sceneHandle);
-			if (!scenePath.has_value())
+			if (!scenePath)
 			{
 				throw std::runtime_error("No valid path was found for scene.");
 			}
 
-			return scenePath.value();
+			return *scenePath;
 		}
 
 		void SaveManifest(ProjectSessionCommandContext& context)
@@ -127,10 +127,10 @@ namespace Ludus::Editor::Commands::Requests::Scenes
 		SaveManifest(context);
 		SaveSceneToPath(context, command.SceneHandle, command.Path);
 
-		if (previousPath.has_value() && previousPath.value() != command.Path)
+		if (previousPath && *previousPath != command.Path)
 		{
 			std::error_code errorCode;
-			std::filesystem::remove(previousPath.value(), errorCode);
+			std::filesystem::remove(*previousPath, errorCode);
 		}
 
 		CommitSceneSave(context, command.Path);

--- a/Editor/Source/Ludus/Editor/Commands/UI/Dialogs.cpp
+++ b/Editor/Source/Ludus/Editor/Commands/UI/Dialogs.cpp
@@ -43,14 +43,14 @@ namespace Ludus::Editor::Commands::UI::Dialogs
 	void OpenRenameSceneDialog(const UICommand::OpenRenameSceneDialog& command, ProjectSessionCommandContext& context)
 	{
 		const auto scenePath = context.ProjectSession.TryGetEditorScenePath(command.SceneHandle);
-		if (!scenePath.has_value())
+		if (!scenePath)
 		{
 			throw std::runtime_error("Scene does not have a path.");
 		}
 
 		Ludus::Editor::Dialogs::RenameSceneDialog dialog(
 			command.SceneHandle,
-			scenePath.value()
+			*scenePath
 		);
 		context.Shell.State.Dialogs.Open(dialog);
 	}

--- a/Editor/Source/Ludus/Editor/Core/EditorHostBuilder.cpp
+++ b/Editor/Source/Ludus/Editor/Core/EditorHostBuilder.cpp
@@ -16,7 +16,30 @@ namespace Ludus::Editor::Core
 {
 	std::unique_ptr<Ludus::Engine::Runtime::ApplicationHost> EditorHostBuilder::Build()
 	{
-		return m_ApplicationHostBuilder.Build();
+		LUDUS_ASSERT(m_RuntimeOptions, "Cannot build editor host without runtime options.");
+		LUDUS_ASSERT(m_WindowOptions, "Cannot build editor host without window options.");
+
+		m_ApplicationHostBuilder
+			.WithRuntimeOptions(std::move(*m_RuntimeOptions))
+			.WithWindowOptions(std::move(*m_WindowOptions));
+
+		if (m_UseImGui)
+		{
+			Ludus::UI::Systems::RegisterImGui(m_ApplicationHostBuilder);
+		}
+
+		auto host = m_ApplicationHostBuilder.Build();
+
+		if (m_UseEditor)
+		{
+			host->AddUpdateSystem<Ludus::Editor::Core::EditorSystem>(
+				*host,
+				std::move(m_EditorConfiguration),
+				std::move(m_StartupOptions)
+			);
+		}
+
+		return host;
 	}
 
 	EditorHostBuilder EditorHostBuilder::Create()
@@ -26,31 +49,62 @@ namespace Ludus::Editor::Core
 
 	EditorHostBuilder& EditorHostBuilder::WithEditorConfiguration(Ludus::Editor::Core::EditorConfiguration editorConfiguration)
 	{
-		m_EditorConfiguration = editorConfiguration;
+		m_EditorConfiguration = std::move(editorConfiguration);
 
 		return *this;
 	}
 
-	EditorHostBuilder& EditorHostBuilder::AddDefaultEngine()
+	EditorHostBuilder& EditorHostBuilder::WithRuntimeOptions(Ludus::Engine::Runtime::RuntimeOptions runtimeOptions)
 	{
-		m_RuntimeOptions = Ludus::Engine::Runtime::RuntimeOptions(Ludus::Editor::Core::DefaultEditorExecutionMask);
-		m_WindowOptions = Ludus::Engine::Windowing::WindowOptions(1920, 1080, "Ludus Editor", true, "Resources/LudusIcon.png");
-
-		Ludus::UI::Systems::RegisterImGui(m_ApplicationHostBuilder);
-
-		m_ApplicationHostBuilder
-			.WithRuntimeOptions(m_RuntimeOptions)
-			.WithWindowOptions(m_WindowOptions);
+		m_RuntimeOptions = std::move(runtimeOptions);
 
 		return *this;
 	}
 
-	EditorHostBuilder& EditorHostBuilder::AddEditorSystem()
+	EditorHostBuilder& EditorHostBuilder::WithStartupOptions(EditorStartupOptions startupOptions)
 	{
-		m_ApplicationHostBuilder.Configure([editorConfiguration = std::move(m_EditorConfiguration)](Ludus::Engine::Runtime::ApplicationHost& host) mutable
+		m_StartupOptions = std::move(startupOptions);
+
+		return *this;
+	}
+
+	EditorHostBuilder& EditorHostBuilder::WithWindowOptions(Ludus::Engine::Windowing::WindowOptions windowOptions)
+	{
+		m_WindowOptions = std::move(windowOptions);
+
+		return *this;
+	}
+
+	EditorHostBuilder& EditorHostBuilder::UseEditor()
+	{
+		if (m_UseEditor)
 		{
-			host.AddUpdateSystem<Ludus::Editor::Core::EditorSystem>(host, std::move(editorConfiguration));
-		});
+			LUDUS_LOG_WARN("Invalid operation: Cannot add editor more than once.");
+		}
+
+		m_UseEditor = true;
+		m_UseImGui = true;
+
+		return *this;
+	}
+
+	EditorHostBuilder& EditorHostBuilder::UseEditorHostDefaults()
+	{
+		if (!m_RuntimeOptions)
+		{
+			m_RuntimeOptions = Ludus::Engine::Runtime::RuntimeOptions(Ludus::Editor::Core::DefaultEditorExecutionMask);
+		}
+
+		if (!m_WindowOptions)
+		{
+			m_WindowOptions = Ludus::Engine::Windowing::WindowOptions(
+				1920,
+				1080,
+				"Ludus Editor",
+				true,
+				"Resources/LudusIcon.png"
+			);
+		}
 
 		return *this;
 	}

--- a/Editor/Source/Ludus/Editor/Core/EditorSession.cpp
+++ b/Editor/Source/Ludus/Editor/Core/EditorSession.cpp
@@ -29,7 +29,7 @@ namespace Ludus::Editor::Core
 			std::optional<Ludus::Editor::Core::ProjectSession>& projectSession
 		)
 		{
-			if (!projectSession.has_value())
+			if (!projectSession)
 			{
 				return;
 			}
@@ -139,7 +139,7 @@ namespace Ludus::Editor::Core
 				// Reset state.
 				m_Shell.State.Mode = Ludus::Editor::Core::EditorMode::Session;
 				pendingTransition = Ludus::Editor::Core::PendingProjectTransition::NoneState();
-				m_HostContext.SetWindowTitle("Ludus Editor - " + out.value().ProjectManifest.ProjectRoot.filename().string());
+				m_HostContext.SetWindowTitle("Ludus Editor - " + out->ProjectManifest.ProjectRoot.filename().string());
 			}
 		}, pendingTransition.Data);
 	}

--- a/Editor/Source/Ludus/Editor/Core/EditorSystem.cpp
+++ b/Editor/Source/Ludus/Editor/Core/EditorSystem.cpp
@@ -10,6 +10,7 @@
 #include <Ludus/Editor/Commands/UICommand.h>
 #include <Ludus/Editor/Core/EditorSystem.h>
 #include <Ludus/Editor/Core/WelcomeWindow.h>
+#include <Ludus/Engine/Debug/Debug.h>
 #include <Ludus/Engine/Persistence/Paths.h>
 #include <Ludus/Engine/Runtime/IHostContext.h>
 #include <Ludus/Engine/Runtime/RuntimeInstanceBuilder.h>
@@ -51,9 +52,11 @@ namespace Ludus::Editor::Core
 
 	EditorSystem::EditorSystem(
 		Ludus::Engine::Runtime::IHostContext& hostContext,
-		Ludus::Editor::Core::EditorConfiguration editorOptions
+		Ludus::Editor::Core::EditorConfiguration editorConfiguration,
+		EditorStartupOptions editorStartupOptions
 	) :
-		m_EditorConfiguration(std::move(editorOptions)),
+		m_EditorConfiguration(std::move(editorConfiguration)),
+		m_EditorStartupOptions(std::move(editorStartupOptions)),
 		m_HostContext(hostContext),
 		m_ScenePersistence(),
 		m_RuntimeManifestPersistence(),
@@ -86,11 +89,11 @@ namespace Ludus::Editor::Core
 
 	Ludus::Editor::Commands::ProjectSessionCommandContext EditorSystem::CreateProjectSessionCommandContext()
 	{
-		LUDUS_ASSERT(m_ProjectSession.has_value(), "Project session context requires an active project.");
+		LUDUS_ASSERT(m_ProjectSession, "Project session context requires an active project.");
 
 		return {
 			.Shell = m_Shell,
-			.ProjectSession = m_ProjectSession.value(),
+			.ProjectSession = *m_ProjectSession,
 			.HostContext = m_HostContext,
 			.ScenePersistence = m_ScenePersistence,
 			.RuntimeManifestPersistence = m_RuntimeManifestPersistence,
@@ -101,7 +104,7 @@ namespace Ludus::Editor::Core
 
 	void EditorSystem::DelegateUICommands()
 	{
-		if (m_ProjectSession.has_value())
+		if (m_ProjectSession)
 		{
 			auto context = CreateProjectSessionCommandContext();
 
@@ -123,7 +126,7 @@ namespace Ludus::Editor::Core
 
 	void EditorSystem::DelegateEditCommands()
 	{
-		if (m_ProjectSession.has_value())
+		if (m_ProjectSession)
 		{
 			auto context = CreateProjectSessionCommandContext();
 
@@ -143,7 +146,7 @@ namespace Ludus::Editor::Core
 
 	void EditorSystem::DelegateRequestCommands()
 	{
-		if (m_ProjectSession.has_value())
+		if (m_ProjectSession)
 		{
 			auto context = CreateProjectSessionCommandContext();
 
@@ -174,17 +177,17 @@ namespace Ludus::Editor::Core
 	{
 		if (auto commands = m_Shell.State.Dialogs.Update())
 		{
-			m_Shell.State.Commands.EnqueueCommands(std::move(commands.value()));
+			m_Shell.State.Commands.EnqueueCommands(std::move(*commands));
 		}
 	}
 
 	void EditorSystem::UpdatePanels()
 	{
-		LUDUS_ASSERT(m_ProjectSession.has_value(), "Panel updates require an active project session.");
+		LUDUS_ASSERT(m_ProjectSession, "Panel updates require an active project session.");
 
 		Ludus::Editor::Core::ProjectSessionContext context {
 			.Shell = m_Shell,
-			.ProjectSession = m_ProjectSession.value(),
+			.ProjectSession = *m_ProjectSession,
 			.HostContext = m_HostContext,
 			.PanelRegistry = m_PanelRegistry
 		};
@@ -211,6 +214,15 @@ namespace Ludus::Editor::Core
 		{
 			m_PanelRegistry.Register(factoryMethod());
 		}
+
+		if (m_EditorStartupOptions.StartupProjectPath)
+		{
+			LUDUS_LOG_INFO("Using startup project from command line: " + m_EditorStartupOptions.StartupProjectPath->string());
+
+			m_Shell.State.Commands.AddRequestCommand(
+				Ludus::Editor::Commands::RequestCommand::OpenProject { *m_EditorStartupOptions.StartupProjectPath }
+			);
+		}
 	}
 
 	void Ludus::Editor::Core::EditorSystem::OnDetachImpl()
@@ -222,7 +234,7 @@ namespace Ludus::Editor::Core
 	{
 		if (auto commands = m_WelcomeWindow.Update())
 		{
-			m_Shell.State.Commands.EnqueueCommands(std::move(commands.value()));
+			m_Shell.State.Commands.EnqueueCommands(std::move(*commands));
 		}
 
 		FlushCommands();
@@ -232,7 +244,7 @@ namespace Ludus::Editor::Core
 
 	void EditorSystem::UpdateProjectSession()
 	{
-		if (!m_ProjectSession.has_value())
+		if (!m_ProjectSession)
 		{
 			throw std::runtime_error("No active project session available.");
 		}

--- a/Editor/Source/Ludus/Editor/Core/ProjectSession.cpp
+++ b/Editor/Source/Ludus/Editor/Core/ProjectSession.cpp
@@ -67,7 +67,7 @@ namespace Ludus::Editor::Core
 		EditorState.ActiveSceneHandle = sceneHandle;
 		EditorState.ActiveSceneState = {
 			.IsDirty = false,
-			.SavePath = sceneSavePath.has_value() ? sceneSavePath : TryGetEditorScenePath(sceneHandle)
+			.SavePath = sceneSavePath ? sceneSavePath : TryGetEditorScenePath(sceneHandle)
 		};
 		GetEditorRuntime().GetScenePresentationState().CurrentSceneHandle = sceneHandle;
 	}

--- a/Editor/Source/Ludus/Editor/Panels/ContentPanel.cpp
+++ b/Editor/Source/Ludus/Editor/Panels/ContentPanel.cpp
@@ -19,7 +19,7 @@ namespace Ludus::Editor::Panels
 		{
 			m_ContentBrowser.Update();
 
-			if (auto openedFilePath = m_ContentBrowser.ConsumeOpenedFilePath(); openedFilePath.has_value())
+			if (auto openedFilePath = m_ContentBrowser.ConsumeOpenedFilePath(); openedFilePath)
 			{
 				if (openedFilePath->filename().generic_string().ends_with(".ludus.scene"))
 				{

--- a/Editor/Source/Ludus/Editor/Panels/InspectorPanel.cpp
+++ b/Editor/Source/Ludus/Editor/Panels/InspectorPanel.cpp
@@ -544,9 +544,8 @@ namespace Ludus::Editor::Panels
 			auto& scene = registry.GetScene(activeSceneHandle);
 
 			auto& ecs = scene.EntityComponentSystem;
-			auto entityHandle = selection.SelectedEntity.value();
-			const bool existsInActiveScene = ecs.IndexOf(entityHandle).has_value();
-			if (!existsInActiveScene)
+			auto entityHandle = *selection.SelectedEntity;
+			if (!ecs.IndexOf(entityHandle))
 			{
 				context.Shell.State.Commands.AddEditCommand(
 					Ludus::Editor::Commands::EditCommand::ClearSelection { }

--- a/Editor/Source/Ludus/Editor/Panels/ViewportPanel.cpp
+++ b/Editor/Source/Ludus/Editor/Panels/ViewportPanel.cpp
@@ -187,7 +187,7 @@ namespace Ludus::Editor::Panels
 			auto& registry = context.ProjectSession.GetSceneRegistry();
 
 			auto active = context.ProjectSession.EditorState.ActiveSceneHandle;
-			if (!m_SelectedSceneHandle.has_value() || !registry.Contains(m_SelectedSceneHandle.value()))
+			if (!m_SelectedSceneHandle || !registry.Contains(*m_SelectedSceneHandle))
 			{
 				m_SelectedSceneHandle = active;
 			}

--- a/Editor/Source/Ludus/Editor/Persistence/ProjectSessionLoader.cpp
+++ b/Editor/Source/Ludus/Editor/Persistence/ProjectSessionLoader.cpp
@@ -52,12 +52,12 @@ namespace Ludus::Editor::Persistence
 	{
 		auto runtimeManifest = m_RuntimeManifestPersistence.Load(projectManifest.RuntimeManifestPath);
 		const auto scenePath = TryFindScenePath(runtimeManifest, runtimeManifest.EntrySceneHandle);
-		if (!scenePath.has_value())
+		if (!scenePath)
 		{
 			throw std::runtime_error("No scene path in runtime manifest.");
 		}
 
-		auto scene = m_ScenePersistence.Load(scenePath.value());
+		auto scene = m_ScenePersistence.Load(*scenePath);
 
 		return {
 			.ProjectManifest = std::move(projectManifest),

--- a/EditorHost/main.cpp
+++ b/EditorHost/main.cpp
@@ -1,12 +1,12 @@
-#include <Ludus/Editor/Core/EditorConfiguration.h>
 #include <Ludus/Editor/Core/EditorHostBuilder.h>
+#include <Ludus/Editor/Core/EditorStartupOptions.h>
 
-int main()
+int main(int argc, char* argv[])
 {
 	auto host = Ludus::Editor::Core::EditorHostBuilder::Create()
-		.AddDefaultEngine()
-		.AddEditorSystem()
-		.WithEditorConfiguration(Ludus::Editor::Core::EditorConfiguration::Default())
+		.WithStartupOptions(Ludus::Editor::Core::EditorStartupOptions::FromCommandLineArgs(argc, argv))
+		.UseEditorHostDefaults()
+		.UseEditor()
 		.Build();
 
 	host->Run();

--- a/Engine/Include/Ludus/Engine/Graphics/NoCameraRenderPass.h
+++ b/Engine/Include/Ludus/Engine/Graphics/NoCameraRenderPass.h
@@ -21,7 +21,7 @@ namespace Ludus::Engine::Graphics
 
 		virtual bool Enabled(RenderContext2D& context) override
 		{
-			if (!context.RenderView.SceneHandle.has_value())
+			if (!context.RenderView.SceneHandle)
 			{
 				return false;
 			}

--- a/Engine/Include/Ludus/Engine/Graphics/RenderViewSystem.h
+++ b/Engine/Include/Ludus/Engine/Graphics/RenderViewSystem.h
@@ -100,9 +100,9 @@ namespace Ludus::Engine::Graphics
 			auto [targetWidth, targetHeight] = request.Target->Framebuffer.GetSize();
 
 			// Explicit camera -> Tool camera.
-			if (request.Camera.has_value())
+			if (request.Camera)
 			{
-				auto camera = request.Camera.value();
+				auto camera = *request.Camera;
 				camera.SetViewport(targetWidth, targetHeight);
 
 				return {
@@ -115,12 +115,12 @@ namespace Ludus::Engine::Graphics
 			}
 
 			// Resolve camera from scene -> Scene primary camera view.
-			if (request.SceneHandle.has_value())
+			if (request.SceneHandle)
 			{
-				auto* scene = sceneRegistry.TryGetScene(request.SceneHandle.value());
+				auto* scene = sceneRegistry.TryGetScene(*request.SceneHandle);
 				if (scene)
 				{
-					if (auto primaryCamera = scene->TryGetPrimaryCamera2D(); primaryCamera.has_value())
+					if (auto primaryCamera = scene->TryGetPrimaryCamera2D(); primaryCamera)
 					{
 						Camera2D camera;
 						camera.SetViewport(targetWidth, targetHeight);

--- a/Engine/Include/Ludus/Engine/Graphics/SceneRenderPass.h
+++ b/Engine/Include/Ludus/Engine/Graphics/SceneRenderPass.h
@@ -20,18 +20,18 @@ namespace Ludus::Engine::Graphics
 
 		virtual bool Enabled(Ludus::Engine::Graphics::RenderContext2D& context) override
 		{
-			return context.RenderView.SceneHandle.has_value()
+			return context.RenderView.SceneHandle
 				&& context.RenderView.CameraSource != CameraSource::None;
 		};
 
 		virtual void Execute(Ludus::Engine::Graphics::RenderContext2D& context, Ludus::Engine::Graphics::Renderer2D& renderer) override
 		{
-			if (!context.RenderView.SceneHandle.has_value())
+			if (!context.RenderView.SceneHandle)
 			{
 				return;
 			}
 
-			const auto* scene = context.SceneRegistry.TryGetScene(context.RenderView.SceneHandle.value());
+			const auto* scene = context.SceneRegistry.TryGetScene(*context.RenderView.SceneHandle);
 			if (!scene)
 			{
 				return;

--- a/Engine/Include/Ludus/Engine/Runtime/RuntimeInstanceBuilder.h
+++ b/Engine/Include/Ludus/Engine/Runtime/RuntimeInstanceBuilder.h
@@ -40,10 +40,10 @@ namespace Ludus::Engine::Runtime
 
 		std::vector<RuntimeInstanceBuilderCommand> m_BuilderCommands;
 
-		bool m_HasDefaultPhysics2D = false;
-		bool m_HasDefaultMainRenderView = false;
-		bool m_HasDefaultRendering2D = false;
-		bool m_HasDefaultScripting = false;
+		bool m_UseDefaultPhysics2D = false;
+		bool m_UseDefaultMainRenderView = false;
+		bool m_UseDefaultRendering2D = false;
+		bool m_UseDefaultScripting = false;
 
 	public:
 		RuntimeInstanceBuilder() = default;

--- a/Engine/Source/Ludus/Engine/Platform/Windows/Modals.Windows.cpp
+++ b/Engine/Source/Ludus/Engine/Platform/Windows/Modals.Windows.cpp
@@ -106,9 +106,9 @@ namespace Ludus::Engine::Platform::Modals
 				// In this case, get shell items only for file system items.
 				hr = openDialog->SetOptions(flags | FOS_FORCEFILESYSTEM);
 
-				if (defaultStartupPath.has_value())
+				if (defaultStartupPath)
 				{
-					SetDialogStartupFolder(openDialog, defaultStartupPath.value());
+					SetDialogStartupFolder(openDialog, *defaultStartupPath);
 				}
 
 				if (SUCCEEDED(hr))
@@ -193,9 +193,9 @@ namespace Ludus::Engine::Platform::Modals
 				// - FOS_STRICTFILETYPES: Keep extension aligned with the selected filter.
 				hr = saveDialog->SetOptions(flags | FOS_FORCEFILESYSTEM | FOS_OVERWRITEPROMPT | FOS_STRICTFILETYPES);
 
-				if (defaultStartupPath.has_value())
+				if (defaultStartupPath)
 				{
-					SetDialogStartupFolder(saveDialog, defaultStartupPath.value());
+					SetDialogStartupFolder(saveDialog, *defaultStartupPath);
 				}
 
 				if (SUCCEEDED(hr))
@@ -215,7 +215,7 @@ namespace Ludus::Engine::Platform::Modals
 
 							if (SUCCEEDED(hr))
 							{
-								if (defaultFileName.has_value() && !defaultFileName->empty())
+								if (defaultFileName && !defaultFileName->empty())
 								{
 									std::wstring fileNameWide = Ludus::Engine::Platform::Windows::Detail::Utf8ToWide(*defaultFileName);
 									saveDialog->SetFileName(fileNameWide.c_str());

--- a/Engine/Source/Ludus/Engine/Runtime/RuntimeInstanceBuilder.cpp
+++ b/Engine/Source/Ludus/Engine/Runtime/RuntimeInstanceBuilder.cpp
@@ -32,14 +32,95 @@ namespace Ludus::Engine::Runtime
 
 		auto runtime = RuntimeInstance::Create(
 			hostContext,
-			std::move(m_RuntimeManifest.value()),
-			std::move(m_RuntimeEnvironment.value()),
-			std::move(m_InitialScene.value()),
+			std::move(*m_RuntimeManifest),
+			std::move(*m_RuntimeEnvironment),
+			std::move(*m_InitialScene),
 			m_InitialSceneMode,
 			std::move(m_RenderingConfiguration),
 			std::move(m_RenderPresentationSettings),
 			std::move(m_PhysicsConfiguration)
 		);
+
+		if (m_UseDefaultMainRenderView)
+		{
+			runtime->AddSystem(
+				Ludus::Engine::Runtime::SystemDescriptor { SystemPhase::Update },
+				std::make_unique<Ludus::Engine::Graphics::MainRenderViewSystem>(
+					runtime->GetHostContext(),
+					runtime->GetRenderViewRequestRegistry(),
+					runtime->GetScenePresentationState()
+				)
+			);
+		}
+
+		if (m_UseDefaultPhysics2D)
+		{
+			auto& physicsConfiguration = runtime->GetPhysicsConfiguration();
+			auto physicsSystem = std::make_unique<Ludus::Engine::Physics::Core::PhysicsSystem2D>(physicsConfiguration, runtime->GetSceneRegistry());
+			auto constraints = Ludus::Engine::Runtime::SystemConstraints::Create()
+				.RequireAllOf(Ludus::Engine::Core::Mask(Ludus::Engine::Core::ExecutionFlags::PhysicsEnabled) | Ludus::Engine::Core::Mask(Ludus::Engine::Core::ExecutionFlags::SimulationEnabled));
+
+			runtime->AddSystem(
+				Ludus::Engine::Runtime::SystemDescriptor { SystemPhase::FixedUpdate, SystemPhaseOrder::Before, constraints },
+				std::move(physicsSystem)
+			);
+		}
+
+		if (m_UseDefaultRendering2D)
+		{
+			auto renderViewSystem = std::make_unique<Ludus::Engine::Graphics::RenderViewSystem>(
+				runtime->GetHostContext(),
+				m_RenderViewConfiguration,
+				runtime->GetRenderViewRegistry(),
+				runtime->GetRenderViewRequestRegistry(),
+				runtime->GetSceneRegistry()
+			);
+			auto constraints = Ludus::Engine::Runtime::SystemConstraints::Create()
+				.RequireAnyOf(Ludus::Engine::Core::Mask(Ludus::Engine::Core::ExecutionFlags::RenderingEnabled));
+
+			runtime->AddSystem(
+				{
+					Ludus::Engine::Runtime::SystemDescriptor { SystemPhase::BeginFrame, SystemPhaseOrder::Before },
+					Ludus::Engine::Runtime::SystemDescriptor { SystemPhase::Render, SystemPhaseOrder::Before, constraints }
+				},
+				std::move(renderViewSystem)
+			);
+
+			auto renderingSystem = std::make_unique<Ludus::Engine::Graphics::RenderingSystem2D>(
+				m_RenderingOptions,
+				runtime->GetRenderingConfiguration(),
+				runtime->GetRenderViewRegistry(),
+				runtime->GetSceneRegistry(),
+				runtime->GetRuntimeEnvironment()
+			);
+
+			runtime->AddSystem(
+				Ludus::Engine::Runtime::SystemDescriptor { SystemPhase::Render, SystemPhaseOrder::Before },
+				std::move(renderingSystem)
+			);
+		}
+
+		if (m_UseDefaultScripting)
+		{
+			auto constraints = Ludus::Engine::Runtime::SystemConstraints::Create()
+				.RequireAllOf(
+					Ludus::Engine::Core::Mask(Ludus::Engine::Core::ExecutionFlags::ScriptingEnabled) |
+					Ludus::Engine::Core::Mask(Ludus::Engine::Core::ExecutionFlags::SimulationSessionEnabled)
+				);
+
+			auto scriptingSystem = std::make_unique<Ludus::Engine::Scripting::ScriptSystem>(
+				runtime->GetHostContext(),
+				runtime->GetSceneRegistry(),
+				runtime->GetScenePresentationState().CurrentSceneHandle,
+				runtime->GetPhysicsConfiguration().QueryCache.get(),
+				runtime->GetRuntimeEnvironment().ScriptModulePath
+			);
+
+			runtime->AddSystem(
+				Ludus::Engine::Runtime::SystemDescriptor { SystemPhase::Update, SystemPhaseOrder::Before, constraints },
+				std::move(scriptingSystem)
+			);
+		}
 
 		for (auto& command : m_BuilderCommands)
 		{
@@ -117,138 +198,48 @@ namespace Ludus::Engine::Runtime
 
 	RuntimeInstanceBuilder& RuntimeInstanceBuilder::UseDefaultPhysics2D()
 	{
-		if (!m_HasDefaultPhysics2D)
-		{
-			m_BuilderCommands.emplace_back([](Ludus::Engine::Runtime::RuntimeInstance& runtime)
-			{
-				// A physics context will already have been created when this build command is invoked.
-				auto& physicsConfiguration = runtime.GetPhysicsConfiguration();
-				auto physicsSystem = std::make_unique<Ludus::Engine::Physics::Core::PhysicsSystem2D>(physicsConfiguration, runtime.GetSceneRegistry());
-				auto constraints = Ludus::Engine::Runtime::SystemConstraints::Create()
-					.RequireAllOf(Ludus::Engine::Core::Mask(Ludus::Engine::Core::ExecutionFlags::PhysicsEnabled) | Ludus::Engine::Core::Mask(Ludus::Engine::Core::ExecutionFlags::SimulationEnabled));
-
-				runtime.AddSystem(
-					Ludus::Engine::Runtime::SystemDescriptor { SystemPhase::FixedUpdate, SystemPhaseOrder::Before, constraints },
-					std::move(physicsSystem)
-				);
-			});
-
-			m_HasDefaultPhysics2D = true;
-		}
-		else
+		if (m_UseDefaultPhysics2D)
 		{
 			LUDUS_LOG_WARN("Invalid operation: Cannot add default physics system more than once.");
 		}
+
+		m_UseDefaultPhysics2D = true;
 
 		return *this;
 	}
 
 	RuntimeInstanceBuilder& RuntimeInstanceBuilder::UseDefaultMainRenderView()
 	{
-		if (!m_HasDefaultMainRenderView)
-		{
-			m_BuilderCommands.emplace_back([](Ludus::Engine::Runtime::RuntimeInstance& runtime)
-			{
-				runtime.AddSystem(
-					Ludus::Engine::Runtime::SystemDescriptor { SystemPhase::Update },
-					std::make_unique<Ludus::Engine::Graphics::MainRenderViewSystem>(
-						runtime.GetHostContext(),
-						runtime.GetRenderViewRequestRegistry(),
-						runtime.GetScenePresentationState()
-					)
-				);
-			});
-
-			m_HasDefaultMainRenderView = true;
-		}
-		else
+		if (m_UseDefaultMainRenderView)
 		{
 			LUDUS_LOG_WARN("Invalid operation: Cannot add default main render view system more than once.");
 		}
+
+		m_UseDefaultMainRenderView = true;
 
 		return *this;
 	}
 
 	RuntimeInstanceBuilder& RuntimeInstanceBuilder::UseDefaultRendering2D()
 	{
-		if (!m_HasDefaultRendering2D)
-		{
-			m_BuilderCommands.emplace_back([renderingOptions = m_RenderingOptions, renderViewConfiguration = m_RenderViewConfiguration](Ludus::Engine::Runtime::RuntimeInstance& runtime)
-			{
-				auto renderViewSystem = std::make_unique<Ludus::Engine::Graphics::RenderViewSystem>(
-					runtime.GetHostContext(),
-					renderViewConfiguration,
-					runtime.GetRenderViewRegistry(),
-					runtime.GetRenderViewRequestRegistry(),
-					runtime.GetSceneRegistry()
-				);
-				auto constraints = Ludus::Engine::Runtime::SystemConstraints::Create()
-					.RequireAnyOf(Ludus::Engine::Core::Mask(Ludus::Engine::Core::ExecutionFlags::RenderingEnabled));
-
-				runtime.AddSystem(
-					{
-						Ludus::Engine::Runtime::SystemDescriptor { SystemPhase::BeginFrame, SystemPhaseOrder::Before },
-						Ludus::Engine::Runtime::SystemDescriptor { SystemPhase::Render, SystemPhaseOrder::Before, constraints }
-					},
-					std::move(renderViewSystem)
-				);
-
-				auto renderingSystem = std::make_unique<Ludus::Engine::Graphics::RenderingSystem2D>(
-					renderingOptions,
-					runtime.GetRenderingConfiguration(),
-					runtime.GetRenderViewRegistry(),
-					runtime.GetSceneRegistry(),
-					runtime.GetRuntimeEnvironment()
-				);
-
-				runtime.AddSystem(
-					Ludus::Engine::Runtime::SystemDescriptor { SystemPhase::Render, SystemPhaseOrder::Before },
-					std::move(renderingSystem)
-				);
-			});
-
-			m_HasDefaultRendering2D = true;
-		}
-		else
+		if (m_UseDefaultRendering2D)
 		{
 			LUDUS_LOG_WARN("Invalid operation: Cannot add default rendering system more than once.");
 		}
+
+		m_UseDefaultRendering2D = true;
 
 		return *this;
 	}
 
 	RuntimeInstanceBuilder& RuntimeInstanceBuilder::UseDefaultScripting()
 	{
-		if (!m_HasDefaultScripting)
-		{
-			m_BuilderCommands.emplace_back([](Ludus::Engine::Runtime::RuntimeInstance& runtime)
-			{
-				auto constraints = Ludus::Engine::Runtime::SystemConstraints::Create()
-					.RequireAllOf(
-						Ludus::Engine::Core::Mask(Ludus::Engine::Core::ExecutionFlags::ScriptingEnabled) |
-						Ludus::Engine::Core::Mask(Ludus::Engine::Core::ExecutionFlags::SimulationSessionEnabled)
-					);
-
-				auto scriptingSystem = std::make_unique<Ludus::Engine::Scripting::ScriptSystem>(
-					runtime.GetHostContext(),
-					runtime.GetSceneRegistry(),
-					runtime.GetScenePresentationState().CurrentSceneHandle,
-					runtime.GetPhysicsConfiguration().QueryCache.get(),
-					runtime.GetRuntimeEnvironment().ScriptModulePath
-				);
-
-				runtime.AddSystem(
-					Ludus::Engine::Runtime::SystemDescriptor { SystemPhase::Update, SystemPhaseOrder::Before, constraints },
-					std::move(scriptingSystem)
-				);
-			});
-
-			m_HasDefaultScripting = true;
-		}
-		else
+		if (m_UseDefaultScripting)
 		{
 			LUDUS_LOG_WARN("Invalid operation: Cannot add default scripting system more than once.");
 		}
+
+		m_UseDefaultScripting = true;
 
 		return *this;
 	}

--- a/Engine/Source/Ludus/Engine/Serialization/Core/DomTokenStreamReader.cpp
+++ b/Engine/Source/Ludus/Engine/Serialization/Core/DomTokenStreamReader.cpp
@@ -55,7 +55,7 @@ namespace Ludus::Engine::Serialization::Core
 	{
 		return std::visit(Overloaded
 			{
-				[](std::monostate) { return Token(Token::Null {}); },
+				[](std::monostate) { return Token(Token::Null { }); },
 				[](bool data) { return Token(Token::Bool { data }); },
 				[](double data) { return Token(Token::Double { data }); },
 				[](int64_t data) { return Token(Token::Int { data }); },
@@ -68,12 +68,12 @@ namespace Ludus::Engine::Serialization::Core
 	{
 		if (IsObject(node))
 		{
-			return Token(Token::StartObject {});
+			return Token(Token::StartObject { });
 		}
 
 		if (IsArray(node))
 		{
-			return Token(Token::StartArray {});
+			return Token(Token::StartArray { });
 		}
 
 		return MakeValueToken(AsValue(node));
@@ -124,7 +124,7 @@ namespace Ludus::Engine::Serialization::Core
 		LUDUS_ASSERT(!m_IsComplete, "Peek cannot be called on a completed DOM document.");
 		LUDUS_ASSERT(!m_NodeStack.empty(), "The DOM document does not have a valid token.");
 
-		if (m_CurrentToken.has_value())
+		if (m_CurrentToken)
 		{
 			return *m_CurrentToken;
 		}
@@ -134,12 +134,12 @@ namespace Ludus::Engine::Serialization::Core
 		{
 			case EmitState::ArrayEnd:
 			{
-				m_CurrentToken = Token::EndArray {};
+				m_CurrentToken = Token::EndArray { };
 				break;
 			}
 			case EmitState::ArrayStart:
 			{
-				m_CurrentToken = Token::StartArray {};
+				m_CurrentToken = Token::StartArray { };
 				break;
 			}
 			case EmitState::Element:
@@ -155,12 +155,12 @@ namespace Ludus::Engine::Serialization::Core
 			}
 			case EmitState::ObjectEnd:
 			{
-				m_CurrentToken = Token::EndObject {};
+				m_CurrentToken = Token::EndObject { };
 				break;
 			}
 			case EmitState::ObjectStart:
 			{
-				m_CurrentToken = Token::StartObject {};
+				m_CurrentToken = Token::StartObject { };
 				break;
 			}
 			case EmitState::Value:
@@ -189,7 +189,7 @@ namespace Ludus::Engine::Serialization::Core
 			return;
 		}
 
-		if (!m_CurrentToken.has_value())
+		if (!m_CurrentToken)
 		{
 			(void)Peek();
 		}
@@ -293,7 +293,7 @@ namespace Ludus::Engine::Serialization::Core
 
 		m_CurrentToken.reset();
 
-		if (m_NodeStack.empty() && !m_CurrentToken.has_value())
+		if (m_NodeStack.empty() && !m_CurrentToken)
 		{
 			m_IsComplete = true;
 		}

--- a/Engine/Source/Ludus/Engine/Serialization/Core/DomTokenStreamWriter.cpp
+++ b/Engine/Source/Ludus/Engine/Serialization/Core/DomTokenStreamWriter.cpp
@@ -23,7 +23,7 @@ namespace Ludus::Engine::Serialization::Core
 		}
 
 		LUDUS_ASSERT(std::holds_alternative<DomObject>(parent->NodeData), "Parent must be an object or array.");
-		LUDUS_ASSERT(m_PendingKey.has_value(), "Object child requires a key.");
+		LUDUS_ASSERT(m_PendingKey, "Object child requires a key.");
 
 		std::string key = std::move(*m_PendingKey);
 		m_PendingKey.reset();
@@ -47,7 +47,7 @@ namespace Ludus::Engine::Serialization::Core
 		{
 			LUDUS_ASSERT(!m_NodeStack.empty(), "EndObject requires an active object.");
 			LUDUS_ASSERT(std::holds_alternative<DomObject>(m_NodeStack.back()->NodeData), "EndObject must close an object.");
-			LUDUS_ASSERT(!m_PendingKey.has_value(), "EndObject cannot close with a pending key.");
+			LUDUS_ASSERT(!m_PendingKey, "EndObject cannot close with a pending key.");
 			m_NodeStack.pop_back();
 		},
 
@@ -67,7 +67,7 @@ namespace Ludus::Engine::Serialization::Core
 		{
 			LUDUS_ASSERT(!m_NodeStack.empty(), "Key requires an active object.");
 			LUDUS_ASSERT(std::holds_alternative<DomObject>(m_NodeStack.back()->NodeData), "Key must be used inside an object.");
-			LUDUS_ASSERT(!m_PendingKey.has_value(), "Cannot emit a key without consuming the previous key.");
+			LUDUS_ASSERT(!m_PendingKey, "Cannot emit a key without consuming the previous key.");
 			m_PendingKey = std::string(value.Data);
 		},
 			[&](const Token::Null&) { AttachNode(m_Document.MakeValueNode(std::monostate { })); },

--- a/Engine/Source/Ludus/Engine/Serialization/Schemas/SceneSchema.cpp
+++ b/Engine/Source/Ludus/Engine/Serialization/Schemas/SceneSchema.cpp
@@ -309,44 +309,44 @@ namespace Ludus::Engine::Serialization::Schemas
 
 						scene.EntityComponentSystem.RestoreEntity(entityHandle);
 
-						if (stagedComponents.Camera.has_value())
+						if (stagedComponents.Camera)
 						{
-							scene.EntityComponentSystem.AttachCamera(stagedComponents.Camera.value());
+							scene.EntityComponentSystem.AttachCamera(*stagedComponents.Camera);
 						}
 
-						if (stagedComponents.Collider.has_value())
+						if (stagedComponents.Collider)
 						{
-							scene.EntityComponentSystem.AttachCollider(stagedComponents.Collider.value());
+							scene.EntityComponentSystem.AttachCollider(*stagedComponents.Collider);
 						}
 
-						if (stagedComponents.DisplayName.has_value())
+						if (stagedComponents.DisplayName)
 						{
-							scene.EntityComponentSystem.AttachDisplayName(stagedComponents.DisplayName.value());
+							scene.EntityComponentSystem.AttachDisplayName(*stagedComponents.DisplayName);
 						}
 
-						if (stagedComponents.RigidBody.has_value())
+						if (stagedComponents.RigidBody)
 						{
-							scene.EntityComponentSystem.AttachRigidBody(stagedComponents.RigidBody.value());
+							scene.EntityComponentSystem.AttachRigidBody(*stagedComponents.RigidBody);
 						}
 
-						if (stagedComponents.Script.has_value())
+						if (stagedComponents.Script)
 						{
-							scene.EntityComponentSystem.AttachScript(stagedComponents.Script.value());
+							scene.EntityComponentSystem.AttachScript(*stagedComponents.Script);
 						}
 
-						if (stagedComponents.Sprite.has_value())
+						if (stagedComponents.Sprite)
 						{
-							scene.EntityComponentSystem.AttachSprite(stagedComponents.Sprite.value());
+							scene.EntityComponentSystem.AttachSprite(*stagedComponents.Sprite);
 						}
 
-						if (stagedComponents.Text.has_value())
+						if (stagedComponents.Text)
 						{
-							scene.EntityComponentSystem.AttachText(stagedComponents.Text.value());
+							scene.EntityComponentSystem.AttachText(*stagedComponents.Text);
 						}
 
-						if (stagedComponents.Transform.has_value())
+						if (stagedComponents.Transform)
 						{
-							scene.EntityComponentSystem.AttachTransform(stagedComponents.Transform.value());
+							scene.EntityComponentSystem.AttachTransform(*stagedComponents.Transform);
 						}
 					}
 

--- a/UI/Include/Ludus/UI/Systems/ImGuiModule.h
+++ b/UI/Include/Ludus/UI/Systems/ImGuiModule.h
@@ -3,7 +3,6 @@
 #include <memory>
 #include <utility>
 
-#include <Ludus/Engine/Debug/Debug.h>
 #include <Ludus/Engine/Runtime/ApplicationHost.h>
 #include <Ludus/Engine/Runtime/ApplicationHostBuilder.h>
 #include <Ludus/Engine/Runtime/SystemPhase.h>
@@ -12,31 +11,16 @@
 
 namespace Ludus::UI::Systems
 {
-	static bool s_IsImGuiEnabled = false;
-
 	inline void RegisterImGui(Ludus::Engine::Runtime::ApplicationHostBuilder& builder)
 	{
-		if (!s_IsImGuiEnabled)
+		builder.Configure([](Ludus::Engine::Runtime::ApplicationHost& host)
 		{
-			builder.Configure(
-				[](Ludus::Engine::Runtime::ApplicationHost& host)
-			{
-				auto imGuiSystem = std::make_unique<Ludus::UI::Systems::ImGuiSystem>(host.GetWindowHandle());
+			auto imGuiSystem = std::make_unique<Ludus::UI::Systems::ImGuiSystem>(host.GetWindowHandle());
 
-				host.AddSystem(
-					{
-						{ Ludus::Engine::Runtime::SystemPhase::BeginFrame, Ludus::Engine::Runtime::SystemPhaseOrder::Before },
-					{ Ludus::Engine::Runtime::SystemPhase::EndFrame, Ludus::Engine::Runtime::SystemPhaseOrder::After }
-					},
-					std::move(imGuiSystem));
-			}
-			);
-
-			s_IsImGuiEnabled = true;
-		}
-		else
-		{
-			LUDUS_LOG_WARN("Invalid operation: Cannot add ImGui system more than once.");
-		}
+			host.AddSystem({
+				{ Ludus::Engine::Runtime::SystemPhase::BeginFrame, Ludus::Engine::Runtime::SystemPhaseOrder::Before },
+				{ Ludus::Engine::Runtime::SystemPhase::EndFrame, Ludus::Engine::Runtime::SystemPhaseOrder::After } },
+				std::move(imGuiSystem));
+		});
 	}
 }

--- a/UI/Source/Ludus/UI/Elements/ContentBrowser.cpp
+++ b/UI/Source/Ludus/UI/Elements/ContentBrowser.cpp
@@ -1,8 +1,8 @@
 #include "pch.h"
 
 #include <algorithm>
-#include <functional>
 #include <filesystem>
+#include <functional>
 #include <ranges>
 
 #include <Ludus/UI/Context/ImageContext.h>
@@ -53,9 +53,9 @@ namespace Ludus::UI::Elements
 
 		m_RootEntries.push_back(BuildTree(directory));
 
-		if (previousCurrentDirectoryPath.has_value())
+		if (previousCurrentDirectoryPath)
 		{
-			if (const auto restoredCurrentDirectoryPath = TryFindIndicesFromPath(*previousCurrentDirectoryPath); restoredCurrentDirectoryPath.has_value())
+			if (const auto restoredCurrentDirectoryPath = TryFindIndicesFromPath(*previousCurrentDirectoryPath); restoredCurrentDirectoryPath)
 			{
 				m_CurrentDirectoryPath = *restoredCurrentDirectoryPath;
 			}
@@ -69,9 +69,9 @@ namespace Ludus::UI::Elements
 			m_CurrentDirectoryPath.clear();
 		}
 
-		if (previousSelectedPath.has_value())
+		if (previousSelectedPath)
 		{
-			if (const auto restoredSelectedPath = TryFindIndicesFromPath(*previousSelectedPath); restoredSelectedPath.has_value())
+			if (const auto restoredSelectedPath = TryFindIndicesFromPath(*previousSelectedPath); restoredSelectedPath)
 			{
 				m_SelectedPath = *restoredSelectedPath;
 			}


### PR DESCRIPTION
# Summary
Added startup options and simple command line args parsing. If a `--project flag "<path>"` is supplied, and that path leads to an editor project, it will be opened on startup.

This PR also includes refactors to builders; The builders now enforce that options and configurations are created before any systems are added, as well as letting build commands provide _intent_ instead of actual construction. 

The PR also includes refactors of optional methods, using pointer-syntax in favor of `has_value()` and` value()`.

# Linked
- Closes #319 
- Story: #318 

