### PR TITLE
Feature: Unified runtime IDs and simplified persistence

### DIFF
--- a/Editor/Include/Ludus/Editor/Commands/CommandManager.h
+++ b/Editor/Include/Ludus/Editor/Commands/CommandManager.h
@@ -5,7 +5,7 @@
 
 #include <Ludus/Editor/Commands/CommandSet.h>
 #include <Ludus/Editor/Commands/EntityReference.h>
-#include <Ludus/Engine/Core/Entity.h>
+#include <Ludus/Engine/Core/Id.h>
 
 namespace Ludus::Editor::Commands
 {
@@ -14,7 +14,7 @@ namespace Ludus::Editor::Commands
 	private:
 		struct TempEntityBinding
 		{
-			Ludus::Engine::Core::EntityHandle Handle { };
+			Ludus::Engine::Core::EntityId Id { Ludus::Engine::Core::EntityId::Invalid() };
 			std::uint64_t LastSeenFrame = 0;
 		};
 
@@ -30,8 +30,8 @@ namespace Ludus::Editor::Commands
 		void AddRequestCommand(Ludus::Editor::Commands::RequestCommand command);
 		void AddUICommand(Ludus::Editor::Commands::UICommand command);
 
-		Ludus::Engine::Core::EntityHandle ResolveEntity(const EntityReference& reference) const;
-		void BindEntityReference(TempReference temp, Ludus::Engine::Core::EntityHandle handle);
+		Ludus::Engine::Core::EntityId ResolveEntity(const EntityReference& reference) const;
+		void BindEntityReference(TempReference temp, Ludus::Engine::Core::EntityId id);
 		void ClearEntityReferences();
 	};
 }

--- a/Editor/Include/Ludus/Editor/Commands/Edit/Components.h
+++ b/Editor/Include/Ludus/Editor/Commands/Edit/Components.h
@@ -77,7 +77,7 @@ namespace Ludus::Editor::Commands::Edit::Components
 	template<typename TComponent>
 	void AddComponent(const EditCommand::AddComponent<TComponent>& command, ProjectSessionCommandContext& context)
 	{
-		auto* scene = context.ProjectSession.GetSceneRegistry().TryGetScene(command.SceneHandle);
+		auto* scene = context.ProjectSession.GetSceneRegistry().TryGetScene(command.SceneId);
 		if (!scene)
 		{
 			return;
@@ -97,7 +97,7 @@ namespace Ludus::Editor::Commands::Edit::Components
 			else
 			{
 				auto component = value;
-				component.OwnerHandle = owner;
+				component.OwnerId = owner;
 				registry.Add(std::move(component));
 			}
 		}, command.Init);
@@ -108,7 +108,7 @@ namespace Ludus::Editor::Commands::Edit::Components
 	template<typename TComponent>
 	void RemoveComponent(const EditCommand::RemoveComponent<TComponent>& command, ProjectSessionCommandContext& context)
 	{
-		auto* scene = context.ProjectSession.GetSceneRegistry().TryGetScene(command.SceneHandle);
+		auto* scene = context.ProjectSession.GetSceneRegistry().TryGetScene(command.SceneId);
 		if (!scene)
 		{
 			return;
@@ -125,7 +125,7 @@ namespace Ludus::Editor::Commands::Edit::Components
 	template<typename TComponent>
 	void UpdateComponent(const EditCommand::UpdateComponent<TComponent>& command, ProjectSessionCommandContext& context)
 	{
-		auto* scene = context.ProjectSession.GetSceneRegistry().TryGetScene(command.SceneHandle);
+		auto* scene = context.ProjectSession.GetSceneRegistry().TryGetScene(command.SceneId);
 		if (!scene)
 		{
 			return;
@@ -135,7 +135,7 @@ namespace Ludus::Editor::Commands::Edit::Components
 		const auto owner = context.Shell.State.Commands.ResolveEntity(command.EntityReference);
 
 		auto after = command.After;
-		after.OwnerHandle = owner;
+		after.OwnerId = owner;
 
 		registry.RemoveByOwner(owner);
 		registry.Add(after);

--- a/Editor/Include/Ludus/Editor/Commands/EditCommand.h
+++ b/Editor/Include/Ludus/Editor/Commands/EditCommand.h
@@ -15,8 +15,7 @@
 #include <Ludus/Engine/Components/Sprite2DComponent.h>
 #include <Ludus/Engine/Components/Text2DComponent.h>
 #include <Ludus/Engine/Components/Transform2DComponent.h>
-#include <Ludus/Engine/Core/Entity.h>
-#include <Ludus/Engine/Core/Scene.h>
+#include <Ludus/Engine/Core/Id.h>
 
 namespace Ludus::Editor::Commands
 {
@@ -27,8 +26,7 @@ namespace Ludus::Editor::Commands
 
 #pragma region Component Commands
 
-		using EntityHandle = Ludus::Engine::Core::EntityHandle;
-		using SceneHandle = Ludus::Engine::Core::SceneHandle;
+		using SceneId = Ludus::Engine::Core::SceneId;
 		using Camera2DComponent = Ludus::Engine::Components::Camera2DComponent;
 		using Collider2DComponent = Ludus::Engine::Components::Collider2DComponent;
 		using DisplayNameComponent = Ludus::Engine::Components::DisplayNameComponent;
@@ -41,20 +39,20 @@ namespace Ludus::Editor::Commands
 		struct UseDefault { };
 
 		template<typename TComponent>
-		struct AddComponent { EntityReference EntityReference { }; SceneHandle SceneHandle; std::variant<UseDefault, TComponent> Init { UseDefault { } }; };
+		struct AddComponent { SceneId SceneId; EntityReference EntityReference { }; std::variant<UseDefault, TComponent> Init { UseDefault { } }; };
 
 		template<typename TComponent>
-		struct RemoveComponent { EntityReference EntityReference; SceneHandle SceneHandle; };
+		struct RemoveComponent { SceneId SceneId; EntityReference EntityReference; };
 
 		template<typename TComponent>
-		struct UpdateComponent { EntityReference EntityReference; SceneHandle SceneHandle; TComponent Before; TComponent After; };
+		struct UpdateComponent { SceneId SceneId; EntityReference EntityReference; TComponent Before; TComponent After; };
 
 #pragma endregion
 
 #pragma region Entity Commands
 
-		struct AddEntity { EntityReference EntityReference; SceneHandle SceneHandle; };
-		struct RemoveEntity { EntityReference EntityReference; SceneHandle SceneHandle; };
+		struct AddEntity { SceneId SceneId; EntityReference EntityReference; };
+		struct RemoveEntity { SceneId SceneId; EntityReference EntityReference; };
 
 #pragma endregion
 

--- a/Editor/Include/Ludus/Editor/Commands/EntityReference.h
+++ b/Editor/Include/Ludus/Editor/Commands/EntityReference.h
@@ -4,7 +4,7 @@
 #include <functional>
 #include <variant>
 
-#include <Ludus/Engine/Core/Entity.h>
+#include <Ludus/Engine/Core/Id.h>
 
 namespace Ludus::Editor::Commands
 {
@@ -18,11 +18,11 @@ namespace Ludus::Editor::Commands
 	struct EntityReference
 	{
 		struct New { TempReference Temp; };
-		std::variant<Ludus::Engine::Core::EntityHandle, New> Value;
+		std::variant<Ludus::Engine::Core::EntityId, New> Value;
 
 		EntityReference() = default;
-		EntityReference(Ludus::Engine::Core::EntityHandle handle)
-			: Value(handle)
+		EntityReference(Ludus::Engine::Core::EntityId id)
+			: Value(id)
 		{ }
 
 		static EntityReference Temporary(TempReference temp)

--- a/Editor/Include/Ludus/Editor/Commands/RequestCommand.h
+++ b/Editor/Include/Ludus/Editor/Commands/RequestCommand.h
@@ -13,7 +13,7 @@
 #include <Ludus/Editor/Core/EditorExecutionFlags.h>
 #include <Ludus/Editor/Core/ExecutionMode.h>
 #include <Ludus/Editor/Panels/PanelKind.h>
-#include <Ludus/Engine/Core/Scene.h>
+#include <Ludus/Engine/Core/Id.h>
 #include <Ludus/UI/Theme/ThemeId.h>
 
 namespace Ludus::Editor::Commands
@@ -33,16 +33,16 @@ namespace Ludus::Editor::Commands
 		struct CreateScene { };
 		struct CreateSceneAs { std::filesystem::path Path; };
 		struct OpenScene { std::filesystem::path Path; bool Additive = false; };
-		struct SaveScene { Ludus::Engine::Core::SceneHandle SceneHandle; };
-		struct SaveSceneAs { Ludus::Engine::Core::SceneHandle SceneHandle; std::filesystem::path Path; };
-		struct RenameScene { Ludus::Engine::Core::SceneHandle SceneHandle; std::filesystem::path Path; };
+		struct SaveScene { Ludus::Engine::Core::SceneId SceneId; };
+		struct SaveSceneAs { Ludus::Engine::Core::SceneId SceneId; std::filesystem::path Path; };
+		struct RenameScene { Ludus::Engine::Core::SceneId SceneId; std::filesystem::path Path; };
 
 		struct CreateProject { std::string Name; };
 		struct CreateProjectAs { std::string Name; std::filesystem::path ProjectRoot; };
 		struct OpenProject { std::filesystem::path Path; };
 		struct CloseProject { };
 
-		struct CreateScript { EntityReference EntityReference; Ludus::Engine::Core::SceneHandle SceneHandle; std::string Name; };
+		struct CreateScript { Ludus::Engine::Core::SceneId SceneId; EntityReference EntityReference; std::string Name; };
 
 		struct RunTargetBuildCommand
 		{

--- a/Editor/Include/Ludus/Editor/Commands/UICommand.h
+++ b/Editor/Include/Ludus/Editor/Commands/UICommand.h
@@ -3,8 +3,7 @@
 #include <utility>
 #include <variant>
 
-#include <Ludus/Engine/Core/Entity.h>
-#include <Ludus/Engine/Core/Scene.h>
+#include <Ludus/Engine/Core/Id.h>
 
 namespace Ludus::Editor::Commands
 {
@@ -13,9 +12,9 @@ namespace Ludus::Editor::Commands
 
 	struct UICommand
 	{
-		struct OpenAddScriptDialog { Ludus::Engine::Core::EntityHandle EntityHandle; Ludus::Engine::Core::SceneHandle SceneHandle; };
+		struct OpenAddScriptDialog { Ludus::Engine::Core::SceneId SceneId; Ludus::Engine::Core::EntityId EntityId; };
 		struct OpenCreateProjectDialog { };
-		struct OpenRenameSceneDialog { Ludus::Engine::Core::SceneHandle SceneHandle; };
+		struct OpenRenameSceneDialog { Ludus::Engine::Core::SceneId SceneId; };
 
 		using Variant = std::variant<OpenAddScriptDialog, OpenCreateProjectDialog, OpenRenameSceneDialog>;
 

--- a/Editor/Include/Ludus/Editor/Core/ProjectSession.h
+++ b/Editor/Include/Ludus/Editor/Core/ProjectSession.h
@@ -10,6 +10,7 @@
 #include <Ludus/Editor/Core/ProjectManifest.h>
 #include <Ludus/Editor/Core/SceneSessionState.h>
 #include <Ludus/Editor/Core/SelectionManager.h>
+#include <Ludus/Engine/Core/Id.h>
 #include <Ludus/Engine/Core/RenderViewRegistry.h>
 #include <Ludus/Engine/Core/RenderViewRequestRegistry.h>
 #include <Ludus/Engine/Core/Scene.h>
@@ -24,17 +25,17 @@ namespace Ludus::Editor::Core
 	struct ProjectSessionEditorState
 	{
 		SceneSessionState ActiveSceneState;
-		Ludus::Engine::Core::SceneHandle ActiveSceneHandle;
+		Ludus::Engine::Core::SceneId ActiveSceneId;
 		Ludus::Editor::Core::SelectionManager Selection;
 
 		static ProjectSessionEditorState Create(
-			Ludus::Engine::Core::SceneHandle activeSceneHandle,
+			Ludus::Engine::Core::SceneId activeSceneId,
 			std::optional<std::filesystem::path> activeSceneSavePath = std::nullopt
 		)
 		{
 			return {
 				.ActiveSceneState = { .IsDirty = false, .SavePath = std::move(activeSceneSavePath) },
-				.ActiveSceneHandle = activeSceneHandle,
+				.ActiveSceneId = activeSceneId,
 				.Selection = { }
 			};
 		}
@@ -51,7 +52,7 @@ namespace Ludus::Editor::Core
 		static ProjectSession Create(
 			Ludus::Editor::Core::ProjectManifest projectManifest,
 			std::unique_ptr<Ludus::Engine::Runtime::RuntimeInstance> editorRuntime,
-			Ludus::Engine::Core::SceneHandle activeSceneHandle
+			Ludus::Engine::Core::SceneId activeSceneId
 		);
 
 #pragma region Editor Helpers
@@ -105,28 +106,27 @@ namespace Ludus::Editor::Core
 
 		Ludus::Engine::Runtime::RuntimeManifest& GetEditorManifest();
 
-		Ludus::Engine::Core::Scene& GetEditorScene(Ludus::Engine::Core::SceneHandle sceneHandle);
-		const Ludus::Engine::Core::Scene& GetEditorScene(Ludus::Engine::Core::SceneHandle sceneHandle) const;
+		Ludus::Engine::Core::Scene& GetEditorScene(Ludus::Engine::Core::SceneId sceneId);
+		const Ludus::Engine::Core::Scene& GetEditorScene(Ludus::Engine::Core::SceneId sceneId) const;
 
-		std::optional<std::filesystem::path> TryGetEditorScenePath(Ludus::Engine::Core::SceneHandle sceneHandle) const;
+		std::optional<std::filesystem::path> TryGetEditorScenePath(Ludus::Engine::Core::SceneId sceneId) const;
 		void AddOrUpdateEditorSceneReference(
-			Ludus::Engine::Core::SceneHandle handle,
+			Ludus::Engine::Core::SceneId id,
 			std::string name,
 			std::filesystem::path path
 		);
 
-		bool HasEditorScriptReference(Ludus::Engine::Components::ScriptHandle handle) const;
+		bool HasEditorScriptReference(Ludus::Engine::Core::ScriptId id) const;
 
 		bool HasEditorScriptReference(std::string_view name) const;
 
 		bool AddOrUpdateEditorScriptReference(
-			Ludus::Engine::Components::ScriptHandle handle,
+			Ludus::Engine::Core::ScriptId id,
 			std::string name
 		);
 
-		bool RemoveEditorScriptReference(Ludus::Engine::Components::ScriptHandle handle);
-		Ludus::Engine::Components::ScriptHandle AllocateEditorScriptHandle() const;
-		std::optional<Ludus::Engine::Components::ScriptHandle> TryFindEditorScriptHandleByName(std::string_view name) const;
+		bool RemoveEditorScriptReference(Ludus::Engine::Core::ScriptId id);
+		Ludus::Engine::Core::ScriptId AllocateEditorScriptId() const;
 		std::vector<std::string> GetEditorScriptNames() const;
 
 #pragma endregion

--- a/Editor/Include/Ludus/Editor/Core/ProjectTemplates.h
+++ b/Editor/Include/Ludus/Editor/Core/ProjectTemplates.h
@@ -8,12 +8,15 @@ namespace Ludus::Editor::Core::ProjectTemplates
 	inline Ludus::Engine::Core::Scene CreateDefaultScene()
 	{
 		auto random = Ludus::Engine::Core::Random();
-		Ludus::Engine::Core::Scene scene(random.NextId(), "Sample Scene");
+		Ludus::Engine::Core::Scene scene(
+			{ random.NextId() },
+			"Sample Scene"
+		);
 
-		const auto handle = scene.EntityComponentSystem.AddEntity();
-		scene.EntityComponentSystem.AttachDisplayName(handle, "Main Camera");
-		scene.EntityComponentSystem.AttachTransform(handle);
-		scene.EntityComponentSystem.AttachCamera(handle);
+		const auto entityId = scene.EntityComponentSystem.AddEntity();
+		scene.EntityComponentSystem.AttachDisplayName(entityId, "Main Camera");
+		scene.EntityComponentSystem.AttachTransform(entityId);
+		scene.EntityComponentSystem.AttachCamera(entityId);
 
 		return scene;
 	}

--- a/Editor/Include/Ludus/Editor/Core/SelectionManager.h
+++ b/Editor/Include/Ludus/Editor/Core/SelectionManager.h
@@ -2,20 +2,20 @@
 
 #include <optional>
 
-#include <Ludus/Engine/Core/Entity.h>
+#include <Ludus/Engine/Core/Id.h>
 
 namespace Ludus::Editor::Core
 {
 	struct SelectionManager
 	{
-		std::optional<Ludus::Engine::Core::EntityHandle> SelectedEntity;
+		std::optional<Ludus::Engine::Core::EntityId> SelectedEntityId;
 
-		void SelectEntity(Ludus::Engine::Core::EntityHandle entity);
-		void DeselectEntity(Ludus::Engine::Core::EntityHandle entity);
+		void SelectEntity(Ludus::Engine::Core::EntityId id);
+		void DeselectEntity(Ludus::Engine::Core::EntityId id);
 
 		void ClearSelection();
 
 		bool HasEntity() const;
-		bool IsSelected(Ludus::Engine::Core::EntityHandle entity) const;
+		bool IsSelected(Ludus::Engine::Core::EntityId id) const;
 	};
 }

--- a/Editor/Include/Ludus/Editor/Dialogs/AddScriptDialog.h
+++ b/Editor/Include/Ludus/Editor/Dialogs/AddScriptDialog.h
@@ -1,15 +1,14 @@
 #pragma once
 
 #include <string>
-#include <unordered_map>
 #include <utility>
 #include <vector>
 
 #include <Ludus/Editor/Commands/CommandSet.h>
 #include <Ludus/Editor/Dialogs/DialogOutcome.h>
 #include <Ludus/Engine/Components/ScriptComponent.h>
-#include <Ludus/Engine/Core/Entity.h>
-#include <Ludus/Engine/Core/Scene.h>
+#include <Ludus/Engine/Core/Id.h>
+#include <Ludus/Engine/Runtime/RuntimeManifest.h>
 
 namespace Ludus::Editor::Dialogs
 {
@@ -25,19 +24,19 @@ namespace Ludus::Editor::Dialogs
 		std::string SelectName;
 		AddScriptTab ActiveTab = AddScriptTab::Create;
 
-		Ludus::Engine::Core::EntityHandle EntityHandle;
-		Ludus::Engine::Core::SceneHandle SceneHandle;
+		Ludus::Engine::Core::SceneId SceneId;
+		Ludus::Engine::Core::EntityId EntityId;
 		std::vector<std::string> ScriptNames;
-		std::unordered_map<std::string, Ludus::Engine::Components::ScriptHandle> ScriptHandlesByName;
+		std::vector<Ludus::Engine::Runtime::ScriptReference> ScriptReferences;
 
 		using Outcome = DialogOutcome<std::string>;
 
 	public:
 		AddScriptDialog(
-			Ludus::Engine::Core::EntityHandle entityHandle,
-			Ludus::Engine::Core::SceneHandle sceneHandle,
+			Ludus::Engine::Core::SceneId sceneId,
+			Ludus::Engine::Core::EntityId entityId,
 			std::vector<std::string> scriptNames,
-			std::unordered_map<std::string, Ludus::Engine::Components::ScriptHandle> scriptHandlesByName
+			std::vector<Ludus::Engine::Runtime::ScriptReference> scriptReferences
 		);
 
 		Outcome Draw();

--- a/Editor/Include/Ludus/Editor/Dialogs/RenameSceneDialog.h
+++ b/Editor/Include/Ludus/Editor/Dialogs/RenameSceneDialog.h
@@ -5,6 +5,7 @@
 
 #include <Ludus/Editor/Commands/CommandSet.h>
 #include <Ludus/Editor/Dialogs/DialogOutcome.h>
+#include <Ludus/Engine/Core/Id.h>
 
 namespace Ludus::Editor::Dialogs
 {
@@ -13,7 +14,7 @@ namespace Ludus::Editor::Dialogs
 	private:
 		struct RenameOutcome
 		{
-			Ludus::Engine::Core::SceneHandle SceneHandle;
+			Ludus::Engine::Core::SceneId SceneId;
 			std::filesystem::path Path;
 		};
 
@@ -24,13 +25,13 @@ namespace Ludus::Editor::Dialogs
 		std::string Name;
 		std::filesystem::path NewPath;
 
-		Ludus::Engine::Core::SceneHandle SceneHandle;
+		Ludus::Engine::Core::SceneId SceneId;
 		std::filesystem::path CurrentPath;
 
 		using Outcome = DialogOutcome<RenameOutcome>;
 
 	public:
-		RenameSceneDialog(Ludus::Engine::Core::SceneHandle sceneHandle, std::filesystem::path currentPath);
+		RenameSceneDialog(Ludus::Engine::Core::SceneId sceneId, std::filesystem::path currentPath);
 
 		Outcome Draw();
 		void Resolve(const Outcome& outcome, Ludus::Editor::Commands::CommandSet& out);

--- a/Editor/Include/Ludus/Editor/Panels/HierarchyPanel.h
+++ b/Editor/Include/Ludus/Editor/Panels/HierarchyPanel.h
@@ -2,7 +2,7 @@
 
 #include <Ludus/Editor/Core/ProjectSessionContext.h>
 #include <Ludus/Editor/Panels/IPanel.h>
-#include <Ludus/Engine/Core/Entity.h>
+#include <Ludus/Engine/Core/Id.h>
 #include <Ludus/Engine/Core/Random.h>
 #include <Ludus/Engine/Core/Scene.h>
 
@@ -14,7 +14,7 @@ namespace Ludus::Editor::Panels
 		Ludus::Engine::Core::Random m_Random { };
 
 		void DrawSceneContextMenu(Ludus::Editor::Core::ProjectSessionContext& context, Ludus::Engine::Core::Scene& scene);
-		void DrawEntityRow(Ludus::Editor::Core::ProjectSessionContext& context, Ludus::Engine::Core::Scene& scene, Ludus::Engine::Core::EntityHandle entityHandle);
+		void DrawEntityRow(Ludus::Editor::Core::ProjectSessionContext& context, Ludus::Engine::Core::Scene& scene, Ludus::Engine::Core::EntityId entityId);
 		void DrawSceneRow(Ludus::Editor::Core::ProjectSessionContext& context, Ludus::Engine::Core::Scene& scene);
 
 	public:

--- a/Editor/Include/Ludus/Editor/Panels/ViewportPanel.h
+++ b/Editor/Include/Ludus/Editor/Panels/ViewportPanel.h
@@ -7,7 +7,7 @@
 #include <Ludus/Editor/Core/ProjectSessionContext.h>
 #include <Ludus/Editor/Core/ViewportDisplayMode.h>
 #include <Ludus/Editor/Panels/IPanel.h>
-#include <Ludus/Engine/Core/Scene.h>
+#include <Ludus/Engine/Core/Id.h>
 #include <Ludus/Engine/Graphics/Camera2D.h>
 #include <Ludus/Engine/Graphics/RenderPresentationSettings.h>
 #include <Ludus/Engine/Graphics/RenderTarget.h>
@@ -28,7 +28,7 @@ namespace Ludus::Editor::Panels
 		std::optional<Ludus::Engine::Graphics::RenderTarget> m_Target;
 		Ludus::Engine::Math::Size<int> m_PreviousTargetSize;
 		Ludus::Editor::Core::ViewportDisplayMode m_DisplayMode;
-		std::optional<Ludus::Engine::Core::SceneHandle> m_SelectedSceneHandle = std::nullopt;
+		std::optional<Ludus::Engine::Core::SceneId> m_SelectedSceneId = std::nullopt;
 
 		bool m_IsCameraPanning = false;
 		bool m_FollowActiveScene = true;

--- a/Editor/Resources/Templates/RuntimeHost/RuntimeHost.vcxproj.template
+++ b/Editor/Resources/Templates/RuntimeHost/RuntimeHost.vcxproj.template
@@ -15,7 +15,7 @@
 	<PropertyGroup Label="Globals">
 		<VCProjectVersion>17.0</VCProjectVersion>
 		<Keyword>Win32Proj</Keyword>
-		<ProjectGuid>{7D744EE7-F882-4E58-98CA-9F2D994A4DA5}</ProjectGuid>
+		<ProjectGuid>{${LUDUS_RUNTIME_HOST_PROJECT_GUID}}</ProjectGuid>
 		<RootNamespace>Runtime Host</RootNamespace>
 		<WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
 	</PropertyGroup>

--- a/Editor/Resources/Templates/Scripting/Scripts.vcxproj.template
+++ b/Editor/Resources/Templates/Scripting/Scripts.vcxproj.template
@@ -14,7 +14,7 @@
 
 	<PropertyGroup Label="Globals">
 		<VCProjectVersion>17.0</VCProjectVersion>
-		<ProjectGuid>{d4a99667-4e18-4ef8-8e4e-f2fd78091d57}</ProjectGuid>
+		<ProjectGuid>{${LUDUS_SCRIPTS_PROJECT_GUID}}</ProjectGuid>
 		<RootNamespace>Scripts</RootNamespace>
 		<WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
 	</PropertyGroup>

--- a/Editor/Source/Ludus/Editor/Build/MSBuild/MSBuildRuntimeHostPipeline.cpp
+++ b/Editor/Source/Ludus/Editor/Build/MSBuild/MSBuildRuntimeHostPipeline.cpp
@@ -1,6 +1,5 @@
 #include "pch.h"
 
-#include <algorithm>
 #include <stdexcept>
 #include <string>
 
@@ -16,6 +15,7 @@
 #include <Ludus/Engine/FileSystem/FileSystem.h>
 #include <Ludus/Engine/Persistence/LmlRuntimeManifestPersistence.h>
 #include <Ludus/Engine/Persistence/Paths.h>
+#include <Ludus/Engine/Platform/Guid.h>
 #include <Ludus/Engine/Platform/Process.h>
 #include <Ludus/Engine/Runtime/RuntimeManifest.h>
 
@@ -37,6 +37,7 @@ namespace
 		static constexpr std::string_view EngineResourcesDirectoryToken = "${LUDUS_RUNTIME_HOST_ENGINE_RESOURCES_DIR}";
 		static constexpr std::string_view EngineProjectPathToken = "${LUDUS_RUNTIME_HOST_ENGINE_PROJECT_PATH}";
 		static constexpr std::string_view RuntimeNameToken = "${LUDUS_RUNTIME_NAME}";
+		static constexpr std::string_view ProjectGuidToken = "${LUDUS_RUNTIME_HOST_PROJECT_GUID}";
 
 		static constexpr std::string_view BuildCommand = "Build";
 		static constexpr std::string_view RebuildCommand = "Rebuild";
@@ -84,7 +85,8 @@ namespace Ludus::Editor::Build::MSBuild
 		}
 
 		const auto sourcePath = templateRoot / std::string(templateFileName);
-		const auto text = Ludus::Engine::FileSystem::ReadAllText(sourcePath);
+		auto text = Ludus::Engine::FileSystem::ReadAllText(sourcePath);
+		text = Ludus::Engine::Core::Strings::ReplaceAll(text, Constants::ProjectGuidToken, Ludus::Engine::Platform::CreateGuid().ToString());
 		Ludus::Engine::FileSystem::WriteAllText(destinationPath, text);
 	}
 

--- a/Editor/Source/Ludus/Editor/Build/MSBuild/MSBuildScriptPipeline.cpp
+++ b/Editor/Source/Ludus/Editor/Build/MSBuild/MSBuildScriptPipeline.cpp
@@ -1,6 +1,5 @@
 #include "pch.h"
 
-#include <algorithm>
 #include <stdexcept>
 #include <string>
 
@@ -13,6 +12,7 @@
 #include <Ludus/Engine/Core/Enums.h>
 #include <Ludus/Engine/Core/Strings.h>
 #include <Ludus/Engine/FileSystem/FileSystem.h>
+#include <Ludus/Engine/Platform/Guid.h>
 #include <Ludus/Engine/Platform/Process.h>
 
 namespace
@@ -39,6 +39,7 @@ namespace
 		static constexpr std::string_view IntermediateDirectoryToken = "${LUDUS_SCRIPT_INT_DIR}";
 		static constexpr std::string_view ScriptingProjectPathToken = "${LUDUS_SCRIPTING_PROJECT_PATH}";
 		static constexpr std::string_view TargetNameToken = "${LUDUS_TARGET_NAME}";
+		static constexpr std::string_view ProjectGuidToken = "${LUDUS_SCRIPTS_PROJECT_GUID}";
 
 		static constexpr std::string_view BuildCommand = "Build";
 		static constexpr std::string_view RebuildCommand = "Rebuild";
@@ -69,7 +70,8 @@ namespace Ludus::Editor::Build::MSBuild
 		}
 
 		const auto sourcePath = templateRoot / std::string(templateFileName);
-		const auto text = Ludus::Engine::FileSystem::ReadAllText(sourcePath);
+		auto text = Ludus::Engine::FileSystem::ReadAllText(sourcePath);
+		text = Ludus::Engine::Core::Strings::ReplaceAll(text, Constants::ProjectGuidToken, Ludus::Engine::Platform::CreateGuid().ToString());
 		Ludus::Engine::FileSystem::WriteAllText(destinationPath, text);
 	}
 

--- a/Editor/Source/Ludus/Editor/Commands/CommandManager.cpp
+++ b/Editor/Source/Ludus/Editor/Commands/CommandManager.cpp
@@ -6,6 +6,7 @@
 #include <utility>
 
 #include <Ludus/Editor/Commands/CommandManager.h>
+#include <Ludus/Engine/Core/Id.h>
 #include <Ludus/Engine/Debug/Debug.h>
 
 namespace Ludus::Editor::Commands
@@ -46,13 +47,13 @@ namespace Ludus::Editor::Commands
 		PendingCommands.UICommands.emplace_back(std::move(command));
 	}
 
-	Ludus::Engine::Core::EntityHandle CommandManager::ResolveEntity(const EntityReference& reference) const
+	Ludus::Engine::Core::EntityId CommandManager::ResolveEntity(const EntityReference& reference) const
 	{
-		return std::visit([&](auto&& value) -> Ludus::Engine::Core::EntityHandle
+		return std::visit([&](auto&& value) -> Ludus::Engine::Core::EntityId
 		{
 			using Alt = std::decay_t<decltype(value)>;
 
-			if constexpr (std::is_same_v<Alt, Ludus::Engine::Core::EntityHandle>)
+			if constexpr (std::is_same_v<Alt, Ludus::Engine::Core::EntityId>)
 			{
 				return value;
 			}
@@ -61,14 +62,14 @@ namespace Ludus::Editor::Commands
 				auto iter = m_TempToBinding.find(value.Temp);
 				LUDUS_ASSERT(iter != m_TempToBinding.end(), "Unresolved temporary entity reference.");
 
-				return iter->second.Handle;
+				return iter->second.Id;
 			}
 		}, reference.Value);
 	}
 
-	void CommandManager::BindEntityReference(TempReference temp, Ludus::Engine::Core::EntityHandle handle)
+	void CommandManager::BindEntityReference(TempReference temp, Ludus::Engine::Core::EntityId id)
 	{
-		m_TempToBinding[temp] = TempEntityBinding { .Handle = handle, .LastSeenFrame = m_FrameIndex };
+		m_TempToBinding[temp] = TempEntityBinding { .Id = id, .LastSeenFrame = m_FrameIndex };
 	}
 
 	void CommandManager::ClearEntityReferences()

--- a/Editor/Source/Ludus/Editor/Commands/Edit/Entities.cpp
+++ b/Editor/Source/Ludus/Editor/Commands/Edit/Entities.cpp
@@ -4,6 +4,7 @@
 
 #include <Ludus/Editor/Commands/Edit/Entities.h>
 #include <Ludus/Editor/Commands/ProjectSessionCommandContext.h>
+#include <Ludus/Engine/Core/Id.h>
 #include <Ludus/Engine/Core/SceneRegistry.h>
 #include <Ludus/Engine/Debug/Debug.h>
 
@@ -11,24 +12,24 @@ namespace Ludus::Editor::Commands::Edit::Entities
 {
 	void AddEntity(const EditCommand::AddEntity& command, ProjectSessionCommandContext& context)
 	{
-		auto* scene = context.ProjectSession.GetSceneRegistry().TryGetScene(command.SceneHandle);
+		auto* scene = context.ProjectSession.GetSceneRegistry().TryGetScene(command.SceneId);
 		if (!scene)
 		{
 			return;
 		}
 
-		const auto handle = scene->EntityComponentSystem.AddEntity();
+		const auto id = scene->EntityComponentSystem.AddEntity();
 
 		std::visit([&](auto&& value)
 		{
 			using Alt = std::decay_t<decltype(value)>;
-			if constexpr (std::is_same_v<Alt, Ludus::Engine::Core::EntityHandle>)
+			if constexpr (std::is_same_v<Alt, Ludus::Engine::Core::EntityId>)
 			{
 				LUDUS_ASSERT(false, "AddEntity must use a temporary entity reference.");
 			}
 			else
 			{
-				context.Shell.State.Commands.BindEntityReference(value.Temp, handle);
+				context.Shell.State.Commands.BindEntityReference(value.Temp, id);
 			}
 		}, command.EntityReference.Value);
 
@@ -37,14 +38,14 @@ namespace Ludus::Editor::Commands::Edit::Entities
 
 	void RemoveEntity(const EditCommand::RemoveEntity& command, ProjectSessionCommandContext& context)
 	{
-		auto* scene = context.ProjectSession.GetSceneRegistry().TryGetScene(command.SceneHandle);
+		auto* scene = context.ProjectSession.GetSceneRegistry().TryGetScene(command.SceneId);
 		if (!scene)
 		{
 			return;
 		}
 
-		const auto handle = context.Shell.State.Commands.ResolveEntity(command.EntityReference);
-		scene->EntityComponentSystem.DestroyEntity(handle);
+		const auto id = context.Shell.State.Commands.ResolveEntity(command.EntityReference);
+		scene->EntityComponentSystem.DestroyEntity(id);
 
 		context.ProjectSession.MarkSceneDirty();
 	}

--- a/Editor/Source/Ludus/Editor/Commands/Requests/Projects.cpp
+++ b/Editor/Source/Ludus/Editor/Commands/Requests/Projects.cpp
@@ -39,8 +39,8 @@ namespace Ludus::Editor::Commands::Requests::Projects
 
 			// Create runtime manifest.
 			const auto runtimeManifest = Ludus::Engine::Runtime::RuntimeManifest::Create(
-				scene.Handle,
-				{ { scene.Handle, scene.Name, scenePath } },
+				scene.Id,
+				{ { scene.Id, scene.Name, scenePath } },
 				{ }
 			);
 			const auto runtimeManifestPath = Ludus::Engine::Persistence::Paths::RuntimeManifestFile(projectRoot, projectName);

--- a/Editor/Source/Ludus/Editor/Commands/Requests/Scenes.cpp
+++ b/Editor/Source/Ludus/Editor/Commands/Requests/Scenes.cpp
@@ -9,6 +9,7 @@
 #include <Ludus/Editor/Core/ProjectTemplates.h>
 #include <Ludus/Editor/Panels/PanelHelpers.h>
 #include <Ludus/Editor/Persistence/ProjectPaths.h>
+#include <Ludus/Engine/Core/Id.h>
 
 namespace Ludus::Editor::Commands::Requests::Scenes
 {
@@ -20,11 +21,11 @@ namespace Ludus::Editor::Commands::Requests::Scenes
 		}
 
 		std::filesystem::path RequireScenePath(
-			Ludus::Engine::Core::SceneHandle sceneHandle,
+			Ludus::Engine::Core::SceneId sceneId,
 			ProjectSessionCommandContext& context
 		)
 		{
-			const auto scenePath = context.ProjectSession.TryGetEditorScenePath(sceneHandle);
+			const auto scenePath = context.ProjectSession.TryGetEditorScenePath(sceneId);
 			if (!scenePath)
 			{
 				throw std::runtime_error("No valid path was found for scene.");
@@ -42,13 +43,13 @@ namespace Ludus::Editor::Commands::Requests::Scenes
 		}
 
 		std::optional<std::filesystem::path> TryGetSceneReferencePath(
-			Ludus::Engine::Core::SceneHandle sceneHandle,
+			Ludus::Engine::Core::SceneId sceneId,
 			ProjectSessionCommandContext& context
 		)
 		{
 			for (const auto& sceneReference : context.ProjectSession.GetEditorManifest().Scenes)
 			{
-				if (sceneReference.Handle == sceneHandle)
+				if (sceneReference.Id == sceneId)
 				{
 					return sceneReference.Path;
 				}
@@ -59,11 +60,11 @@ namespace Ludus::Editor::Commands::Requests::Scenes
 
 		void SaveSceneToPath(
 			ProjectSessionCommandContext& context,
-			Ludus::Engine::Core::SceneHandle sceneHandle,
+			Ludus::Engine::Core::SceneId sceneId,
 			const std::filesystem::path& path
 		)
 		{
-			context.ScenePersistence.Save(context.ProjectSession.GetEditorScene(sceneHandle), path);
+			context.ScenePersistence.Save(context.ProjectSession.GetEditorScene(sceneId), path);
 		}
 
 		void CommitSceneSave(
@@ -98,34 +99,34 @@ namespace Ludus::Editor::Commands::Requests::Scenes
 
 	void SaveScene(const RequestCommand::SaveScene& command, ProjectSessionCommandContext& context)
 	{
-		const auto scenePath = RequireScenePath(command.SceneHandle, context);
-		SaveSceneToPath(context, command.SceneHandle, scenePath);
+		const auto scenePath = RequireScenePath(command.SceneId, context);
+		SaveSceneToPath(context, command.SceneId, scenePath);
 
 		CommitSceneSave(context, scenePath);
 	}
 
 	void SaveSceneAs(const RequestCommand::SaveSceneAs& command, ProjectSessionCommandContext& context)
 	{
-		const auto& scene = context.ProjectSession.GetEditorScene(command.SceneHandle);
-		context.ProjectSession.AddOrUpdateEditorSceneReference(command.SceneHandle, scene.Name, command.Path);
+		const auto& scene = context.ProjectSession.GetEditorScene(command.SceneId);
+		context.ProjectSession.AddOrUpdateEditorSceneReference(scene.Id, scene.Name, command.Path);
 
 		SaveManifest(context);
-		SaveSceneToPath(context, command.SceneHandle, command.Path);
+		SaveSceneToPath(context, command.SceneId, command.Path);
 
 		CommitSceneSave(context, command.Path);
 	}
 
 	void RenameScene(const RequestCommand::RenameScene& command, ProjectSessionCommandContext& context)
 	{
-		auto& scene = context.ProjectSession.GetEditorScene(command.SceneHandle);
+		auto& scene = context.ProjectSession.GetEditorScene(command.SceneId);
 		const auto newName = Ludus::Editor::Persistence::ProjectPaths::SceneName(command.Path);
-		const auto previousPath = TryGetSceneReferencePath(command.SceneHandle, context);
+		const auto previousPath = TryGetSceneReferencePath(command.SceneId, context);
 
-		context.ProjectSession.AddOrUpdateEditorSceneReference(command.SceneHandle, newName, command.Path);
+		context.ProjectSession.AddOrUpdateEditorSceneReference(scene.Id, newName, command.Path);
 		scene.Name = newName;
 
 		SaveManifest(context);
-		SaveSceneToPath(context, command.SceneHandle, command.Path);
+		SaveSceneToPath(context, command.SceneId, command.Path);
 
 		if (previousPath && *previousPath != command.Path)
 		{

--- a/Editor/Source/Ludus/Editor/Commands/Requests/Scripts.cpp
+++ b/Editor/Source/Ludus/Editor/Commands/Requests/Scripts.cpp
@@ -8,6 +8,7 @@
 #include <Ludus/Editor/Commands/Requests/Scripts.h>
 #include <Ludus/Editor/Panels/PanelHelpers.h>
 #include <Ludus/Editor/Persistence/ProjectPaths.h>
+#include <Ludus/Engine/Core/Id.h>
 
 namespace Ludus::Editor::Commands::Requests::Scripts
 {
@@ -26,9 +27,9 @@ namespace Ludus::Editor::Commands::Requests::Scripts
 			throw std::runtime_error("Script source file already exists: " + scriptSourcePath.string());
 		}
 
-		const auto handle = context.ProjectSession.AllocateEditorScriptHandle();
+		const auto id = context.ProjectSession.AllocateEditorScriptId();
 		auto& runtimeManifest = context.ProjectSession.GetEditorManifest();
-		context.ProjectSession.AddOrUpdateEditorScriptReference(handle, command.Name);
+		context.ProjectSession.AddOrUpdateEditorScriptReference(id, command.Name);
 		context.RuntimeManifestPersistence.Save(runtimeManifest, context.ProjectSession.ProjectManifest.RuntimeManifestPath);
 
 		auto& build = context.Shell.Build;
@@ -40,7 +41,7 @@ namespace Ludus::Editor::Commands::Requests::Scripts
 		catch (...)
 		{
 			// Make sure to roll back persistence in case of exceptions.
-			context.ProjectSession.RemoveEditorScriptReference(handle);
+			context.ProjectSession.RemoveEditorScriptReference(id);
 			context.RuntimeManifestPersistence.Save(runtimeManifest, context.ProjectSession.ProjectManifest.RuntimeManifestPath);
 			Ludus::Editor::Panels::RefreshContentPanel(projectRoot, context.PanelRegistry);
 
@@ -49,9 +50,7 @@ namespace Ludus::Editor::Commands::Requests::Scripts
 
 		context.Shell.State.Commands.AddEditCommand(
 			Ludus::Editor::Commands::EditCommand::AddComponent<Ludus::Engine::Components::ScriptComponent> {
-			.EntityReference = command.EntityReference,
-				.SceneHandle = command.SceneHandle,
-				.Init = Ludus::Engine::Components::ScriptComponent { command.Name, handle }
+			.SceneId = command.SceneId, .EntityReference = command.EntityReference, .Init = Ludus::Engine::Components::ScriptComponent { id }
 		});
 
 		Ludus::Editor::Panels::RefreshContentPanel(projectRoot, context.PanelRegistry);

--- a/Editor/Source/Ludus/Editor/Commands/UI/Dialogs.cpp
+++ b/Editor/Source/Ludus/Editor/Commands/UI/Dialogs.cpp
@@ -3,9 +3,7 @@
 #include <filesystem>
 #include <stdexcept>
 #include <string>
-#include <unordered_map>
 #include <utility>
-#include <vector>
 
 #include <Ludus/Editor/Commands/ProjectSessionCommandContext.h>
 #include <Ludus/Editor/Commands/StartupCommandContext.h>
@@ -14,23 +12,18 @@
 #include <Ludus/Editor/Dialogs/DialogManager.h>
 #include <Ludus/Editor/Dialogs/RenameSceneDialog.h>
 #include <Ludus/Engine/Components/ScriptComponent.h>
+#include <Ludus/Engine/Core/Id.h>
 #include <Ludus/Engine/Persistence/Paths.h>
 
 namespace Ludus::Editor::Commands::UI::Dialogs
 {
 	void OpenAddScriptDialog(const UICommand::OpenAddScriptDialog& command, ProjectSessionCommandContext& context)
 	{
-		auto scriptHandlesByName = std::unordered_map<std::string, Ludus::Engine::Components::ScriptHandle> { };
-		for (const auto& reference : context.ProjectSession.GetEditorManifest().Scripts)
-		{
-			scriptHandlesByName.emplace(reference.Name, reference.Handle);
-		}
-
 		Ludus::Editor::Dialogs::AddScriptDialog dialog(
-			command.EntityHandle,
-			command.SceneHandle,
+			command.SceneId,
+			command.EntityId,
 			context.ProjectSession.GetEditorScriptNames(),
-			std::move(scriptHandlesByName)
+			context.ProjectSession.GetEditorManifest().Scripts
 		);
 		context.Shell.State.Dialogs.Open(dialog);
 	}
@@ -42,14 +35,14 @@ namespace Ludus::Editor::Commands::UI::Dialogs
 
 	void OpenRenameSceneDialog(const UICommand::OpenRenameSceneDialog& command, ProjectSessionCommandContext& context)
 	{
-		const auto scenePath = context.ProjectSession.TryGetEditorScenePath(command.SceneHandle);
+		const auto scenePath = context.ProjectSession.TryGetEditorScenePath(command.SceneId);
 		if (!scenePath)
 		{
 			throw std::runtime_error("Scene does not have a path.");
 		}
 
 		Ludus::Editor::Dialogs::RenameSceneDialog dialog(
-			command.SceneHandle,
+			command.SceneId,
 			*scenePath
 		);
 		context.Shell.State.Dialogs.Open(dialog);

--- a/Editor/Source/Ludus/Editor/Core/EditorSession.cpp
+++ b/Editor/Source/Ludus/Editor/Core/EditorSession.cpp
@@ -50,8 +50,6 @@ namespace Ludus::Editor::Core
 			auto renderingConfiguration = Ludus::Engine::Graphics::RenderingConfiguration2D { };
 			renderingConfiguration.AddPass(std::make_unique<Ludus::Editor::Core::EditorGridRenderPass>());
 
-			const auto entrySceneHandle = runtimeManifest.EntrySceneHandle;
-
 			// Build runtime instance.
 			auto runtime = Ludus::Engine::Runtime::RuntimeInstanceBuilder::Create()
 				.UseDefaultPhysics2D()
@@ -63,10 +61,12 @@ namespace Ludus::Editor::Core
 				.WithEntryScene(std::move(entryScene))
 				.Build(hostContext);
 
+			const auto entrySceneId = runtime->GetScenePresentationState().CurrentSceneId;
+
 			return Ludus::Editor::Core::ProjectSession::Create(
 				std::move(projectManifest),
 				std::move(runtime),
-				entrySceneHandle
+				entrySceneId
 			);
 		}
 	}

--- a/Editor/Source/Ludus/Editor/Core/ProjectSession.cpp
+++ b/Editor/Source/Ludus/Editor/Core/ProjectSession.cpp
@@ -6,6 +6,7 @@
 #include <utility>
 
 #include <Ludus/Editor/Core/ProjectSession.h>
+#include <Ludus/Engine/Core/Id.h>
 #include <Ludus/Engine/Core/Random.h>
 #include <Ludus/Engine/Core/Scene.h>
 #include <Ludus/Engine/Runtime/RuntimeInstanceBuilder.h>
@@ -15,7 +16,7 @@ namespace Ludus::Editor::Core
 	ProjectSession ProjectSession::Create(
 		Ludus::Editor::Core::ProjectManifest projectManifest,
 		std::unique_ptr<Ludus::Engine::Runtime::RuntimeInstance> editorRuntime,
-		Ludus::Engine::Core::SceneHandle activeSceneHandle
+		Ludus::Engine::Core::SceneId activeSceneId
 	)
 	{
 		if (!editorRuntime)
@@ -23,7 +24,7 @@ namespace Ludus::Editor::Core
 			throw std::runtime_error("ProjectSession requires an editor runtime.");
 		}
 
-		if (!editorRuntime->GetSceneRegistry().Contains(activeSceneHandle))
+		if (!editorRuntime->GetSceneRegistry().Contains(activeSceneId))
 		{
 			throw std::runtime_error("ProjectSession requires an active scene to exist in the editor runtime.");
 		}
@@ -33,7 +34,7 @@ namespace Ludus::Editor::Core
 		std::optional<std::filesystem::path> activeSceneSavePath;
 		for (const auto& sceneReference : runtimeManifest.Scenes)
 		{
-			if (sceneReference.Handle == activeSceneHandle)
+			if (sceneReference.Id == activeSceneId)
 			{
 				activeSceneSavePath = sceneReference.Path;
 				break;
@@ -43,14 +44,14 @@ namespace Ludus::Editor::Core
 		return {
 			.ProjectManifest = std::move(projectManifest),
 			.EditorManifest = Ludus::Engine::Runtime::RuntimeManifest::Create(
-				runtimeManifest.EntrySceneHandle,
+				runtimeManifest.EntrySceneId,
 				runtimeManifest.Scenes,
 				runtimeManifest.Scripts
 			),
 			.EditorRuntime = std::move(editorRuntime),
 			.SimulationRuntime = nullptr,
 			.EditorState = Ludus::Editor::Core::ProjectSessionEditorState::Create(
-				activeSceneHandle,
+				activeSceneId,
 				std::move(activeSceneSavePath)
 			)
 		};
@@ -61,15 +62,15 @@ namespace Ludus::Editor::Core
 		auto& sceneRegistry = GetEditorRuntime().GetSceneRegistry();
 		sceneRegistry.Clear();
 
-		const auto sceneHandle = scene.Handle;
+		const auto sceneId = scene.Id;
 		sceneRegistry.AddScene(std::move(scene));
 
-		EditorState.ActiveSceneHandle = sceneHandle;
+		EditorState.ActiveSceneId = sceneId;
 		EditorState.ActiveSceneState = {
 			.IsDirty = false,
-			.SavePath = sceneSavePath ? sceneSavePath : TryGetEditorScenePath(sceneHandle)
+			.SavePath = sceneSavePath ? sceneSavePath : TryGetEditorScenePath(sceneId)
 		};
-		GetEditorRuntime().GetScenePresentationState().CurrentSceneHandle = sceneHandle;
+		GetEditorRuntime().GetScenePresentationState().CurrentSceneId = sceneId;
 	}
 
 	void ProjectSession::StartSimulation(Ludus::Engine::Runtime::IHostContext& hostContext)
@@ -82,8 +83,8 @@ namespace Ludus::Editor::Core
 
 		const auto& editorRuntime = *EditorRuntime;
 		const auto& editorManifest = GetEditorManifest();
-		const auto activeSceneHandle = EditorState.ActiveSceneHandle;
-		const auto& activeScene = editorRuntime.GetSceneRegistry().GetScene(activeSceneHandle);
+		const auto activeSceneId = EditorState.ActiveSceneId;
+		const auto& activeScene = editorRuntime.GetSceneRegistry().GetScene(activeSceneId);
 
 		auto simulationRuntime = Ludus::Engine::Runtime::RuntimeInstanceBuilder::Create()
 			.UseDefaultPhysics2D()
@@ -147,23 +148,23 @@ namespace Ludus::Editor::Core
 		return EditorManifest;
 	}
 
-	Ludus::Engine::Core::Scene& ProjectSession::GetEditorScene(Ludus::Engine::Core::SceneHandle sceneHandle)
+	Ludus::Engine::Core::Scene& ProjectSession::GetEditorScene(Ludus::Engine::Core::SceneId sceneId)
 	{
-		return GetEditorRuntime().GetSceneRegistry().GetScene(sceneHandle);
+		return GetEditorRuntime().GetSceneRegistry().GetScene(sceneId);
 	}
 
-	const Ludus::Engine::Core::Scene& ProjectSession::GetEditorScene(Ludus::Engine::Core::SceneHandle sceneHandle) const
+	const Ludus::Engine::Core::Scene& ProjectSession::GetEditorScene(Ludus::Engine::Core::SceneId sceneId) const
 	{
-		return GetEditorRuntime().GetSceneRegistry().GetScene(sceneHandle);
+		return GetEditorRuntime().GetSceneRegistry().GetScene(sceneId);
 	}
 
-	std::optional<std::filesystem::path> ProjectSession::TryGetEditorScenePath(Ludus::Engine::Core::SceneHandle sceneHandle) const
+	std::optional<std::filesystem::path> ProjectSession::TryGetEditorScenePath(Ludus::Engine::Core::SceneId sceneId) const
 	{
 		std::filesystem::path scenePath;
 
 		for (const auto& sceneReference : GetEditorManifest().Scenes)
 		{
-			if (sceneReference.Handle == sceneHandle)
+			if (sceneReference.Id == sceneId)
 			{
 				scenePath = sceneReference.Path;
 				break;
@@ -179,14 +180,14 @@ namespace Ludus::Editor::Core
 	}
 
 	void ProjectSession::AddOrUpdateEditorSceneReference(
-		Ludus::Engine::Core::SceneHandle handle,
+		Ludus::Engine::Core::SceneId id,
 		std::string name,
 		std::filesystem::path path
 	)
 	{
 		for (auto& sceneReference : GetEditorManifest().Scenes)
 		{
-			if (sceneReference.Handle == handle)
+			if (sceneReference.Id == id)
 			{
 				sceneReference.Name = std::move(name);
 				sceneReference.Path = std::move(path);
@@ -195,14 +196,14 @@ namespace Ludus::Editor::Core
 			}
 		}
 
-		GetEditorManifest().Scenes.push_back({ handle, std::move(name), std::move(path) });
+		GetEditorManifest().Scenes.push_back({ id, std::move(name), std::move(path) });
 	}
 
-	bool ProjectSession::HasEditorScriptReference(Ludus::Engine::Components::ScriptHandle handle) const
+	bool ProjectSession::HasEditorScriptReference(Ludus::Engine::Core::ScriptId id) const
 	{
 		for (const auto& scriptReference : GetEditorManifest().Scripts)
 		{
-			if (scriptReference.Handle == handle)
+			if (scriptReference.Id == id)
 			{
 				return true;
 			}
@@ -225,13 +226,13 @@ namespace Ludus::Editor::Core
 	}
 
 	bool ProjectSession::AddOrUpdateEditorScriptReference(
-		Ludus::Engine::Components::ScriptHandle handle,
+		Ludus::Engine::Core::ScriptId id,
 		std::string name
 	)
 	{
 		for (auto& scriptReference : GetEditorManifest().Scripts)
 		{
-			if (scriptReference.Handle == handle)
+			if (scriptReference.Id == id)
 			{
 				if (scriptReference.Name == name)
 				{
@@ -243,16 +244,16 @@ namespace Ludus::Editor::Core
 			}
 		}
 
-		GetEditorManifest().Scripts.push_back({ handle, std::move(name) });
+		GetEditorManifest().Scripts.push_back({ id, std::move(name) });
 		return true;
 	}
 
-	bool ProjectSession::RemoveEditorScriptReference(Ludus::Engine::Components::ScriptHandle handle)
+	bool ProjectSession::RemoveEditorScriptReference(Ludus::Engine::Core::ScriptId id)
 	{
 		auto& scripts = GetEditorManifest().Scripts;
 		for (auto iter = scripts.begin(); iter != scripts.end(); ++iter)
 		{
-			if (iter->Handle == handle)
+			if (iter->Id == id)
 			{
 				scripts.erase(iter);
 				return true;
@@ -262,30 +263,17 @@ namespace Ludus::Editor::Core
 		return false;
 	}
 
-	Ludus::Engine::Components::ScriptHandle ProjectSession::AllocateEditorScriptHandle() const
+	Ludus::Engine::Core::ScriptId ProjectSession::AllocateEditorScriptId() const
 	{
 		auto random = Ludus::Engine::Core::Random();
-		auto handle = random.NextId();
+		auto id = Ludus::Engine::Core::ScriptId { random.NextId() };
 
-		while (HasEditorScriptReference(handle))
+		while (HasEditorScriptReference(id))
 		{
-			handle = random.NextId();
+			id = Ludus::Engine::Core::ScriptId { random.NextId() };
 		}
 
-		return handle;
-	}
-
-	std::optional<Ludus::Engine::Components::ScriptHandle> ProjectSession::TryFindEditorScriptHandleByName(std::string_view name) const
-	{
-		for (const auto& scriptReference : GetEditorManifest().Scripts)
-		{
-			if (scriptReference.Name == name)
-			{
-				return scriptReference.Handle;
-			}
-		}
-
-		return std::nullopt;
+		return id;
 	}
 
 	std::vector<std::string> ProjectSession::GetEditorScriptNames() const

--- a/Editor/Source/Ludus/Editor/Core/SelectionManager.cpp
+++ b/Editor/Source/Ludus/Editor/Core/SelectionManager.cpp
@@ -1,34 +1,35 @@
 #include "pch.h"
 
 #include <Ludus/Editor/Core/SelectionManager.h>
+#include <Ludus/Engine/Core/Id.h>
 
 namespace Ludus::Editor::Core
 {
-	void SelectionManager::SelectEntity(Ludus::Engine::Core::EntityHandle entity)
+	void SelectionManager::SelectEntity(Ludus::Engine::Core::EntityId id)
 	{
-		SelectedEntity = entity;
+		SelectedEntityId = id;
 	}
 
-	void SelectionManager::DeselectEntity(Ludus::Engine::Core::EntityHandle entity)
+	void SelectionManager::DeselectEntity(Ludus::Engine::Core::EntityId id)
 	{
-		if (SelectedEntity == entity)
+		if (SelectedEntityId == id)
 		{
-			SelectedEntity = std::nullopt;
+			SelectedEntityId = std::nullopt;
 		}
 	}
 
 	void SelectionManager::ClearSelection()
 	{
-		SelectedEntity = std::nullopt;
+		SelectedEntityId = std::nullopt;
 	}
 
 	bool SelectionManager::HasEntity() const
 	{
-		return SelectedEntity.has_value();
+		return SelectedEntityId.has_value();
 	}
 
-	bool SelectionManager::IsSelected(Ludus::Engine::Core::EntityHandle entity) const
+	bool SelectionManager::IsSelected(Ludus::Engine::Core::EntityId id) const
 	{
-		return SelectedEntity == entity;
+		return SelectedEntityId == id;
 	}
 }

--- a/Editor/Source/Ludus/Editor/Dialogs/AddScriptDialog.cpp
+++ b/Editor/Source/Ludus/Editor/Dialogs/AddScriptDialog.cpp
@@ -2,13 +2,13 @@
 
 #include <string>
 #include <type_traits>
-#include <unordered_map>
 #include <vector>
 
 #include <Ludus/Editor/Core/Constants.h>
 #include <Ludus/Editor/Dialogs/AddScriptDialog.h>
 #include <Ludus/Editor/Persistence/ProjectPaths.h>
 #include <Ludus/Engine/Core/Entity.h>
+#include <Ludus/Engine/Core/Id.h>
 #include <Ludus/Engine/Core/Scene.h>
 #include <Ludus/UI/Context/LayoutContext.h>
 #include <Ludus/UI/Context/PopupContext.h>
@@ -27,15 +27,15 @@
 namespace Ludus::Editor::Dialogs
 {
 	AddScriptDialog::AddScriptDialog(
-		Ludus::Engine::Core::EntityHandle entityHandle,
-		Ludus::Engine::Core::SceneHandle sceneHandle,
+		Ludus::Engine::Core::SceneId sceneId,
+		Ludus::Engine::Core::EntityId entityId,
 		std::vector<std::string> scriptNames,
-		std::unordered_map<std::string, Ludus::Engine::Components::ScriptHandle> scriptHandlesByName
+		std::vector<Ludus::Engine::Runtime::ScriptReference> scriptReferences
 	) :
-		EntityHandle(entityHandle),
-		SceneHandle(sceneHandle),
+		SceneId(sceneId),
+		EntityId(entityId),
 		ScriptNames(std::move(scriptNames)),
-		ScriptHandlesByName(std::move(scriptHandlesByName))
+		ScriptReferences(std::move(scriptReferences))
 	{ }
 
 	AddScriptDialog::Outcome AddScriptDialog::Draw()
@@ -127,9 +127,16 @@ namespace Ludus::Editor::Dialogs
 					if (ActiveTab == AddScriptTab::Create)
 					{
 						Error = Ludus::Editor::Persistence::ProjectPaths::ValidateFileName(CreateName);
-						if (Error.empty() && ScriptHandlesByName.find(CreateName) != ScriptHandlesByName.end())
+						if (Error.empty())
 						{
-							Error = "Script already exists.";
+							for (const auto& scriptReference : ScriptReferences)
+							{
+								if (scriptReference.Name == CreateName)
+								{
+									Error = "Script already exists.";
+									break;
+								}
+							}
 						}
 
 						if (!Error.empty())
@@ -180,21 +187,24 @@ namespace Ludus::Editor::Dialogs
 				if (ActiveTab == AddScriptTab::Create)
 				{
 					out.RequestCommands.emplace_back(
-						Ludus::Editor::Commands::RequestCommand::CreateScript { EntityHandle, SceneHandle, value.Payload }
+						Ludus::Editor::Commands::RequestCommand::CreateScript { SceneId, EntityId, value.Payload }
 					);
 					return;
 				}
 
-				const auto handle = ScriptHandlesByName.find(value.Payload);
-				if (handle == ScriptHandlesByName.end())
+				for (const auto& scriptReference : ScriptReferences)
 				{
+					if (scriptReference.Name != value.Payload)
+					{
+						continue;
+					}
+
+					out.EditCommands.emplace_back(
+						Ludus::Editor::Commands::EditCommand::AddComponent<Ludus::Engine::Components::ScriptComponent> {
+						.SceneId = SceneId, .EntityReference = EntityId, .Init = Ludus::Engine::Components::ScriptComponent { scriptReference.Id }
+					});
 					return;
 				}
-
-				out.EditCommands.emplace_back(
-					Ludus::Editor::Commands::EditCommand::AddComponent<Ludus::Engine::Components::ScriptComponent> {
-					.EntityReference = EntityHandle, .SceneHandle = SceneHandle, .Init = Ludus::Engine::Components::ScriptComponent { value.Payload, handle->second }
-				});
 			}
 		}, outcome.Data);
 	}

--- a/Editor/Source/Ludus/Editor/Dialogs/RenameSceneDialog.cpp
+++ b/Editor/Source/Ludus/Editor/Dialogs/RenameSceneDialog.cpp
@@ -6,6 +6,7 @@
 #include <Ludus/Editor/Core/Constants.h>
 #include <Ludus/Editor/Dialogs/RenameSceneDialog.h>
 #include <Ludus/Editor/Persistence/ProjectPaths.h>
+#include <Ludus/Engine/Core/Id.h>
 #include <Ludus/UI/Context/LayoutContext.h>
 #include <Ludus/UI/Context/PopupContext.h>
 #include <Ludus/UI/Context/ThemeContext.h>
@@ -17,8 +18,8 @@
 
 namespace Ludus::Editor::Dialogs
 {
-	RenameSceneDialog::RenameSceneDialog(Ludus::Engine::Core::SceneHandle sceneHandle, std::filesystem::path currentPath)
-		: SceneHandle(sceneHandle), CurrentPath(currentPath)
+	RenameSceneDialog::RenameSceneDialog(Ludus::Engine::Core::SceneId sceneId, std::filesystem::path currentPath)
+		: SceneId(sceneId), CurrentPath(currentPath)
 	{ }
 
 	RenameSceneDialog::Outcome RenameSceneDialog::Draw()
@@ -55,7 +56,7 @@ namespace Ludus::Editor::Dialogs
 				if (Error.empty())
 				{
 					IsOpen = false;
-					return Outcome::Confirm({ .SceneHandle = SceneHandle, .Path = NewPath });
+					return Outcome::Confirm({ .SceneId = SceneId, .Path = NewPath });
 				}
 			}
 
@@ -91,7 +92,7 @@ namespace Ludus::Editor::Dialogs
 			else if constexpr (std::is_same_v<Alt, typename Outcome::Confirmed>)
 			{
 				out.RequestCommands.emplace_back(
-					Ludus::Editor::Commands::RequestCommand::RenameScene { value.Payload.SceneHandle, value.Payload.Path }
+					Ludus::Editor::Commands::RequestCommand::RenameScene { value.Payload.SceneId, value.Payload.Path }
 				);
 			}
 		}, outcome.Data);

--- a/Editor/Source/Ludus/Editor/Panels/DockPanel.cpp
+++ b/Editor/Source/Ludus/Editor/Panels/DockPanel.cpp
@@ -15,6 +15,7 @@
 #include <Ludus/Editor/Panels/DockPanel.h>
 #include <Ludus/Editor/Panels/PanelRegistry.h>
 #include <Ludus/Editor/Persistence/ProjectPaths.h>
+#include <Ludus/Engine/Core/Id.h>
 #include <Ludus/Engine/Core/SceneRegistry.h>
 #include <Ludus/Engine/Persistence/Paths.h>
 #include <Ludus/Engine/Platform/Modals.h>
@@ -95,15 +96,15 @@ namespace Ludus::Editor::Panels
 
 					if (Ludus::UI::Widgets::MenuItem("Save"))
 					{
-						const auto activeHandle = context.ProjectSession.EditorState.ActiveSceneHandle;
-						if (!context.ProjectSession.GetSceneRegistry().Contains(activeHandle))
+						const auto activeSceneId = context.ProjectSession.EditorState.ActiveSceneId;
+						if (!context.ProjectSession.GetSceneRegistry().Contains(activeSceneId))
 						{
 							return;
 						}
 
 						if (context.ProjectSession.ActiveSceneHasSavePath())
 						{
-							context.Shell.State.Commands.AddRequestCommand(Ludus::Editor::Commands::RequestCommand::SaveScene { .SceneHandle = activeHandle });
+							context.Shell.State.Commands.AddRequestCommand(Ludus::Editor::Commands::RequestCommand::SaveScene { .SceneId = activeSceneId });
 						}
 						else
 						{
@@ -115,15 +116,15 @@ namespace Ludus::Editor::Panels
 								"Untitled"
 							))
 							{
-								context.Shell.State.Commands.AddRequestCommand(Ludus::Editor::Commands::RequestCommand::SaveSceneAs { .SceneHandle = activeHandle, .Path = path });
+								context.Shell.State.Commands.AddRequestCommand(Ludus::Editor::Commands::RequestCommand::SaveSceneAs { .SceneId = activeSceneId, .Path = path });
 							}
 						}
 					}
 
 					if (Ludus::UI::Widgets::MenuItem("Save As"))
 					{
-						const auto activeHandle = context.ProjectSession.EditorState.ActiveSceneHandle;
-						if (!context.ProjectSession.GetSceneRegistry().Contains(activeHandle))
+						const auto activeSceneId = context.ProjectSession.EditorState.ActiveSceneId;
+						if (!context.ProjectSession.GetSceneRegistry().Contains(activeSceneId))
 						{
 							return;
 						}
@@ -136,7 +137,7 @@ namespace Ludus::Editor::Panels
 							"Untitled"
 						))
 						{
-							context.Shell.State.Commands.AddRequestCommand(Ludus::Editor::Commands::RequestCommand::SaveSceneAs { .SceneHandle = activeHandle, .Path = path });
+							context.Shell.State.Commands.AddRequestCommand(Ludus::Editor::Commands::RequestCommand::SaveSceneAs { .SceneId = activeSceneId, .Path = path });
 						}
 					}
 				}
@@ -164,6 +165,13 @@ namespace Ludus::Editor::Panels
 
 				if (Ludus::UI::Widgets::MenuItem("Close Project"))
 				{
+					if (context.Shell.State.Execution.ExecutionMode != Ludus::Editor::Core::ExecutionMode::Stop)
+					{
+						context.Shell.State.Commands.AddRequestCommand(
+							Ludus::Editor::Commands::RequestCommand::SetExecutionMode { Ludus::Editor::Core::ExecutionMode::Stop }
+						);
+					}
+
 					context.Shell.State.Commands.AddRequestCommand(Ludus::Editor::Commands::RequestCommand::CloseProject { });
 				}
 			}

--- a/Editor/Source/Ludus/Editor/Panels/HierarchyPanel.cpp
+++ b/Editor/Source/Ludus/Editor/Panels/HierarchyPanel.cpp
@@ -8,6 +8,7 @@
 #include <Ludus/Editor/Commands/Enqueue.h>
 #include <Ludus/Editor/Core/Constants.h>
 #include <Ludus/Editor/Panels/HierarchyPanel.h>
+#include <Ludus/Engine/Core/Id.h>
 #include <Ludus/Engine/Core/Scene.h>
 #include <Ludus/Engine/Core/SceneRegistry.h>
 #include <Ludus/Engine/Debug/Debug.h>
@@ -41,36 +42,36 @@ namespace Ludus::Editor::Panels
 		}
 	}
 
-	void HierarchyPanel::DrawEntityRow(Ludus::Editor::Core::ProjectSessionContext& context, Ludus::Engine::Core::Scene& scene, Ludus::Engine::Core::EntityHandle entityHandle)
+	void HierarchyPanel::DrawEntityRow(Ludus::Editor::Core::ProjectSessionContext& context, Ludus::Engine::Core::Scene& scene, Ludus::Engine::Core::EntityId entityId)
 	{
 		auto& selection = context.ProjectSession.EditorState.Selection;
 		auto& ecs = scene.EntityComponentSystem;
-		const auto sceneHandle = scene.Handle;
+		const auto sceneId = scene.Id;
 
-		const auto* displayNamePtr = ecs.DisplayNames.TryGetByOwner(entityHandle);
+		const auto* displayNamePtr = ecs.DisplayNames.TryGetByOwner(entityId);
 		LUDUS_ASSERT(displayNamePtr != nullptr, "An entity must have a DisplayNameComponent.");
 		const auto entityLabel = displayNamePtr != nullptr
-			? Ludus::UI::CreateLabelWithIcon(ICON_CUBE, displayNamePtr->Name, std::to_string(entityHandle))
-			: Ludus::UI::CreateLabelWithIcon(ICON_CUBE, std::format("Entity {}", entityHandle), std::to_string(entityHandle));
+			? Ludus::UI::CreateLabelWithIcon(ICON_CUBE, displayNamePtr->Name, std::to_string(entityId.Value))
+			: Ludus::UI::CreateLabelWithIcon(ICON_CUBE, std::format("Entity {}", entityId.Value), std::to_string(entityId.Value));
 
-		if (Ludus::UI::Widgets::Selectable(entityLabel.c_str(), selection.IsSelected(entityHandle)))
+		if (Ludus::UI::Widgets::Selectable(entityLabel.c_str(), selection.IsSelected(entityId)))
 		{
-			Commands::EnqueueEdit(context.Shell.State.Commands, Commands::EditCommand::SelectEntity { entityHandle });
+			Commands::EnqueueEdit(context.Shell.State.Commands, Commands::EditCommand::SelectEntity { entityId });
 		}
 
 		if (Ludus::UI::Scope::PopupContextItemScope contextItem; contextItem)
 		{
 			if (Ludus::UI::Widgets::MenuItem("Select"))
 			{
-				Commands::EnqueueEdit(context.Shell.State.Commands, Commands::EditCommand::SelectEntity { entityHandle });
+				Commands::EnqueueEdit(context.Shell.State.Commands, Commands::EditCommand::SelectEntity { entityId });
 			}
 
 			Ludus::UI::Context::LayoutContext::Separator();
 
 			if (Ludus::UI::Widgets::MenuItem("Remove"))
 			{
-				Commands::EnqueueEdit(context.Shell.State.Commands, Commands::EditCommand::RemoveEntity { .EntityReference = entityHandle, .SceneHandle = sceneHandle });
-				Commands::EnqueueEdit(context.Shell.State.Commands, Commands::EditCommand::DeselectEntity { entityHandle });
+				Commands::EnqueueEdit(context.Shell.State.Commands, Commands::EditCommand::RemoveEntity { .SceneId = sceneId, .EntityReference = entityId });
+				Commands::EnqueueEdit(context.Shell.State.Commands, Commands::EditCommand::DeselectEntity { entityId });
 			}
 
 			Ludus::UI::Context::LayoutContext::Separator();
@@ -79,57 +80,57 @@ namespace Ludus::Editor::Panels
 			{
 				auto isComponentAdded = false;
 
-				if (MenuItemConditional("Camera 2D", !ecs.Cameras.ContainsOwner(entityHandle)))
+				if (MenuItemConditional("Camera 2D", !ecs.Cameras.ContainsOwner(entityId)))
 				{
 					Commands::EnqueueEdit(context.Shell.State.Commands, Commands::EditCommand::AddComponent<Component::Camera2DComponent> {
-						.EntityReference = entityHandle, .SceneHandle = sceneHandle
+						.SceneId = sceneId, .EntityReference = entityId
 					});
 					isComponentAdded = true;
 				}
 
-				if (MenuItemConditional("Collider 2D", !ecs.Colliders.ContainsOwner(entityHandle)))
+				if (MenuItemConditional("Collider 2D", !ecs.Colliders.ContainsOwner(entityId)))
 				{
 					Commands::EnqueueEdit(context.Shell.State.Commands, Commands::EditCommand::AddComponent<Component::Collider2DComponent> {
-						.EntityReference = entityHandle, .SceneHandle = sceneHandle
+						.SceneId = sceneId, .EntityReference = entityId
 					});
 					isComponentAdded = true;
 				}
 
-				if (MenuItemConditional("Rigidbody 2D", !ecs.RigidBodies.ContainsOwner(entityHandle)))
+				if (MenuItemConditional("Rigidbody 2D", !ecs.RigidBodies.ContainsOwner(entityId)))
 				{
 					Commands::EnqueueEdit(context.Shell.State.Commands, Commands::EditCommand::AddComponent<Component::RigidBody2DComponent> {
-						.EntityReference = entityHandle, .SceneHandle = sceneHandle
+						.SceneId = sceneId, .EntityReference = entityId
 					});
 					isComponentAdded = true;
 				}
 
-				if (MenuItemConditional("Script", !ecs.Scripts.ContainsOwner(entityHandle)))
+				if (MenuItemConditional("Script", !ecs.Scripts.ContainsOwner(entityId)))
 				{
 					Commands::EnqueueUI(context.Shell.State.Commands, Commands::UICommand::OpenAddScriptDialog {
-						.EntityHandle = entityHandle, .SceneHandle = sceneHandle
+						.SceneId = sceneId, .EntityId = entityId
 						});
 					// The added component will be selected later as part of the command chain.
 				}
 
-				if (MenuItemConditional("Sprite 2D", !ecs.Sprites.ContainsOwner(entityHandle)))
+				if (MenuItemConditional("Sprite 2D", !ecs.Sprites.ContainsOwner(entityId)))
 				{
 					Commands::EnqueueEdit(context.Shell.State.Commands, Commands::EditCommand::AddComponent<Component::Sprite2DComponent> {
-						.EntityReference = entityHandle, .SceneHandle = sceneHandle
+						.SceneId = sceneId, .EntityReference = entityId
 					});
 					isComponentAdded = true;
 				}
 
-				if (MenuItemConditional("Text 2D", !ecs.Texts.ContainsOwner(entityHandle)))
+				if (MenuItemConditional("Text 2D", !ecs.Texts.ContainsOwner(entityId)))
 				{
 					Commands::EnqueueEdit(context.Shell.State.Commands, Commands::EditCommand::AddComponent<Component::Text2DComponent> {
-						.EntityReference = entityHandle, .SceneHandle = sceneHandle
+						.SceneId = sceneId, .EntityReference = entityId
 					});
 					isComponentAdded = true;
 				}
 
 				if (isComponentAdded)
 				{
-					Commands::EnqueueEdit(context.Shell.State.Commands, Commands::EditCommand::SelectEntity { .EntityReference = entityHandle });
+					Commands::EnqueueEdit(context.Shell.State.Commands, Commands::EditCommand::SelectEntity { .EntityReference = entityId });
 				}
 			}
 		}
@@ -143,21 +144,19 @@ namespace Ludus::Editor::Panels
 		if (Ludus::UI::Scope::PopupContextWindowScope contextWindow("HierarchyWindowContext", flags); contextWindow)
 		{
 			auto entityReference = Commands::EntityReference::Temporary(Commands::TempReference { m_Random.NextId() });
-			const auto sceneHandle = scene.Handle;
+			const auto sceneId = scene.Id;
 			bool isEntityAdded = false;
 
 			auto enqueueAddEntity = [&](const Commands::EntityReference& reference)
 			{
-				Commands::EnqueueEdit(context.Shell.State.Commands, Commands::EditCommand::AddEntity { .EntityReference = reference, .SceneHandle = sceneHandle });
+				Commands::EnqueueEdit(context.Shell.State.Commands, Commands::EditCommand::AddEntity { .SceneId = sceneId, .EntityReference = reference });
 			};
 
 			auto enqueueAddComponent = [&](auto init)
 			{
 				using Component = std::decay_t<decltype(init)>;
 				Commands::EnqueueEdit(context.Shell.State.Commands, Commands::EditCommand::AddComponent<Component> {
-					.EntityReference = entityReference,
-						.SceneHandle = sceneHandle,
-						.Init = std::move(init)
+					.SceneId = sceneId, .EntityReference = entityReference, .Init = std::move(init)
 				});
 			};
 
@@ -244,12 +243,12 @@ namespace Ludus::Editor::Panels
 			{
 				if (Ludus::UI::Widgets::MenuItem("Rename"))
 				{
-					Commands::EnqueueUI(context.Shell.State.Commands, Commands::UICommand::OpenRenameSceneDialog { .SceneHandle = scene.Handle });
+					Commands::EnqueueUI(context.Shell.State.Commands, Commands::UICommand::OpenRenameSceneDialog { .SceneId = scene.Id });
 				}
 
 				if (Ludus::UI::Widgets::MenuItem("Save"))
 				{
-					Commands::EnqueueRequest(context.Shell.State.Commands, Commands::RequestCommand::SaveScene { .SceneHandle = scene.Handle });
+					Commands::EnqueueRequest(context.Shell.State.Commands, Commands::RequestCommand::SaveScene { .SceneId = scene.Id });
 				}
 			}
 
@@ -257,7 +256,7 @@ namespace Ludus::Editor::Panels
 
 			for (const auto& entity : scene.EntityComponentSystem.View())
 			{
-				DrawEntityRow(context, scene, entity.Handle);
+				DrawEntityRow(context, scene, entity.Id);
 			}
 
 			if (Ludus::UI::Context::InputContext::IsMouseClicked(Ludus::Engine::Windowing::MouseButton::Left) &&
@@ -276,7 +275,7 @@ namespace Ludus::Editor::Panels
 		{
 			auto& registry = context.ProjectSession.GetSceneRegistry();
 
-			const auto selectedScene = context.ProjectSession.EditorState.ActiveSceneHandle;
+			const auto selectedScene = context.ProjectSession.EditorState.ActiveSceneId;
 			if (!registry.Contains(selectedScene))
 			{
 				// No scene available.

--- a/Editor/Source/Ludus/Editor/Panels/InspectorPanel.cpp
+++ b/Editor/Source/Ludus/Editor/Panels/InspectorPanel.cpp
@@ -20,6 +20,7 @@
 #include <Ludus/Engine/Components/Transform2DComponent.h>
 #include <Ludus/Engine/Core/Entity.h>
 #include <Ludus/Engine/Core/Enums.h>
+#include <Ludus/Engine/Core/Id.h>
 #include <Ludus/Engine/Core/SceneRegistry.h>
 #include <Ludus/Engine/Graphics/Color.h>
 #include <Ludus/Engine/Graphics/HorizontalTextAlignment.h>
@@ -54,7 +55,6 @@
 
 namespace Ludus::Editor::Panels
 {
-
 	namespace
 	{
 		namespace Component = Ludus::Engine::Components;
@@ -76,25 +76,29 @@ namespace Ludus::Editor::Panels
 
 		bool InputFloatFill(
 			const std::string& label,
-			float* value,
-			float step = 0.0f,
-			float step_fast = 0.0f,
-			const char* format = "%.2f",
-			Ludus::UI::Flags::InputText flags = Ludus::UI::Flags::InputText::None
+			float* value
 		)
 		{
 			Ludus::UI::Context::LayoutContext::SetNextItemWidthFill();
-			return Ludus::UI::Widgets::InputFloat(label, value, step, step_fast, format, flags);
+			return Ludus::UI::Widgets::InputFloat(label, value);
+		}
+
+		bool InputIntFill(
+			const std::string& label,
+			int* value
+		)
+		{
+			Ludus::UI::Context::LayoutContext::SetNextItemWidthFill();
+			return Ludus::UI::Widgets::InputInt(label, value);
 		}
 
 		bool InputTextFill(
 			const std::string& label,
-			std::string& text,
-			Ludus::UI::Flags::InputText flags = Ludus::UI::Flags::InputText::None
+			std::string& text
 		)
 		{
 			Ludus::UI::Context::LayoutContext::SetNextItemWidthFill();
-			return Ludus::UI::Widgets::InputText(label, text, flags);
+			return Ludus::UI::Widgets::InputText(label, text);
 		}
 
 		template<typename TEnum>
@@ -136,8 +140,8 @@ namespace Ludus::Editor::Panels
 				{
 					context.Shell.State.Commands.AddEditCommand(
 						Ludus::Editor::Commands::EditCommand::RemoveComponent<TComponent>(
-							component.OwnerHandle,
-							context.ProjectSession.GetActiveRuntime().GetScenePresentationState().CurrentSceneHandle
+							context.ProjectSession.GetActiveRuntime().GetScenePresentationState().CurrentSceneId,
+							component.OwnerId
 						)
 					);
 
@@ -257,9 +261,13 @@ namespace Ludus::Editor::Panels
 
 				Ludus::UI::Context::TableContext::TableNextRowFirstColumn();
 				DrawInspectorLabel("Orthographic Size");
-
 				Ludus::UI::Context::TableContext::TableSetColumnIndex(1);
 				changed |= InputFloatFill("##Camera2D_Panel_OrthographicSize", &component.OrthographicSize);
+
+				Ludus::UI::Context::TableContext::TableNextRowFirstColumn();
+				DrawInspectorLabel("Priority");
+				Ludus::UI::Context::TableContext::TableSetColumnIndex(1);
+				changed |= InputIntFill("##Camera2D_Panel_Priority", &component.Priority);
 			}
 		}
 
@@ -393,7 +401,8 @@ namespace Ludus::Editor::Panels
 				DrawInspectorLabel("Name");
 				Ludus::UI::Context::TableContext::TableSetColumnIndex(1);
 
-				auto scriptReferences = context.ProjectSession.GetEditorManifest().Scripts;
+				const auto& editorManifest = context.ProjectSession.GetEditorManifest();
+				const auto& scriptReferences = editorManifest.Scripts;
 				if (scriptReferences.empty())
 				{
 					const auto noneValues = { "None" };
@@ -407,50 +416,38 @@ namespace Ludus::Editor::Panels
 					// The variable passed to Combo must be an integer. 
 					auto currentIndex = -1;
 
-					// Check for handle.
 					for (auto i = 0; i < static_cast<int>(scriptReferences.size()); i++)
 					{
 						const auto& reference = scriptReferences[static_cast<size_t>(i)];
-						if (reference.Handle == component.Handle)
+						if (reference.Id == component.Id)
 						{
 							currentIndex = i;
 							break;
 						}
 					}
 
-					// Check for name.
 					if (currentIndex < 0)
 					{
-						for (auto i = 0; i < static_cast<int>(scriptReferences.size()); i++)
+						const auto missingValues = { "Missing Script Reference" };
+						auto missingIndex = 0;
+
+						Ludus::UI::Scope::DisabledScope disabled(true);
+						auto _ = ComboFill("##Script_Panel_Name", &missingIndex, missingValues);
+					}
+					else
+					{
+						auto items = Ludus::UI::Widgets::GetCStringItems(scriptReferences, [](const Ludus::Engine::Runtime::ScriptReference& item)
 						{
-							const auto& reference = scriptReferences[static_cast<size_t>(i)];
-							if (reference.Name == component.Name)
-							{
-								currentIndex = i;
-								break;
-							}
+							return item.Name.c_str();
+						});
+
+						if (ComboFill("##Script_Panel_Name", &currentIndex, items))
+						{
+							const auto& selected = scriptReferences[static_cast<size_t>(currentIndex)];
+							component.Id = selected.Id;
+
+							changed = true;
 						}
-					}
-
-					// Default to first item.
-					if (currentIndex < 0)
-					{
-						currentIndex = 0;
-					}
-
-					auto items = Ludus::UI::Widgets::GetCStringItems(scriptReferences, [](const Ludus::Engine::Runtime::ScriptReference& item)
-					{
-						return item.Name.c_str();
-					});
-
-					if (ComboFill("##Script_Panel_Name", &currentIndex, items))
-					{
-						const auto& selected = scriptReferences[static_cast<size_t>(currentIndex)];
-
-						component.Name = selected.Name;
-						component.Handle = selected.Handle;
-
-						changed = true;
 					}
 				}
 			}
@@ -535,17 +532,17 @@ namespace Ludus::Editor::Panels
 
 			auto& registry = context.ProjectSession.GetSceneRegistry();
 
-			auto activeSceneHandle = context.ProjectSession.EditorState.ActiveSceneHandle;
-			if (!registry.Contains(activeSceneHandle))
+			auto activeSceneId = context.ProjectSession.EditorState.ActiveSceneId;
+			if (!registry.Contains(activeSceneId))
 			{
 				return true;
 			}
 
-			auto& scene = registry.GetScene(activeSceneHandle);
+			auto& scene = registry.GetScene(activeSceneId);
 
 			auto& ecs = scene.EntityComponentSystem;
-			auto entityHandle = *selection.SelectedEntity;
-			if (!ecs.IndexOf(entityHandle))
+			auto entityId = *selection.SelectedEntityId;
+			if (!ecs.IndexOf(entityId))
 			{
 				context.Shell.State.Commands.AddEditCommand(
 					Ludus::Editor::Commands::EditCommand::ClearSelection { }
@@ -556,8 +553,8 @@ namespace Ludus::Editor::Panels
 			bool changed = false;
 
 			// Draw required components.
-			auto* transformPtr = ecs.Transforms.TryGetByOwnerMutable(entityHandle);
-			auto* displayNamePtr = ecs.DisplayNames.TryGetByOwnerMutable(entityHandle);
+			auto* transformPtr = ecs.Transforms.TryGetByOwnerMutable(entityId);
+			auto* displayNamePtr = ecs.DisplayNames.TryGetByOwnerMutable(entityId);
 
 			if (!displayNamePtr || !transformPtr)
 			{
@@ -568,12 +565,12 @@ namespace Ludus::Editor::Panels
 			changed |= DrawTransform2D(*transformPtr);
 
 			// Draw remaining components.
-			auto* colliderPtr = ecs.Colliders.TryGetByOwnerMutable(entityHandle);
-			auto* rigidBodyPtr = ecs.RigidBodies.TryGetByOwnerMutable(entityHandle);
-			auto* scriptPtr = ecs.Scripts.TryGetByOwnerMutable(entityHandle);
-			auto* spritePtr = ecs.Sprites.TryGetByOwnerMutable(entityHandle);
-			auto* textPtr = ecs.Texts.TryGetByOwnerMutable(entityHandle);
-			auto* cameraPtr = ecs.Cameras.TryGetByOwnerMutable(entityHandle);
+			auto* colliderPtr = ecs.Colliders.TryGetByOwnerMutable(entityId);
+			auto* rigidBodyPtr = ecs.RigidBodies.TryGetByOwnerMutable(entityId);
+			auto* scriptPtr = ecs.Scripts.TryGetByOwnerMutable(entityId);
+			auto* spritePtr = ecs.Sprites.TryGetByOwnerMutable(entityId);
+			auto* textPtr = ecs.Texts.TryGetByOwnerMutable(entityId);
+			auto* cameraPtr = ecs.Cameras.TryGetByOwnerMutable(entityId);
 
 			if (cameraPtr)
 			{
@@ -637,57 +634,57 @@ namespace Ludus::Editor::Panels
 			{
 				auto isComponentAdded = false;
 
-				if (!ecs.Cameras.ContainsOwner(entityHandle) && Ludus::UI::Widgets::MenuItem("Camera 2D"))
+				if (!ecs.Cameras.ContainsOwner(entityId) && Ludus::UI::Widgets::MenuItem("Camera 2D"))
 				{
 					Commands::EnqueueEdit(context.Shell.State.Commands, Commands::EditCommand::AddComponent<Component::Camera2DComponent> {
-						.EntityReference = entityHandle, .SceneHandle = activeSceneHandle
+						.SceneId = activeSceneId, .EntityReference = entityId
 					});
 					isComponentAdded = true;
 				}
 
-				if (!ecs.Colliders.ContainsOwner(entityHandle) && Ludus::UI::Widgets::MenuItem("Collider 2D"))
+				if (!ecs.Colliders.ContainsOwner(entityId) && Ludus::UI::Widgets::MenuItem("Collider 2D"))
 				{
 					Commands::EnqueueEdit(context.Shell.State.Commands, Commands::EditCommand::AddComponent<Component::Collider2DComponent> {
-						.EntityReference = entityHandle, .SceneHandle = activeSceneHandle
+						.SceneId = activeSceneId, .EntityReference = entityId
 					});
 					isComponentAdded = true;
 				}
 
-				if (!ecs.RigidBodies.ContainsOwner(entityHandle) && Ludus::UI::Widgets::MenuItem("Rigid Body 2D"))
+				if (!ecs.RigidBodies.ContainsOwner(entityId) && Ludus::UI::Widgets::MenuItem("Rigid Body 2D"))
 				{
 					Commands::EnqueueEdit(context.Shell.State.Commands, Commands::EditCommand::AddComponent<Component::RigidBody2DComponent> {
-						.EntityReference = entityHandle, .SceneHandle = activeSceneHandle
+						.SceneId = activeSceneId, .EntityReference = entityId
 					});
 					isComponentAdded = true;
 				}
 
-				if (!ecs.Scripts.ContainsOwner(entityHandle) && Ludus::UI::Widgets::MenuItem("Script"))
+				if (!ecs.Scripts.ContainsOwner(entityId) && Ludus::UI::Widgets::MenuItem("Script"))
 				{
 					Commands::EnqueueUI(context.Shell.State.Commands, Commands::UICommand::OpenAddScriptDialog {
-						.EntityHandle = entityHandle, .SceneHandle = activeSceneHandle
+						.SceneId = activeSceneId, .EntityId = entityId
 						});
 					// The added component will be selected later as part of the command chain.
 				}
 
-				if (!ecs.Sprites.ContainsOwner(entityHandle) && Ludus::UI::Widgets::MenuItem("Sprite 2D"))
+				if (!ecs.Sprites.ContainsOwner(entityId) && Ludus::UI::Widgets::MenuItem("Sprite 2D"))
 				{
 					Commands::EnqueueEdit(context.Shell.State.Commands, Commands::EditCommand::AddComponent<Component::Sprite2DComponent> {
-						.EntityReference = entityHandle, .SceneHandle = activeSceneHandle
+						.SceneId = activeSceneId, .EntityReference = entityId
 					});
 					isComponentAdded = true;
 				}
 
-				if (!ecs.Texts.ContainsOwner(entityHandle) && Ludus::UI::Widgets::MenuItem("Text 2D"))
+				if (!ecs.Texts.ContainsOwner(entityId) && Ludus::UI::Widgets::MenuItem("Text 2D"))
 				{
 					Commands::EnqueueEdit(context.Shell.State.Commands, Commands::EditCommand::AddComponent<Component::Text2DComponent> {
-						.EntityReference = entityHandle, .SceneHandle = activeSceneHandle
+						.SceneId = activeSceneId, .EntityReference = entityId
 					});
 					isComponentAdded = true;
 				}
 
 				if (isComponentAdded)
 				{
-					Commands::EnqueueEdit(context.Shell.State.Commands, Commands::EditCommand::SelectEntity { .EntityReference = entityHandle });
+					Commands::EnqueueEdit(context.Shell.State.Commands, Commands::EditCommand::SelectEntity { .EntityReference = entityId });
 					Ludus::UI::Context::PopupContext::CloseCurrentPopup();
 				}
 			}

--- a/Editor/Source/Ludus/Editor/Panels/ViewportPanel.cpp
+++ b/Editor/Source/Ludus/Editor/Panels/ViewportPanel.cpp
@@ -8,6 +8,7 @@
 #include <Ludus/Editor/Core/Constants.h>
 #include <Ludus/Editor/Core/ViewportDisplayMode.h>
 #include <Ludus/Editor/Panels/ViewportPanel.h>
+#include <Ludus/Engine/Core/Id.h>
 #include <Ludus/Engine/Core/RenderViewRequestRegistry.h>
 #include <Ludus/Engine/Core/SceneRegistry.h>
 #include <Ludus/Engine/Graphics/Color.h>
@@ -186,10 +187,10 @@ namespace Ludus::Editor::Panels
 
 			auto& registry = context.ProjectSession.GetSceneRegistry();
 
-			auto active = context.ProjectSession.EditorState.ActiveSceneHandle;
-			if (!m_SelectedSceneHandle || !registry.Contains(*m_SelectedSceneHandle))
+			auto active = context.ProjectSession.EditorState.ActiveSceneId;
+			if (!m_SelectedSceneId || !registry.Contains(*m_SelectedSceneId))
 			{
-				m_SelectedSceneHandle = active;
+				m_SelectedSceneId = active;
 			}
 
 			const auto& renderPresentationSettings = context.ProjectSession.GetRenderPresentationSettings();
@@ -233,7 +234,7 @@ namespace Ludus::Editor::Panels
 
 			Ludus::Engine::Graphics::RenderViewRequest2D renderViewRequest {
 				.Camera = camera,
-				.SceneHandle = m_SelectedSceneHandle,
+				.SceneId = m_SelectedSceneId,
 				.Target = &*m_Target,
 				.ViewportRect = Ludus::Engine::Math::Rect::Create(viewportPosition, aspectSize)
 			};

--- a/Editor/Source/Ludus/Editor/Persistence/ProjectSessionLoader.cpp
+++ b/Editor/Source/Ludus/Editor/Persistence/ProjectSessionLoader.cpp
@@ -1,6 +1,5 @@
 #include "pch.h"
 
-#include <optional>
 #include <stdexcept>
 #include <utility>
 
@@ -14,25 +13,6 @@
 
 namespace Ludus::Editor::Persistence
 {
-	namespace
-	{
-		std::optional<std::filesystem::path> TryFindScenePath(
-			const Ludus::Engine::Runtime::RuntimeManifest& runtimeManifest,
-			Ludus::Engine::Core::SceneHandle sceneHandle
-		)
-		{
-			for (const auto& sceneReference : runtimeManifest.Scenes)
-			{
-				if (sceneReference.Handle == sceneHandle)
-				{
-					return sceneReference.Path;
-				}
-			}
-
-			return std::nullopt;
-		}
-	}
-
 	ProjectSessionLoader::ProjectSessionLoader(
 		Ludus::Engine::Persistence::IScenePersistence& scenePersistence,
 		Ludus::Engine::Persistence::IRuntimeManifestPersistence& runtimeManifestPersistence,
@@ -51,13 +31,34 @@ namespace Ludus::Editor::Persistence
 	LoadedProjectData ProjectSessionLoader::Load(Ludus::Editor::Core::ProjectManifest projectManifest)
 	{
 		auto runtimeManifest = m_RuntimeManifestPersistence.Load(projectManifest.RuntimeManifestPath);
-		const auto scenePath = TryFindScenePath(runtimeManifest, runtimeManifest.EntrySceneHandle);
-		if (!scenePath)
+
+		const Ludus::Engine::Runtime::SceneReference* entrySceneReference = nullptr;
+		if (runtimeManifest.EntrySceneId.IsValid())
 		{
-			throw std::runtime_error("No scene path in runtime manifest.");
+			for (const auto& sceneReference : runtimeManifest.Scenes)
+			{
+				if (sceneReference.Id == runtimeManifest.EntrySceneId)
+				{
+					entrySceneReference = &sceneReference;
+					break;
+				}
+			}
 		}
 
-		auto scene = m_ScenePersistence.Load(*scenePath);
+		if (!entrySceneReference)
+		{
+			throw std::runtime_error("Runtime manifest entry scene was not found.");
+		}
+
+		auto scene = m_ScenePersistence.Load(entrySceneReference->Path);
+
+		for (const auto& script : scene.EntityComponentSystem.Scripts.View())
+		{
+			if (!runtimeManifest.TryGetScriptReference(script.Id))
+			{
+				throw std::runtime_error("Scene contains script id that is not present in the runtime manifest.");
+			}
+		}
 
 		return {
 			.ProjectManifest = std::move(projectManifest),

--- a/EditorTests/Ludus/EditorTests/Persistence/BuildPathsTests.cpp
+++ b/EditorTests/Ludus/EditorTests/Persistence/BuildPathsTests.cpp
@@ -26,29 +26,46 @@ namespace Ludus::EditorTests::Persistence
 
 	TEST(BuildPaths, BinDirectory_Should_ReturnBinPath)
 	{
+		// Arrange.
 		const auto projectRoot = std::filesystem::path("C:/Projects/Sandbox");
+
+		// Act.
 		const auto path = BuildPaths::BinDirectory(projectRoot);
+
+		// Assert.
 		ASSERT_EQ(path, projectRoot / "bin");
 	}
 
 	TEST(BuildPaths, ObjDirectory_Should_ReturnObjPath)
 	{
+		// Arrange.
 		const auto projectRoot = std::filesystem::path("C:/Projects/Sandbox");
+
+		// Act.
 		const auto path = BuildPaths::ObjDirectory(projectRoot);
+
+		// Assert.
 		ASSERT_EQ(path, projectRoot / "obj");
 	}
 
 	TEST(BuildPaths, BuildsDirectory_Should_ReturnBuildsPath)
 	{
+		// Arrange.
 		const auto projectRoot = std::filesystem::path("C:/Projects/Sandbox");
+
+		// Act.
 		const auto path = BuildPaths::BuildsDirectory(projectRoot);
+
+		// Assert.
 		ASSERT_EQ(path, projectRoot / "builds");
 	}
 
 	TEST(BuildPaths, RuntimeOutputDirectory_Should_ReturnRuntimeOutputPath)
 	{
+		// Arrange.
 		const auto projectRoot = std::filesystem::path("C:/Projects/Sandbox");
 
+		// Act.
 		const auto path = BuildPaths::RuntimeOutputDirectory(
 			projectRoot,
 			"Sandbox",
@@ -57,135 +74,193 @@ namespace Ludus::EditorTests::Persistence
 			Ludus::Editor::Build::BuildConfiguration::Release
 		);
 
+		// Assert.
 		ASSERT_EQ(path, projectRoot / "builds" / "Windows" / "x64" / "Release" / "Sandbox");
 	}
 
 	TEST(BuildPaths, ScriptsBinDirectory_Should_ReturnScriptsBinPath)
 	{
+		// Arrange.
 		const auto projectRoot = std::filesystem::path("C:/Projects/Sandbox");
+
+		// Act.
 		const auto path = BuildPaths::ScriptsBinDirectory(projectRoot);
+
+		// Assert.
 		ASSERT_EQ(path, projectRoot / "bin" / "Scripts");
 	}
 
 	TEST(BuildPaths, ScriptsBinDirectory_WithPlatformAndConfiguration_Should_ReturnScriptsBuildOutputPath)
 	{
+		// Arrange.
 		const auto projectRoot = std::filesystem::path("C:/Projects/Sandbox");
 
+		// Act.
 		const auto path = BuildPaths::ScriptsBinDirectory(
 			projectRoot,
 			Ludus::Editor::Build::BuildPlatform::WindowsX64,
 			Ludus::Editor::Build::BuildConfiguration::Release
 		);
 
+		// Assert.
 		ASSERT_EQ(path, projectRoot / "bin" / "Scripts" / "x64" / "Release");
 	}
 
 	TEST(BuildPaths, ScriptsObjDirectory_Should_ReturnScriptsObjPath)
 	{
+		// Arrange.
 		const auto projectRoot = std::filesystem::path("C:/Projects/Sandbox");
+
+		// Act.
 		const auto path = BuildPaths::ScriptsObjDirectory(projectRoot);
+
+		// Assert.
 		ASSERT_EQ(path, projectRoot / "obj" / "Scripts");
 	}
 
 	TEST(BuildPaths, ScriptsObjDirectory_WithPlatformAndConfiguration_Should_ReturnScriptsIntermediatePath)
 	{
+		// Arrange.
 		const auto projectRoot = std::filesystem::path("C:/Projects/Sandbox");
 
+		// Act.
 		const auto path = BuildPaths::ScriptsObjDirectory(
 			projectRoot,
 			Ludus::Editor::Build::BuildPlatform::WindowsX64,
 			Ludus::Editor::Build::BuildConfiguration::Debug
 		);
 
+		// Assert.
 		ASSERT_EQ(path, projectRoot / "obj" / "Scripts" / "x64" / "Debug");
 	}
 
 	TEST(BuildPaths, ScriptsDllFile_Should_ReturnScriptsDllPath)
 	{
+		// Arrange.
 		const auto projectRoot = std::filesystem::path("C:/Projects/Sandbox");
 
+		// Act.
 		const auto path = BuildPaths::ScriptsDllFile(
 			projectRoot,
 			Ludus::Editor::Build::BuildPlatform::WindowsX64,
 			Ludus::Editor::Build::BuildConfiguration::Release
 		);
 
+		// Assert.
 		ASSERT_EQ(path, projectRoot / "bin" / "Scripts" / "x64" / "Release" / "Scripts.dll");
 	}
 
 	TEST(BuildPaths, RuntimeHostBinDirectory_Should_ReturnRuntimeHostBinPath)
 	{
+		// Arrange.
 		const auto projectRoot = std::filesystem::path("C:/Projects/Sandbox");
+
+		// Act.
 		const auto path = BuildPaths::RuntimeHostBinDirectory(projectRoot);
+
+		// Assert.
 		ASSERT_EQ(path, projectRoot / "bin" / "RuntimeHost");
 	}
 
 	TEST(BuildPaths, RuntimeHostBinDirectory_WithPlatformAndConfiguration_Should_ReturnRuntimeHostBuildOutputPath)
 	{
+		// Arrange.
 		const auto projectRoot = std::filesystem::path("C:/Projects/Sandbox");
 
+		// Act.
 		const auto path = BuildPaths::RuntimeHostBinDirectory(
 			projectRoot,
 			Ludus::Editor::Build::BuildPlatform::WindowsX64,
 			Ludus::Editor::Build::BuildConfiguration::Debug
 		);
 
+		// Assert.
 		ASSERT_EQ(path, projectRoot / "bin" / "RuntimeHost" / "x64" / "Debug");
 	}
 
 	TEST(BuildPaths, RuntimeHostExecutableFile_Should_ReturnRuntimeHostExecutablePath)
 	{
+		// Arrange.
 		const auto runtimeHostRoot = std::filesystem::path("C:/Projects/Sandbox/bin/RuntimeHost/x64/Debug");
+
+		// Act.
 		const auto path = BuildPaths::RuntimeHostExecutableFile(runtimeHostRoot);
+
+		// Assert.
 		ASSERT_EQ(path, runtimeHostRoot / "RuntimeHost.exe");
 	}
 
 	TEST(BuildPaths, RuntimeExecutableFile_Should_ReturnRuntimeExecutablePath)
 	{
+		// Arrange.
 		const auto runtimeOutputRoot = std::filesystem::path("C:/Projects/Sandbox/builds/Windows/x64/Release/Sandbox");
+
+		// Act.
 		const auto path = BuildPaths::RuntimeExecutableFile(runtimeOutputRoot, "Sandbox");
+
+		// Assert.
 		ASSERT_EQ(path, runtimeOutputRoot / "Sandbox.exe");
 	}
 
 	TEST(BuildPaths, RuntimeHostObjDirectory_Should_ReturnRuntimeHostObjPath)
 	{
+		// Arrange.
 		const auto projectRoot = std::filesystem::path("C:/Projects/Sandbox");
+
+		// Act.
 		const auto path = BuildPaths::RuntimeHostObjDirectory(projectRoot);
+
+		// Assert.
 		ASSERT_EQ(path, projectRoot / "obj" / "RuntimeHost");
 	}
 
 	TEST(BuildPaths, RuntimeHostObjDirectory_WithPlatformAndConfiguration_Should_ReturnRuntimeHostIntermediatePath)
 	{
+		// Arrange.
 		const auto projectRoot = std::filesystem::path("C:/Projects/Sandbox");
 
+		// Act.
 		const auto path = BuildPaths::RuntimeHostObjDirectory(
 			projectRoot,
 			Ludus::Editor::Build::BuildPlatform::WindowsX64,
 			Ludus::Editor::Build::BuildConfiguration::Release
 		);
 
+		// Assert.
 		ASSERT_EQ(path, projectRoot / "obj" / "RuntimeHost" / "x64" / "Release");
 	}
 
 	TEST(BuildPaths, RuntimeHostModuleFile_Should_ReturnRuntimeHostModulePath)
 	{
+		// Arrange.
 		const auto projectRoot = std::filesystem::path("C:/Projects/Sandbox");
+
+		// Act.
 		const auto path = BuildPaths::RuntimeHostModuleFile(projectRoot);
+
+		// Assert.
 		ASSERT_EQ(path, projectRoot / "obj" / "RuntimeHost" / "RuntimeHostModule.cpp");
 	}
 
 	TEST(BuildPaths, RuntimeHostProjectFile_Should_ReturnRuntimeHostProjectPath)
 	{
+		// Arrange.
 		const auto projectRoot = std::filesystem::path("C:/Projects/Sandbox");
+
+		// Act.
 		const auto path = BuildPaths::RuntimeHostProjectFile(projectRoot);
+
+		// Assert.
 		ASSERT_EQ(path, projectRoot / "obj" / "RuntimeHost" / "RuntimeHost.vcxproj");
 	}
 
 	TEST(BuildPaths, EnsureRuntimeOutputDirectory_Should_CreateRuntimeOutputDirectories)
 	{
+		// Arrange.
 		const auto tempDirectoryScope = CreateTestDirectory();
 		const auto projectRoot = tempDirectoryScope.Path / "Sandbox";
 
+		// Act.
 		BuildPaths::EnsureRuntimeOutputDirectory(
 			projectRoot,
 			"Sandbox",
@@ -194,6 +269,7 @@ namespace Ludus::EditorTests::Persistence
 			Ludus::Editor::Build::BuildConfiguration::Release
 		);
 
+		// Assert.
 		const auto runtimeOutputDirectory = projectRoot / "builds" / "Windows" / "x64" / "Release" / "Sandbox";
 		ASSERT_TRUE(std::filesystem::exists(Ludus::Engine::Persistence::Paths::AssetsDirectory(runtimeOutputDirectory)));
 		ASSERT_TRUE(std::filesystem::exists(Ludus::Engine::Persistence::Paths::ResourcesDirectory(runtimeOutputDirectory)));
@@ -202,11 +278,14 @@ namespace Ludus::EditorTests::Persistence
 
 	TEST(BuildPaths, EnsureProjectScriptsBuildLayoutExists_Should_CreateScriptsBuildDirectories)
 	{
+		// Arrange.
 		const auto tempDirectoryScope = CreateTestDirectory();
 		const auto projectRoot = tempDirectoryScope.Path / "Sandbox";
 
+		// Act.
 		BuildPaths::EnsureProjectScriptsBuildLayoutExists(projectRoot);
 
+		// Assert.
 		ASSERT_TRUE(std::filesystem::exists(projectRoot / "bin" / "Scripts"));
 		ASSERT_TRUE(std::filesystem::is_directory(projectRoot / "bin" / "Scripts"));
 		ASSERT_TRUE(std::filesystem::exists(projectRoot / "obj" / "Scripts"));
@@ -215,11 +294,14 @@ namespace Ludus::EditorTests::Persistence
 
 	TEST(BuildPaths, EnsureProjectRuntimeHostBuildLayoutExists_Should_CreateRuntimeHostBuildDirectories)
 	{
+		// Arrange.
 		const auto tempDirectoryScope = CreateTestDirectory();
 		const auto projectRoot = tempDirectoryScope.Path / "Sandbox";
 
+		// Act.
 		BuildPaths::EnsureProjectRuntimeHostBuildLayoutExists(projectRoot);
 
+		// Assert.
 		ASSERT_TRUE(std::filesystem::exists(projectRoot / "bin" / "RuntimeHost"));
 		ASSERT_TRUE(std::filesystem::is_directory(projectRoot / "bin" / "RuntimeHost"));
 		ASSERT_TRUE(std::filesystem::exists(projectRoot / "obj" / "RuntimeHost"));

--- a/EditorTests/Ludus/EditorTests/Persistence/ProjectPathsTests.cpp
+++ b/EditorTests/Ludus/EditorTests/Persistence/ProjectPathsTests.cpp
@@ -24,166 +24,252 @@ namespace Ludus::EditorTests::Persistence
 
 	TEST(ProjectPaths, LudusRoot_Should_ReturnLocalAppDataLudusDirectory)
 	{
+		// Arrange.
 		const auto expected = Ludus::Engine::Platform::Paths::LocalAppData() / "Ludus";
+
+		// Act.
 		const auto path = ProjectPaths::LudusRoot();
+
+		// Assert.
 		ASSERT_EQ(path, expected);
 	}
 
 	TEST(ProjectPaths, ProjectsRoot_Should_ReturnProjectsDirectoryUnderLudusRoot)
 	{
+		// Arrange.
 		const auto expected = ProjectPaths::LudusRoot() / "Projects";
+
+		// Act.
 		const auto path = ProjectPaths::ProjectsRoot();
+
+		// Assert.
 		ASSERT_EQ(path, expected);
 	}
 
 	TEST(ProjectPaths, ProjectRoot_Should_ReturnProjectPathUnderProjectsRoot)
 	{
+		// Arrange & Act.
 		const auto path = ProjectPaths::ProjectRoot("Sandbox");
+
+		// Assert.
 		ASSERT_EQ(path, ProjectPaths::ProjectsRoot() / "Sandbox");
 	}
 
 	TEST(ProjectPaths, ProjectManifestFile_Should_ReturnProjectManifestName)
 	{
+		// Arrange & Act.
 		const auto path = ProjectPaths::ProjectManifestFile("Sandbox");
+
+		// Assert.
 		ASSERT_EQ(path, std::filesystem::path("Sandbox.ludus.project"));
 	}
 
 	TEST(ProjectPaths, ProjectManifestFile_WithRoot_Should_ReturnProjectManifestPath)
 	{
+		// Arrange.
 		const auto projectRoot = std::filesystem::path("C:/Projects/Sandbox");
+
+		// Act.
 		const auto path = ProjectPaths::ProjectManifestFile(projectRoot, "Sandbox");
+
+		// Assert.
 		ASSERT_EQ(path, projectRoot / "Sandbox.ludus.project");
 	}
 
 	TEST(ProjectPaths, ValidateFileName_Should_ReturnError_WhenNameIsEmpty)
 	{
+		// Arrange & Act.
 		const auto error = ProjectPaths::ValidateFileName("");
+
+		// Assert.
 		ASSERT_EQ(error, "Name must not be empty.");
 	}
 
 	TEST(ProjectPaths, ValidateFileName_Should_ReturnError_WhenNameContainsInvalidCharacters)
 	{
+		// Arrange & Act.
 		const auto error = ProjectPaths::ValidateFileName("Sand:box");
+
+		// Assert.
 		ASSERT_EQ(error, "Name contains invalid path characters.");
 	}
 
 	TEST(ProjectPaths, SceneFileName_Should_ReturnSceneFileName)
 	{
+		// Arrange & Act.
 		const auto path = ProjectPaths::SceneFileName("Sandbox");
+
+		// Assert.
 		ASSERT_EQ(path, std::filesystem::path("Sandbox.ludus.scene"));
 	}
 
 	TEST(ProjectPaths, SceneFile_Should_ReturnProjectScenePath)
 	{
+		// Arrange.
 		const auto projectRoot = std::filesystem::path("C:/Projects/Sandbox");
+
+		// Act.
 		const auto path = ProjectPaths::SceneFile(projectRoot, "Main");
+
+		// Assert.
 		ASSERT_EQ(path, projectRoot / "Scenes" / "Main.ludus.scene");
 	}
 
 	TEST(ProjectPaths, SceneFileInDirectory_Should_ReturnScenePathUnderDirectory)
 	{
+		// Arrange.
 		const auto directory = std::filesystem::path("C:/Projects/Sandbox/Scenes");
+
+		// Act.
 		const auto path = ProjectPaths::SceneFileInDirectory(directory, "Main");
+
+		// Assert.
 		ASSERT_EQ(path, directory / "Main.ludus.scene");
 	}
 
 	TEST(ProjectPaths, SceneName_Should_ReturnSceneNameFromPath)
 	{
+		// Arrange & Act.
 		const auto name = ProjectPaths::SceneName("C:/Projects/Sandbox/Scenes/Main.ludus.scene");
+
+		// Assert.
 		ASSERT_EQ(name, "Main");
 	}
 
 	TEST(ProjectPaths, ValidateAvailablePath_Should_ReturnError_WhenPathIsEmpty)
 	{
+		// Arrange & Act.
 		const auto error = ProjectPaths::ValidateAvailablePath({ });
+
+		// Assert.
 		ASSERT_EQ(error, "Path is invalid.");
 	}
 
 	TEST(ProjectPaths, ValidateAvailablePath_Should_ReturnError_WhenPathAlreadyExists)
 	{
+		// Arrange.
 		const auto tempDirectoryScope = CreateTestDirectory();
 		const auto projectRoot = tempDirectoryScope.Path / "Sandbox";
 		std::filesystem::create_directories(projectRoot);
 
+		// Act.
 		const auto error = ProjectPaths::ValidateAvailablePath(projectRoot);
 
+		// Assert.
 		ASSERT_EQ(error, "Path already exists.");
 	}
 
 	TEST(ProjectPaths, ValidateAvailablePath_Should_ReturnEmpty_WhenPathIsNew)
 	{
+		// Arrange.
 		const auto tempDirectoryScope = CreateTestDirectory();
 		const auto projectRoot = tempDirectoryScope.Path / "Sandbox";
 
+		// Act.
 		const auto error = ProjectPaths::ValidateAvailablePath(projectRoot);
 
+		// Assert.
 		ASSERT_TRUE(error.empty());
 	}
 
 	TEST(ProjectPaths, ScriptsDirectory_Should_ReturnScriptsPath)
 	{
+		// Arrange.
 		const auto projectRoot = std::filesystem::path("C:/Projects/Sandbox");
+
+		// Act.
 		const auto path = ProjectPaths::ScriptsDirectory(projectRoot);
+
+		// Assert.
 		ASSERT_EQ(path, projectRoot / "Scripts");
 	}
 
 	TEST(ProjectPaths, ScriptsSourceDirectory_Should_ReturnScriptsSourcePath)
 	{
+		// Arrange.
 		const auto projectRoot = std::filesystem::path("C:/Projects/Sandbox");
+
+		// Act.
 		const auto path = ProjectPaths::ScriptsSourceDirectory(projectRoot);
+
+		// Assert.
 		ASSERT_EQ(path, projectRoot / "Scripts" / "Source");
 	}
 
 	TEST(ProjectPaths, ScriptSourceFile_Should_ReturnScriptSourcePath)
 	{
+		// Arrange.
 		const auto projectRoot = std::filesystem::path("C:/Projects/Sandbox");
+
+		// Act.
 		const auto path = ProjectPaths::ScriptSourceFile(projectRoot, "PlayerController");
+
+		// Assert.
 		ASSERT_EQ(path, projectRoot / "Scripts" / "Source" / "PlayerController.cpp");
 	}
 
 	TEST(ProjectPaths, ScriptsModuleFile_Should_ReturnScriptsModulePath)
 	{
+		// Arrange.
 		const auto projectRoot = std::filesystem::path("C:/Projects/Sandbox");
+
+		// Act.
 		const auto path = ProjectPaths::ScriptsModuleFile(projectRoot);
+
+		// Assert.
 		ASSERT_EQ(path, projectRoot / "Scripts" / "Source" / "ScriptsModule.cpp");
 	}
 
 	TEST(ProjectPaths, ScriptsProjectFile_Should_ReturnScriptsProjectPath)
 	{
+		// Arrange.
 		const auto projectRoot = std::filesystem::path("C:/Projects/Sandbox");
+
+		// Act.
 		const auto path = ProjectPaths::ScriptsProjectFile(projectRoot);
+
+		// Assert.
 		ASSERT_EQ(path, projectRoot / "Scripts" / "Source" / "Scripts.vcxproj");
 	}
 
 	TEST(ProjectPaths, EnsureProjectRootExists_Should_CreateProjectRoot)
 	{
+		// Arrange.
 		const auto tempDirectoryScope = CreateTestDirectory();
 		const auto projectRoot = tempDirectoryScope.Path / "Sandbox";
 
+		// Act.
 		ProjectPaths::EnsureProjectRootExists(projectRoot);
 
+		// Assert.
 		ASSERT_TRUE(std::filesystem::exists(projectRoot));
 		ASSERT_TRUE(std::filesystem::is_directory(projectRoot));
 	}
 
 	TEST(ProjectPaths, EnsureProjectScriptsSourceLayoutExists_Should_CreateScriptsSourceDirectory)
 	{
+		// Arrange.
 		const auto tempDirectoryScope = CreateTestDirectory();
 		const auto projectRoot = tempDirectoryScope.Path / "Sandbox";
 
+		// Act.
 		ProjectPaths::EnsureProjectScriptsSourceLayoutExists(projectRoot);
 
+		// Assert.
 		ASSERT_TRUE(std::filesystem::exists(projectRoot / "Scripts" / "Source"));
 		ASSERT_TRUE(std::filesystem::is_directory(projectRoot / "Scripts" / "Source"));
 	}
 
 	TEST(ProjectPaths, EnsureProjectLayoutExists_Should_CreateProjectRuntimeDirectories)
 	{
+		// Arrange.
 		const auto tempDirectoryScope = CreateTestDirectory();
 		const auto projectRoot = tempDirectoryScope.Path / "Sandbox";
 
+		// Act.
 		ProjectPaths::EnsureProjectLayoutExists(projectRoot);
 
+		// Assert.
 		ASSERT_TRUE(std::filesystem::exists(projectRoot));
 		ASSERT_TRUE(std::filesystem::exists(Ludus::Engine::Persistence::Paths::AssetsDirectory(projectRoot)));
 		ASSERT_TRUE(std::filesystem::exists(Ludus::Engine::Persistence::Paths::ScenesDirectory(projectRoot)));

--- a/EditorTests/Ludus/EditorTests/Persistence/RepositoryPathsTests.cpp
+++ b/EditorTests/Ludus/EditorTests/Persistence/RepositoryPathsTests.cpp
@@ -10,85 +10,127 @@ namespace Ludus::EditorTests::Persistence
 
 	TEST(RepositoryPaths, ResolveRepositoryRoot_Should_ReturnRepositoryRoot)
 	{
+		// Arrange & Act.
 		const auto path = RepositoryPaths::ResolveRepositoryRoot();
+
+		// Assert.
 		ASSERT_TRUE(std::filesystem::exists(path / "Ludus.sln"));
 	}
 
 	TEST(RepositoryPaths, EditorDirectory_Should_ReturnEditorDirectory)
 	{
+		// Arrange & Act.
 		const auto path = RepositoryPaths::EditorDirectory();
+
+		// Assert.
 		ASSERT_EQ(path, RepositoryPaths::ResolveRepositoryRoot() / "Editor");
 	}
 
 	TEST(RepositoryPaths, EditorIncludeDirectory_Should_ReturnEditorIncludeDirectory)
 	{
+		// Arrange & Act.
 		const auto path = RepositoryPaths::EditorIncludeDirectory();
+
+		// Assert.
 		ASSERT_EQ(path, RepositoryPaths::EditorDirectory() / "Include");
 	}
 
 	TEST(RepositoryPaths, EditorResourcesDirectory_Should_ReturnEditorResourcesDirectory)
 	{
+		// Arrange & Act.
 		const auto path = RepositoryPaths::EditorResourcesDirectory();
+
+		// Assert.
 		ASSERT_EQ(path, RepositoryPaths::EditorDirectory() / "Resources");
 	}
 
 	TEST(RepositoryPaths, EngineDirectory_Should_ReturnEngineDirectory)
 	{
+		// Arrange & Act.
 		const auto path = RepositoryPaths::EngineDirectory();
+
+		// Assert.
 		ASSERT_EQ(path, RepositoryPaths::ResolveRepositoryRoot() / "Engine");
 	}
 
 	TEST(RepositoryPaths, EngineIncludeDirectory_Should_ReturnEngineIncludeDirectory)
 	{
+		// Arrange & Act.
 		const auto path = RepositoryPaths::EngineIncludeDirectory();
+
+		// Assert.
 		ASSERT_EQ(path, RepositoryPaths::EngineDirectory() / "Include");
 	}
 
 	TEST(RepositoryPaths, EngineResourcesDirectory_Should_ReturnEngineResourcesDirectory)
 	{
+		// Arrange & Act.
 		const auto path = RepositoryPaths::EngineResourcesDirectory();
+
+		// Assert.
 		ASSERT_EQ(path, RepositoryPaths::EngineDirectory() / "Resources");
 	}
 
 	TEST(RepositoryPaths, EngineVendorsDirectory_Should_ReturnEngineVendorsDirectory)
 	{
+		// Arrange & Act.
 		const auto path = RepositoryPaths::EngineVendorsDirectory();
+
+		// Assert.
 		ASSERT_EQ(path, RepositoryPaths::EngineDirectory() / "Vendors");
 	}
 
 	TEST(RepositoryPaths, ScriptingDirectory_Should_ReturnScriptingDirectory)
 	{
+		// Arrange & Act.
 		const auto path = RepositoryPaths::ScriptingDirectory();
+
+		// Assert.
 		ASSERT_EQ(path, RepositoryPaths::ResolveRepositoryRoot() / "Scripting");
 	}
 
 	TEST(RepositoryPaths, ScriptingIncludeDirectory_Should_ReturnScriptingIncludeDirectory)
 	{
+		// Arrange & Act.
 		const auto path = RepositoryPaths::ScriptingIncludeDirectory();
+
+		// Assert.
 		ASSERT_EQ(path, RepositoryPaths::ScriptingDirectory() / "Include");
 	}
 
 	TEST(RepositoryPaths, ScriptingAPIIncludeDirectory_Should_ReturnAPIIncludeDirectory)
 	{
+		// Arrange & Act.
 		const auto path = RepositoryPaths::ScriptingAPIIncludeDirectory();
+
+		// Assert.
 		ASSERT_EQ(path, RepositoryPaths::ScriptingIncludeDirectory() / "Ludus" / "Scripting" / "API");
 	}
 
 	TEST(RepositoryPaths, TemplatesDirectory_Should_ReturnRequestedTemplateDirectory)
 	{
+		// Arrange & Act.
 		const auto path = RepositoryPaths::TemplatesDirectory("RuntimeHost");
+
+		// Assert.
 		ASSERT_EQ(path, RepositoryPaths::EditorResourcesDirectory() / "Templates" / "RuntimeHost");
 	}
 
 	TEST(RepositoryPaths, RuntimeHostTemplatesDirectory_Should_ReturnRuntimeHostTemplatesDirectory)
 	{
+		// Arrange & Act.
 		const auto path = RepositoryPaths::RuntimeHostTemplatesDirectory();
+
+		// Assert.
 		ASSERT_EQ(path, RepositoryPaths::EditorResourcesDirectory() / "Templates" / "RuntimeHost");
 	}
 
 	TEST(RepositoryPaths, ScriptTemplatesDirectory_Should_ReturnScriptTemplatesDirectory)
 	{
+		// Arrange & Act.
 		const auto path = RepositoryPaths::ScriptTemplatesDirectory();
+
+		// Assert.
 		ASSERT_EQ(path, RepositoryPaths::EditorResourcesDirectory() / "Templates" / "Scripting");
 	}
 }

--- a/EditorTests/Ludus/EditorTests/Serialization/Schemas/ProjectManifestSchemaTests.cpp
+++ b/EditorTests/Ludus/EditorTests/Serialization/Schemas/ProjectManifestSchemaTests.cpp
@@ -101,7 +101,7 @@ namespace Ludus::EditorTests::Serialization::Schemas
 		ASSERT_NE(FindMember(manifestObject, "RuntimeManifestPath"), nullptr);
 		ASSERT_EQ(FindMember(manifestObject, "Scenes"), nullptr);
 		ASSERT_EQ(FindMember(manifestObject, "Scripts"), nullptr);
-		ASSERT_EQ(FindMember(manifestObject, "EntrySceneHandle"), nullptr);
+		ASSERT_EQ(FindMember(manifestObject, "EntrySceneId"), nullptr);
 	}
 
 	TEST(ProjectManifestSchema, Deserialize_ReadsVersionProjectRootAndRuntimeManifestPath_When_ArchiveIsValid)

--- a/EditorTests/Ludus/EditorTests/SmokeTests.cpp
+++ b/EditorTests/Ludus/EditorTests/SmokeTests.cpp
@@ -4,6 +4,7 @@ namespace Ludus::EditorTests
 {
 	TEST(SmokeTests, Compiles)
 	{
+		// Arrange & Act & Assert.
 		SUCCEED();
 	}
 }

--- a/Engine/Engine.vcxproj
+++ b/Engine/Engine.vcxproj
@@ -29,6 +29,8 @@
   <ItemGroup>
     <ClInclude Include="Include\Ludus\Engine\Components\DisplayNameComponent.h" />
     <ClInclude Include="Include\Ludus\Engine\Components\ScriptComponent.h" />
+    <ClInclude Include="Include\Ludus\Engine\Core\Id.h" />
+    <ClInclude Include="Include\Ludus\Engine\Platform\Guid.h" />
     <ClInclude Include="Include\Ludus\Engine\Runtime\InitialSceneMode.h" />
     <ClInclude Include="Include\Ludus\Engine\Runtime\RuntimeManifest.h" />
     <ClInclude Include="Include\Ludus\Engine\Runtime\RuntimeEnvironment.h" />
@@ -487,6 +489,7 @@
     <ClInclude Include="Vendors\stb_image\stb_image.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="Source\Ludus\Engine\Platform\Windows\Guid.Windows.cpp" />
     <ClCompile Include="Source\Ludus\Engine\Runtime\ApplicationHostBuilder.cpp" />
     <ClCompile Include="Source\Ludus\Engine\Runtime\RuntimeInstanceBuilder.cpp" />
     <ClCompile Include="Source\Ludus\Engine\Runtime\RuntimeLauncher.cpp" />

--- a/Engine/Include/Ludus/Engine/Components/Camera2DComponent.h
+++ b/Engine/Include/Ludus/Engine/Components/Camera2DComponent.h
@@ -1,15 +1,13 @@
 #pragma once
 
-#include <Ludus/Engine/Core/Entity.h>
-#include <Ludus/Engine/Math/Numeric.h>
-#include <Ludus/Engine/Math/Rect.h>
+#include <Ludus/Engine/Core/Id.h>
 
 namespace Ludus::Engine::Components
 {
 	struct Camera2DComponent
 	{
 	public:
-		Ludus::Engine::Core::EntityHandle OwnerHandle {};
+		Ludus::Engine::Core::EntityId OwnerId { Ludus::Engine::Core::EntityId::Invalid() };
 		float OrthographicSize = 10.0f;
 		int Priority = -1;
 
@@ -19,12 +17,12 @@ namespace Ludus::Engine::Components
 			: OrthographicSize(orthographicSize), Priority(priority)
 		{ }
 
-		Camera2DComponent(Ludus::Engine::Core::EntityHandle owner, float orthographicSize = 10.0f, int priority = -1)
-			: OwnerHandle(owner), OrthographicSize(orthographicSize), Priority(priority)
+		Camera2DComponent(Ludus::Engine::Core::EntityId owner, float orthographicSize = 10.0f, int priority = -1)
+			: OwnerId(owner), OrthographicSize(orthographicSize), Priority(priority)
 		{ }
 
 		~Camera2DComponent() = default;
 
-		bool operator==(const Camera2DComponent& other) const { return OwnerHandle == other.OwnerHandle; }
+		bool operator==(const Camera2DComponent& other) const { return OwnerId == other.OwnerId; }
 	};
 }

--- a/Engine/Include/Ludus/Engine/Components/Collider2DComponent.h
+++ b/Engine/Include/Ludus/Engine/Components/Collider2DComponent.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <Ludus/Engine/Components/Transform2DComponent.h>
-#include <Ludus/Engine/Core/Entity.h>
+#include <Ludus/Engine/Core/Id.h>
 #include <Ludus/Engine/Math/AABB.h>
 #include <Ludus/Engine/Math/Circle.h>
 #include <Ludus/Engine/Physics/Core/LayerMask.h>
@@ -11,7 +11,7 @@ namespace Ludus::Engine::Components
 	struct Collider2DComponent
 	{
 	public:
-		Ludus::Engine::Core::EntityHandle OwnerHandle {};
+		Ludus::Engine::Core::EntityId OwnerId { Ludus::Engine::Core::EntityId::Invalid() };
 		Ludus::Engine::Physics::Core::LayerIndex LayerIndex = 0;
 		Ludus::Engine::Physics::Core::LayerMask CollidesWith = Ludus::Engine::Physics::Core::LayerMask::GetEmpty();
 		bool IsTrigger = false;
@@ -29,12 +29,12 @@ namespace Ludus::Engine::Components
 		{ }
 
 		Collider2DComponent(
-			Ludus::Engine::Core::EntityHandle owner,
+			Ludus::Engine::Core::EntityId owner,
 			Ludus::Engine::Physics::Core::LayerIndex layerIndex = 0,
 			Ludus::Engine::Physics::Core::LayerMask collidesWith = Ludus::Engine::Physics::Core::LayerMask::GetEmpty(),
 			bool isTrigger = false
 		) :
-			OwnerHandle(owner),
+			OwnerId(owner),
 			LayerIndex(layerIndex),
 			CollidesWith(collidesWith),
 			IsTrigger(isTrigger)
@@ -42,7 +42,7 @@ namespace Ludus::Engine::Components
 
 		~Collider2DComponent() = default;
 
-		bool operator==(const Collider2DComponent& other) const { return OwnerHandle == other.OwnerHandle; }
+		bool operator==(const Collider2DComponent& other) const { return OwnerId == other.OwnerId; }
 
 		Ludus::Engine::Math::AABB ToAABB(const Ludus::Engine::Components::Transform2DComponent& transform) const
 		{

--- a/Engine/Include/Ludus/Engine/Components/DisplayNameComponent.h
+++ b/Engine/Include/Ludus/Engine/Components/DisplayNameComponent.h
@@ -3,14 +3,14 @@
 #include <string>
 #include <utility>
 
-#include <Ludus/Engine/Core/Entity.h>
+#include <Ludus/Engine/Core/Id.h>
 
 namespace Ludus::Engine::Components
 {
 	struct DisplayNameComponent
 	{
 	public:
-		Ludus::Engine::Core::EntityHandle OwnerHandle { };
+		Ludus::Engine::Core::EntityId OwnerId { Ludus::Engine::Core::EntityId::Invalid() };
 		std::string Name = "";
 
 		DisplayNameComponent() = default;
@@ -22,15 +22,15 @@ namespace Ludus::Engine::Components
 		{ }
 
 		DisplayNameComponent(
-			Ludus::Engine::Core::EntityHandle owner,
+			Ludus::Engine::Core::EntityId owner,
 			std::string name = ""
 		) :
-			OwnerHandle(owner),
+			OwnerId(owner),
 			Name(std::move(name))
 		{ }
 
 		~DisplayNameComponent() = default;
 
-		bool operator==(const DisplayNameComponent& other) const { return OwnerHandle == other.OwnerHandle; }
+		bool operator==(const DisplayNameComponent& other) const { return OwnerId == other.OwnerId; }
 	};
 }

--- a/Engine/Include/Ludus/Engine/Components/RigidBody2DComponent.h
+++ b/Engine/Include/Ludus/Engine/Components/RigidBody2DComponent.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <Ludus/Engine/Core/Entity.h>
+#include <Ludus/Engine/Core/Id.h>
 #include <Ludus/Engine/Math/Vector2D.h>
 #include <Ludus/Engine/Physics/Core/BodyType.h>
 
@@ -9,7 +9,7 @@ namespace Ludus::Engine::Components
 	struct RigidBody2DComponent
 	{
 	public:
-		Ludus::Engine::Core::EntityHandle OwnerHandle { };
+		Ludus::Engine::Core::EntityId OwnerId { Ludus::Engine::Core::EntityId::Invalid() };
 		Ludus::Engine::Math::Vector2D Velocity;
 		float GravityScale = 1.0f;
 		float Mass = 1.0f;
@@ -30,13 +30,13 @@ namespace Ludus::Engine::Components
 		{ }
 
 		RigidBody2DComponent(
-			Ludus::Engine::Core::EntityHandle owner,
+			Ludus::Engine::Core::EntityId owner,
 			Ludus::Engine::Math::Vector2D velocity = { 0.0f, 0.0f },
 			Ludus::Engine::Physics::Core::BodyType bodyType = Ludus::Engine::Physics::Core::BodyType::Dynamic,
 			float gravityScale = 1.0f,
 			float mass = 1.0f
 		) :
-			OwnerHandle(owner),
+			OwnerId(owner),
 			Velocity(velocity),
 			BodyType(bodyType),
 			GravityScale(gravityScale),
@@ -45,6 +45,6 @@ namespace Ludus::Engine::Components
 
 		~RigidBody2DComponent() = default;
 
-		bool operator==(const RigidBody2DComponent& other) const { return OwnerHandle == other.OwnerHandle; }
+		bool operator==(const RigidBody2DComponent& other) const { return OwnerId == other.OwnerId; }
 	};
 }

--- a/Engine/Include/Ludus/Engine/Components/ScriptComponent.h
+++ b/Engine/Include/Ludus/Engine/Components/ScriptComponent.h
@@ -1,43 +1,31 @@
 #pragma once
 
-#include <string>
-#include <string_view>
-
-#include <Ludus/Engine/Core/Entity.h>
+#include <Ludus/Engine/Core/Id.h>
 
 namespace Ludus::Engine::Components
 {
-	using ScriptHandle = uint64_t;
-
 	struct ScriptComponent
 	{
 	public:
-		Ludus::Engine::Core::EntityHandle OwnerHandle {};
-		std::string Name = "";
-		ScriptHandle Handle {};
+		Ludus::Engine::Core::EntityId OwnerId { Ludus::Engine::Core::EntityId::Invalid() };
+		Ludus::Engine::Core::ScriptId Id { Ludus::Engine::Core::ScriptId::Invalid() };
 
 		ScriptComponent() = default;
 
-		explicit ScriptComponent(
-			std::string_view name,
-			ScriptHandle handle = {}
-		) :
-			Name(name),
-			Handle(handle)
+		explicit ScriptComponent(Ludus::Engine::Core::ScriptId id)
+			: Id(id)
 		{ }
 
 		ScriptComponent(
-			Ludus::Engine::Core::EntityHandle ownerHandle,
-			std::string_view name = "",
-			ScriptHandle handle = {}
+			Ludus::Engine::Core::EntityId ownerId,
+			Ludus::Engine::Core::ScriptId id = Ludus::Engine::Core::ScriptId::Invalid()
 		) :
-			OwnerHandle(ownerHandle),
-			Name(name),
-			Handle(handle == ScriptHandle {} ? static_cast<ScriptHandle>(ownerHandle) : handle)
+			OwnerId(ownerId),
+			Id(id)
 		{ }
 
 		~ScriptComponent() = default;
 
-		bool operator==(const ScriptComponent& other) const { return Handle == other.Handle; }
+		bool operator==(const ScriptComponent& other) const { return Id == other.Id; }
 	};
 }

--- a/Engine/Include/Ludus/Engine/Components/Sprite2DComponent.h
+++ b/Engine/Include/Ludus/Engine/Components/Sprite2DComponent.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <Ludus/Engine/Core/Entity.h>
+#include <Ludus/Engine/Core/Id.h>
 #include <Ludus/Engine/Graphics/Color.h>
 #include <Ludus/Engine/Graphics/Shape.h>
 #include <Ludus/Engine/Graphics/Texture.h>
@@ -10,7 +10,7 @@ namespace Ludus::Engine::Components
 	struct Sprite2DComponent
 	{
 	public:
-		Ludus::Engine::Core::EntityHandle OwnerHandle {};
+		Ludus::Engine::Core::EntityId OwnerId { Ludus::Engine::Core::EntityId::Invalid() };
 		Ludus::Engine::Graphics::Shape Shape = Ludus::Engine::Graphics::Shape::Quad;
 		Ludus::Engine::Graphics::Color Color = Ludus::Engine::Graphics::Colors::White;
 		Ludus::Engine::Graphics::Texture* Texture = nullptr;
@@ -31,13 +31,13 @@ namespace Ludus::Engine::Components
 		{ }
 
 		Sprite2DComponent(
-			Ludus::Engine::Core::EntityHandle owner,
+			Ludus::Engine::Core::EntityId owner,
 			Ludus::Engine::Graphics::Shape shape = Ludus::Engine::Graphics::Shape::Quad,
 			Ludus::Engine::Graphics::Color color = Ludus::Engine::Graphics::Colors::White,
 			Ludus::Engine::Graphics::Texture* texture = nullptr,
 			bool fill = true
 		) :
-			OwnerHandle(owner),
+			OwnerId(owner),
 			Shape(shape),
 			Color(color),
 			Texture(texture),
@@ -46,7 +46,7 @@ namespace Ludus::Engine::Components
 
 		~Sprite2DComponent() = default;
 
-		bool operator==(const Sprite2DComponent& other) const { return OwnerHandle == other.OwnerHandle; }
+		bool operator==(const Sprite2DComponent& other) const { return OwnerId == other.OwnerId; }
 	};
 }
 

--- a/Engine/Include/Ludus/Engine/Components/Text2DComponent.h
+++ b/Engine/Include/Ludus/Engine/Components/Text2DComponent.h
@@ -2,7 +2,7 @@
 
 #include <string>
 
-#include <Ludus/Engine/Core/Entity.h>
+#include <Ludus/Engine/Core/Id.h>
 #include <Ludus/Engine/Graphics/Color.h>
 #include <Ludus/Engine/Graphics/HorizontalTextAlignment.h>
 
@@ -11,7 +11,7 @@ namespace Ludus::Engine::Components
 	struct Text2DComponent
 	{
 	public:
-		Ludus::Engine::Core::EntityHandle OwnerHandle { };
+		Ludus::Engine::Core::EntityId OwnerId { Ludus::Engine::Core::EntityId::Invalid() };
 		std::string Text = "";
 		Ludus::Engine::Graphics::Color Color = Ludus::Engine::Graphics::Colors::White;
 		Ludus::Engine::Graphics::HorizontalTextAlignment HorizontalTextAlignment = Ludus::Engine::Graphics::HorizontalTextAlignment::Left;
@@ -29,12 +29,12 @@ namespace Ludus::Engine::Components
 		{ }
 
 		Text2DComponent(
-			Ludus::Engine::Core::EntityHandle owner,
+			Ludus::Engine::Core::EntityId owner,
 			std::string text = "",
 			Ludus::Engine::Graphics::Color color = Ludus::Engine::Graphics::Colors::White,
 			Ludus::Engine::Graphics::HorizontalTextAlignment horizontalTextAlignment = Ludus::Engine::Graphics::HorizontalTextAlignment::Left
 		) :
-			OwnerHandle(owner),
+			OwnerId(owner),
 			Text(text),
 			Color(color),
 			HorizontalTextAlignment(horizontalTextAlignment)
@@ -42,7 +42,7 @@ namespace Ludus::Engine::Components
 
 		~Text2DComponent() = default;
 
-		bool operator==(const Text2DComponent& other) const { return OwnerHandle == other.OwnerHandle; }
+		bool operator==(const Text2DComponent& other) const { return OwnerId == other.OwnerId; }
 	};
 }
 

--- a/Engine/Include/Ludus/Engine/Components/Transform2DComponent.h
+++ b/Engine/Include/Ludus/Engine/Components/Transform2DComponent.h
@@ -2,8 +2,7 @@
 
 #include <cmath>
 
-#include <Ludus/Engine/Core/Entity.h>  
-#include <Ludus/Engine/Math/Numeric.h>  
+#include <Ludus/Engine/Core/Id.h>
 #include <Ludus/Engine/Math/Vector2D.h>
 
 namespace Ludus::Engine::Components
@@ -11,7 +10,7 @@ namespace Ludus::Engine::Components
 	struct Transform2DComponent
 	{
 	public:
-		Ludus::Engine::Core::EntityHandle OwnerHandle { };
+		Ludus::Engine::Core::EntityId OwnerId { Ludus::Engine::Core::EntityId::Invalid() };
 		Ludus::Engine::Math::Vector2D Position { 0.0f, 0.0f };
 		Ludus::Engine::Math::Vector2D Scale { 1.0f, 1.0f };
 		float Rotation { 0.0f };
@@ -29,12 +28,12 @@ namespace Ludus::Engine::Components
 		{ }
 
 		Transform2DComponent(
-			Ludus::Engine::Core::EntityHandle ownerHandle,
+			Ludus::Engine::Core::EntityId ownerId,
 			Ludus::Engine::Math::Vector2D position = { 0.0f, 0.0f },
 			Ludus::Engine::Math::Vector2D scale = { 1.0f, 1.0f },
 			float rotation = 0.0f
 		) :
-			OwnerHandle(ownerHandle),
+			OwnerId(ownerId),
 			Position(position),
 			Scale(scale),
 			Rotation(rotation)
@@ -42,21 +41,6 @@ namespace Ludus::Engine::Components
 
 		~Transform2DComponent() = default;
 
-		bool operator==(const Transform2DComponent& other) const { return OwnerHandle == other.OwnerHandle; }
-
-		/// <summary>
-		/// Computes the forward unit vector from the transform's rotation.
-		/// </summary>
-		/// <returns>A unit vector pointing in the forward direction.</returns>
-		Ludus::Engine::Math::Vector2D Forward() const
-		{
-			const float r = Ludus::Engine::Math::Numeric::DegreesToRadians(Rotation);
-			return { std::cos(r), std::sin(r) };
-		}
-
-		void Rotate(const Ludus::Engine::Math::Vector2D& unitVector)
-		{
-			Rotation = Ludus::Engine::Math::Numeric::RotationDegreesFromDirection(unitVector.X, unitVector.Y);
-		}
+		bool operator==(const Transform2DComponent& other) const { return OwnerId == other.OwnerId; }
 	};
 }

--- a/Engine/Include/Ludus/Engine/Core/ComponentRegistry.h
+++ b/Engine/Include/Ludus/Engine/Core/ComponentRegistry.h
@@ -7,18 +7,16 @@
 #include <utility>
 #include <vector>
 
-#include <Ludus/Engine/Core/Entity.h>
+#include <Ludus/Engine/Core/Id.h>
 
 namespace Ludus::Engine::Core
 {
-	using Handle = uint32_t;
-
 	template<typename T>
 	struct ComponentRegistry
 	{
 	private:
-		std::vector<T> m_Data;												// Object Storage.
-		std::unordered_map<EntityHandle, size_t> m_OwnerHandleToIndex;		// Owner handle -> index.
+		std::vector<T> m_Data;										// Object Storage.
+		std::unordered_map<EntityId, size_t> m_OwnerIdToIndex;		// Owner id -> index.
 
 		void RemoveAndReorderIndices(size_t index)
 		{
@@ -28,12 +26,12 @@ namespace Ludus::Engine::Core
 				std::swap(m_Data[index], m_Data[lastIndex]);
 
 				// Fix the indices of the moved element.
-				const EntityHandle movedOwnerHandle = m_Data[index].OwnerHandle;
+				const EntityId movedOwnerId = m_Data[index].OwnerId;
 
-				m_OwnerHandleToIndex[movedOwnerHandle] = index;
+				m_OwnerIdToIndex[movedOwnerId] = index;
 			}
 
-			m_OwnerHandleToIndex.erase(m_Data[lastIndex].OwnerHandle);
+			m_OwnerIdToIndex.erase(m_Data[lastIndex].OwnerId);
 
 			m_Data.pop_back();
 		}
@@ -43,31 +41,31 @@ namespace Ludus::Engine::Core
 		std::span<T> ViewMutable() { return { m_Data.data(), m_Data.size() }; }
 
 		template<typename... Args>
-			requires std::constructible_from<T, EntityHandle, Args...>
-		void Add(EntityHandle owner, Args&&... args)
+			requires std::constructible_from<T, EntityId, Args...>
+		void Add(EntityId owner, Args&&... args)
 		{
 			LUDUS_ASSERT(!ContainsOwner(owner), "Invalid component handle.");
 
 			m_Data.emplace_back(owner, std::forward<Args>(args)...);
 
 			const auto index = m_Data.size() - 1;
-			m_OwnerHandleToIndex[owner] = index;
+			m_OwnerIdToIndex[owner] = index;
 		}
 
 		void Add(T component)
 		{
-			const auto owner = component.OwnerHandle;
+			const auto owner = component.OwnerId;
 
 			LUDUS_ASSERT(!ContainsOwner(owner), "Invalid component handle.");
 
 			m_Data.push_back(std::move(component));
 			const auto index = m_Data.size() - 1;
-			m_OwnerHandleToIndex[owner] = index;
+			m_OwnerIdToIndex[owner] = index;
 		}
 
-		bool RemoveByOwner(EntityHandle ownerHandle)
+		bool RemoveByOwner(EntityId ownerId)
 		{
-			if (auto iter = m_OwnerHandleToIndex.find(ownerHandle); iter != m_OwnerHandleToIndex.end())
+			if (auto iter = m_OwnerIdToIndex.find(ownerId); iter != m_OwnerIdToIndex.end())
 			{
 				RemoveAndReorderIndices(iter->second);
 				return true;
@@ -80,9 +78,9 @@ namespace Ludus::Engine::Core
 
 #pragma region Lookups
 
-		const T* TryGetByOwner(EntityHandle ownerHandle) const
+		const T* TryGetByOwner(EntityId ownerId) const
 		{
-			if (auto iter = m_OwnerHandleToIndex.find(ownerHandle); iter != m_OwnerHandleToIndex.end())
+			if (auto iter = m_OwnerIdToIndex.find(ownerId); iter != m_OwnerIdToIndex.end())
 			{
 				return &m_Data[iter->second];
 			}
@@ -90,9 +88,9 @@ namespace Ludus::Engine::Core
 			return nullptr;
 		}
 
-		T* TryGetByOwnerMutable(EntityHandle ownerHandle)
+		T* TryGetByOwnerMutable(EntityId ownerId)
 		{
-			if (auto iter = m_OwnerHandleToIndex.find(ownerHandle); iter != m_OwnerHandleToIndex.end())
+			if (auto iter = m_OwnerIdToIndex.find(ownerId); iter != m_OwnerIdToIndex.end())
 			{
 				return &m_Data[iter->second];
 			}
@@ -100,7 +98,7 @@ namespace Ludus::Engine::Core
 			return nullptr;
 		}
 
-		bool ContainsOwner(EntityHandle ownerHandle) const { return m_OwnerHandleToIndex.contains(ownerHandle); }
+		bool ContainsOwner(EntityId ownerId) const { return m_OwnerIdToIndex.contains(ownerId); }
 
 #pragma endregion
 

--- a/Engine/Include/Ludus/Engine/Core/Entity.h
+++ b/Engine/Include/Ludus/Engine/Core/Entity.h
@@ -1,18 +1,17 @@
 #pragma once
 
-#include <cstdint>
+#include <Ludus/Engine/Core/Id.h>
 
 namespace Ludus::Engine::Core
 {
-	using EntityHandle = uint64_t;
-
 	struct Entity
 	{
 	public:
-		EntityHandle Handle;
+		EntityId Id { EntityId::Invalid() };
 
-		Entity(EntityHandle handle)
-			: Handle(handle)
+		Entity() = default;
+
+		Entity(EntityId id) : Id(id)
 		{ }
 
 		Entity(const Entity&) = default;
@@ -21,6 +20,7 @@ namespace Ludus::Engine::Core
 		Entity& operator=(Entity&&) noexcept = default;
 		~Entity() = default;
 
-		bool operator==(const Entity& other) const { return Handle == other.Handle; }
+		bool operator==(const Entity& other) const { return Id == other.Id; }
 	};
 }
+

--- a/Engine/Include/Ludus/Engine/Core/EntityComponentSystem.h
+++ b/Engine/Include/Ludus/Engine/Core/EntityComponentSystem.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <optional>
-#include <string>
 
 #include <Ludus/Engine/Components/Camera2DComponent.h>
 #include <Ludus/Engine/Components/Collider2DComponent.h>
@@ -13,6 +12,7 @@
 #include <Ludus/Engine/Components/Transform2DComponent.h>
 #include <Ludus/Engine/Core/ComponentRegistry.h>
 #include <Ludus/Engine/Core/EntityRegistry.h>
+#include <Ludus/Engine/Core/Id.h>
 #include <Ludus/Engine/Graphics/HorizontalTextAlignment.h>
 #include <Ludus/Engine/Graphics/Shape.h>
 #include <Ludus/Engine/Graphics/Texture.h>
@@ -42,116 +42,116 @@ namespace Ludus::Engine::Core
 		EntityComponentSystem(EntityComponentSystem&&) noexcept = default;
 		EntityComponentSystem& operator=(EntityComponentSystem&&) noexcept = default;
 
-		void RestoreEntity(EntityHandle handle)
+		EntityId RestoreEntity(EntityId id)
 		{
-			m_Entities.AddEntity(handle);
+			return m_Entities.RestoreEntity(id);
 		}
 
-		EntityHandle AddEntity()
+		EntityId AddEntity()
 		{
 			return m_Entities.CreateEntity();
 		}
 
-		bool DestroyEntity(EntityHandle handle)
+		bool DestroyEntity(EntityId id)
 		{
-			Cameras.RemoveByOwner(handle);
-			Colliders.RemoveByOwner(handle);
-			DisplayNames.RemoveByOwner(handle);
-			RigidBodies.RemoveByOwner(handle);
-			Scripts.RemoveByOwner(handle);
-			Sprites.RemoveByOwner(handle);
-			Texts.RemoveByOwner(handle);
-			Transforms.RemoveByOwner(handle);
+			Cameras.RemoveByOwner(id);
+			Colliders.RemoveByOwner(id);
+			DisplayNames.RemoveByOwner(id);
+			RigidBodies.RemoveByOwner(id);
+			Scripts.RemoveByOwner(id);
+			Sprites.RemoveByOwner(id);
+			Texts.RemoveByOwner(id);
+			Transforms.RemoveByOwner(id);
 
-			return m_Entities.DestroyEntity(handle);
+			return m_Entities.DestroyEntity(id);
 		}
 
-		void AttachCamera(EntityHandle handle, float orthographicSize = 10.0f, int priority = -1)
+		void AttachCamera(EntityId id, float orthographicSize = 10.0f, int priority = -1)
 		{
-			Cameras.Add(handle, orthographicSize, priority);
+			Cameras.Add(id, orthographicSize, priority);
 		}
 
 		void AttachCamera(Ludus::Engine::Components::Camera2DComponent component) { Cameras.Add(component); }
 
 		void AttachCollider(
-			EntityHandle handle,
+			EntityId id,
 			Ludus::Engine::Physics::Core::LayerIndex layer = 0,
 			Ludus::Engine::Physics::Core::LayerMask collidesWith = Ludus::Engine::Physics::Core::LayerMask::GetEmpty(),
 			bool isTrigger = false
 		)
 		{
-			Colliders.Add(handle, layer, collidesWith, isTrigger);
+			Colliders.Add(id, layer, collidesWith, isTrigger);
 		}
 
 		void AttachCollider(Ludus::Engine::Components::Collider2DComponent component) { Colliders.Add(component); }
 
-		void AttachDisplayName(EntityHandle handle, std::string name = "")
+		void AttachDisplayName(EntityId id, std::string name = "")
 		{
-			DisplayNames.Add(handle, name);
+			DisplayNames.Add(id, name);
 		}
 
 		void AttachDisplayName(Ludus::Engine::Components::DisplayNameComponent component) { DisplayNames.Add(component); }
 
 		void AttachRigidBody(
-			EntityHandle handle,
+			EntityId id,
 			Ludus::Engine::Math::Vector2D velocity = { 0.0f, 0.0f },
 			Ludus::Engine::Physics::Core::BodyType type = Ludus::Engine::Physics::Core::BodyType::Dynamic,
 			float gravityScale = 1.0f,
 			float mass = 1.0f
 		)
 		{
-			RigidBodies.Add(handle, velocity, type, gravityScale, mass);
+			RigidBodies.Add(id, velocity, type, gravityScale, mass);
 		}
 
 		void AttachRigidBody(Ludus::Engine::Components::RigidBody2DComponent component) { RigidBodies.Add(component); }
 
-		void AttachScript(EntityHandle ownerHandle, Ludus::Engine::Components::ScriptHandle handle, std::string_view name)
+		void AttachScript(EntityId ownerId, Ludus::Engine::Core::ScriptId id = Ludus::Engine::Core::ScriptId::Invalid())
 		{
-			Scripts.Add(ownerHandle, name, handle);
+			Scripts.Add(ownerId, id);
 		}
 
 		void AttachScript(Ludus::Engine::Components::ScriptComponent component) { Scripts.Add(component); }
 
 		void AttachSprite(
-			EntityHandle handle,
+			EntityId id,
 			Ludus::Engine::Graphics::Shape shape = Ludus::Engine::Graphics::Shape::Quad,
 			Ludus::Engine::Graphics::Color color = Ludus::Engine::Graphics::Colors::White,
 			Ludus::Engine::Graphics::Texture* texture = nullptr,
 			bool fill = true
 		)
 		{
-			Sprites.Add(handle, shape, color, texture, fill);
+			Sprites.Add(id, shape, color, texture, fill);
 		}
 
 		void AttachSprite(Ludus::Engine::Components::Sprite2DComponent component) { Sprites.Add(component); }
 
 		void AttachText(
-			EntityHandle handle,
+			EntityId id,
 			std::string text = "",
 			Ludus::Engine::Graphics::Color color = Ludus::Engine::Graphics::Colors::White,
 			Ludus::Engine::Graphics::HorizontalTextAlignment horizontalTextAlignment = Ludus::Engine::Graphics::HorizontalTextAlignment::Left
 		)
 		{
-			Texts.Add(handle, text, color, horizontalTextAlignment);
+			Texts.Add(id, text, color, horizontalTextAlignment);
 		}
 
 		void AttachText(Ludus::Engine::Components::Text2DComponent component) { Texts.Add(component); }
 
 		void AttachTransform(
-			EntityHandle handle,
+			EntityId id,
 			Ludus::Engine::Math::Vector2D position = { 0.0f, 0.0f },
 			Ludus::Engine::Math::Vector2D scale = { 1.0f, 1.0f },
 			float rotation = 0.0f
 		)
 		{
-			Transforms.Add(handle, position, scale, rotation);
+			Transforms.Add(id, position, scale, rotation);
 		}
 
 		void AttachTransform(Ludus::Engine::Components::Transform2DComponent component) { Transforms.Add(component); }
 
 		size_t GetEntityCount() const { return m_Entities.GetCount(); }
 
-		std::optional<size_t> IndexOf(EntityHandle handle) const { return m_Entities.IndexOf(handle); }
+		std::optional<size_t> IndexOf(EntityId id) const { return m_Entities.IndexOf(id); }
 
 		std::span<const Entity> View() const { return m_Entities.View(); }
 	};

--- a/Engine/Include/Ludus/Engine/Core/EntityRegistry.h
+++ b/Engine/Include/Ludus/Engine/Core/EntityRegistry.h
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include <Ludus/Engine/Core/Entity.h>
+#include <Ludus/Engine/Core/Id.h>
 #include <Ludus/Engine/Core/Random.h>
 #include <Ludus/Engine/Debug/Debug.h>
 
@@ -15,9 +16,9 @@ namespace Ludus::Engine::Core
 	struct EntityRegistry
 	{
 	private:
-		std::vector<Entity> m_Data;										// Entity Storage.
-		std::vector<EntityHandle> m_Handles;							// Index -> entity handle.
-		std::unordered_map<EntityHandle, size_t> m_HandleToIndex;		// Entity handle -> index.
+		std::vector<Entity> m_Data;									// Entity Storage.
+		std::vector<EntityId> m_Ids;								// Index -> entity id.
+		std::unordered_map<EntityId, size_t> m_IdToIndex;			// Entity id -> index.
 		Ludus::Engine::Core::Random m_Random;
 		static constexpr size_t MaxUniqueIdAttempts = 32;
 
@@ -27,62 +28,76 @@ namespace Ludus::Engine::Core
 			if (index != lastIndex)
 			{
 				std::swap(m_Data[index], m_Data[lastIndex]);
-				std::swap(m_Handles[index], m_Handles[lastIndex]);
+				std::swap(m_Ids[index], m_Ids[lastIndex]);
 
 				// Fix the indices of the moved element.
-				const EntityHandle movedHandle = m_Handles[index];
+				const EntityId movedId = m_Ids[index];
 
-				m_HandleToIndex[movedHandle] = index;
+				m_IdToIndex[movedId] = index;
 			}
 
-			m_HandleToIndex.erase(m_Handles[lastIndex]);
+			m_IdToIndex.erase(m_Ids[lastIndex]);
 
 			m_Data.pop_back();
-			m_Handles.pop_back();
+			m_Ids.pop_back();
 		}
 
-		EntityHandle CommitEntity(Entity entity)
+		EntityId CommitEntity(Entity entity)
 		{
-			const auto handle = entity.Handle;
-			LUDUS_ASSERT(!m_HandleToIndex.contains(handle), "Entity handle collision.");
+			const auto id = CreateUniqueId();
+			entity.Id = id;
 
 			m_Data.push_back(std::move(entity));
-			m_Handles.push_back(handle);
-			m_HandleToIndex[handle] = m_Data.size() - 1;
+			m_Ids.push_back(id);
+			m_IdToIndex[id] = m_Data.size() - 1;
 
-			return handle;
+			return id;
 		}
 
-		EntityHandle CreateUniqueId()
+		EntityId CreateUniqueId()
 		{
 			// Retry a fixed number of times to avoid collision loop.
 			for (size_t attempt = 0; attempt < MaxUniqueIdAttempts; ++attempt)
 			{
-				const auto handle = m_Random.NextId();
-				if (!m_HandleToIndex.contains(handle))
+				const auto id = EntityId { m_Random.NextId() };
+				if (!m_IdToIndex.contains(id))
 				{
-					return handle;
+					return id;
 				}
 			}
 
-			LUDUS_ASSERT(false, "Failed to generate a unique entity handle.");
-			return m_Random.NextId();
+			LUDUS_ASSERT(false, "Failed to generate a unique entity id.");
+			return EntityId { m_Random.NextId() };
 		}
 
 	public:
-		void AddEntity(EntityHandle handle)
+		EntityId AddEntity(Entity entity)
 		{
-			(void)CommitEntity(Entity { handle });
+			return CommitEntity(std::move(entity));
 		}
 
-		EntityHandle CreateEntity()
+		EntityId CreateEntity()
 		{
-			return CommitEntity(Entity { CreateUniqueId() });
+			return CommitEntity(Entity { EntityId::Invalid() });
 		}
 
-		bool DestroyEntity(EntityHandle handle)
+		EntityId RestoreEntity(EntityId id)
 		{
-			if (auto iter = m_HandleToIndex.find(handle); iter != m_HandleToIndex.end())
+			LUDUS_ASSERT(id.IsValid(), "Cannot restore an invalid entity id.");
+			LUDUS_ASSERT(!m_IdToIndex.contains(id), "Cannot restore a duplicate entity id.");
+
+			auto entity = Entity { id };
+
+			m_Data.push_back(entity);
+			m_Ids.push_back(id);
+			m_IdToIndex[id] = m_Data.size() - 1;
+
+			return id;
+		}
+
+		bool DestroyEntity(EntityId id)
+		{
+			if (auto iter = m_IdToIndex.find(id); iter != m_IdToIndex.end())
 			{
 				RemoveAndReorderIndices(iter->second);
 
@@ -92,9 +107,9 @@ namespace Ludus::Engine::Core
 			return false;
 		}
 
-		Entity* TryGet(EntityHandle handle)
+		Entity* TryGet(EntityId id)
 		{
-			if (auto iter = m_HandleToIndex.find(handle); iter != m_HandleToIndex.end())
+			if (auto iter = m_IdToIndex.find(id); iter != m_IdToIndex.end())
 			{
 				return &m_Data[iter->second];
 			}
@@ -102,9 +117,9 @@ namespace Ludus::Engine::Core
 			return nullptr;
 		}
 
-		const Entity* TryGet(EntityHandle handle) const
+		const Entity* TryGet(EntityId id) const
 		{
-			if (auto iter = m_HandleToIndex.find(handle); iter != m_HandleToIndex.end())
+			if (auto iter = m_IdToIndex.find(id); iter != m_IdToIndex.end())
 			{
 				return &m_Data[iter->second];
 			}
@@ -114,9 +129,9 @@ namespace Ludus::Engine::Core
 
 		std::span<const Entity> View() const { return { m_Data.data(), m_Data.size() }; }
 
-		std::optional<size_t> IndexOf(EntityHandle handle) const
+		std::optional<size_t> IndexOf(EntityId id) const
 		{
-			if (auto iter = m_HandleToIndex.find(handle); iter != m_HandleToIndex.end())
+			if (auto iter = m_IdToIndex.find(id); iter != m_IdToIndex.end())
 			{
 				return iter->second;
 			}

--- a/Engine/Include/Ludus/Engine/Core/Id.h
+++ b/Engine/Include/Ludus/Engine/Core/Id.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <compare>
+#include <cstdint>
+#include <functional>
+
+namespace Ludus::Engine::Core
+{
+	template<typename TTag>
+	struct Id
+	{
+		std::uint64_t Value = 0;
+
+		static constexpr Id Invalid()
+		{
+			return { };
+		}
+
+		constexpr bool IsValid() const
+		{
+			return Value != 0;
+		}
+
+		auto operator<=>(const Id&) const = default;
+	};
+
+	struct EntityIdTag;
+	struct SceneIdTag;
+	struct ScriptIdTag;
+
+	using EntityId = Id<EntityIdTag>;
+	using SceneId = Id<SceneIdTag>;
+	using ScriptId = Id<ScriptIdTag>;
+}
+
+template<>
+struct std::hash<Ludus::Engine::Core::EntityId>
+{
+	std::size_t operator()(const Ludus::Engine::Core::EntityId& id) const noexcept
+	{
+		return std::hash<std::uint64_t> {}(id.Value);
+	}
+};
+
+template<>
+struct std::hash<Ludus::Engine::Core::SceneId>
+{
+	std::size_t operator()(const Ludus::Engine::Core::SceneId& id) const noexcept
+	{
+		return std::hash<std::uint64_t> {}(id.Value);
+	}
+};
+
+template<>
+struct std::hash<Ludus::Engine::Core::ScriptId>
+{
+	std::size_t operator()(const Ludus::Engine::Core::ScriptId& id) const noexcept
+	{
+		return std::hash<std::uint64_t> {}(id.Value);
+	}
+};

--- a/Engine/Include/Ludus/Engine/Core/RenderViewRegistry.h
+++ b/Engine/Include/Ludus/Engine/Core/RenderViewRegistry.h
@@ -3,7 +3,7 @@
 #include <span>
 #include <vector>
 
-#include <Ludus/Engine/Core/Scene.h>
+#include <Ludus/Engine/Core/Id.h>
 #include <Ludus/Engine/Graphics/RenderView2D.h>
 
 namespace Ludus::Engine::Core
@@ -21,13 +21,13 @@ namespace Ludus::Engine::Core
 			m_RenderViews.push_back(renderView);
 		}
 
-		void RegisterFullscreen(std::optional<SceneHandle> sceneHandle, const Ludus::Engine::Graphics::Camera2D& camera, Ludus::Engine::Graphics::RenderTarget& target)
+		void RegisterFullscreen(std::optional<SceneId> sceneId, const Ludus::Engine::Graphics::Camera2D& camera, Ludus::Engine::Graphics::RenderTarget& target)
 		{
 			const auto [width, height] = target.Framebuffer.GetSize();
 
 			Ludus::Engine::Graphics::RenderView2D renderView {
 				.Camera = camera,
-				.SceneHandle = sceneHandle,
+				.SceneId = sceneId,
 				.Target = &target,
 				.ViewportRect = Ludus::Engine::Math::Rect::Create(
 					{ 0.0f, 0.0f },

--- a/Engine/Include/Ludus/Engine/Core/Scene.h
+++ b/Engine/Include/Ludus/Engine/Core/Scene.h
@@ -1,30 +1,31 @@
 #pragma once
 
-#include <cstdint>
 #include <optional>
 #include <string>
 #include <string_view>
+#include <unordered_map>
 
 #include <Ludus/Engine/Components/Camera2DComponent.h>
 #include <Ludus/Engine/Core/EntityComponentSystem.h>
+#include <Ludus/Engine/Core/Id.h>
 
 namespace Ludus::Engine::Core
 {
-	using SceneHandle = uint64_t;
-
 	struct Scene
 	{
 	public:
-		SceneHandle Handle;
+		SceneId Id { SceneId::Invalid() };
 		std::string Name;
 		Ludus::Engine::Core::EntityComponentSystem EntityComponentSystem;
 
-		Scene(SceneHandle handle)
-			: Handle(handle), Name("Untitled")
+		Scene() = default;
+
+		Scene(SceneId id)
+			: Id(id), Name("Untitled")
 		{ }
 
-		Scene(SceneHandle handle, std::string_view name)
-			: Handle(handle), Name(name)
+		Scene(SceneId id, std::string_view name)
+			: Id(id), Name(name)
 		{ }
 
 		Scene(const Scene&) = delete;
@@ -34,51 +35,69 @@ namespace Ludus::Engine::Core
 
 		static Scene Clone(const Scene& source)
 		{
-			auto clone = Scene(source.Handle, source.Name);
+			auto clone = Scene(source.Id, source.Name);
+			auto clonedEntityIds = std::unordered_map<EntityId, EntityId> { };
 
 			for (const auto& entity : source.EntityComponentSystem.View())
 			{
-				clone.EntityComponentSystem.RestoreEntity(entity.Handle);
+				const auto clonedEntityId = clone.EntityComponentSystem.RestoreEntity(entity.Id);
+				clonedEntityIds.emplace(entity.Id, clonedEntityId);
 			}
 
 			for (const auto& component : source.EntityComponentSystem.Cameras.View())
 			{
-				clone.EntityComponentSystem.AttachCamera(component);
+				auto cloned = component;
+				cloned.OwnerId = clonedEntityIds.at(component.OwnerId);
+				clone.EntityComponentSystem.AttachCamera(cloned);
 			}
 
 			for (const auto& component : source.EntityComponentSystem.Colliders.View())
 			{
-				clone.EntityComponentSystem.AttachCollider(component);
+				auto cloned = component;
+				cloned.OwnerId = clonedEntityIds.at(component.OwnerId);
+				clone.EntityComponentSystem.AttachCollider(cloned);
 			}
 
 			for (const auto& component : source.EntityComponentSystem.DisplayNames.View())
 			{
-				clone.EntityComponentSystem.AttachDisplayName(component);
+				auto cloned = component;
+				cloned.OwnerId = clonedEntityIds.at(component.OwnerId);
+				clone.EntityComponentSystem.AttachDisplayName(cloned);
 			}
 
 			for (const auto& component : source.EntityComponentSystem.RigidBodies.View())
 			{
-				clone.EntityComponentSystem.AttachRigidBody(component);
+				auto cloned = component;
+				cloned.OwnerId = clonedEntityIds.at(component.OwnerId);
+				clone.EntityComponentSystem.AttachRigidBody(cloned);
 			}
 
 			for (const auto& component : source.EntityComponentSystem.Scripts.View())
 			{
-				clone.EntityComponentSystem.AttachScript(component);
+				auto cloned = component;
+				cloned.OwnerId = clonedEntityIds.at(component.OwnerId);
+				clone.EntityComponentSystem.AttachScript(cloned);
 			}
 
 			for (const auto& component : source.EntityComponentSystem.Sprites.View())
 			{
-				clone.EntityComponentSystem.AttachSprite(component);
+				auto cloned = component;
+				cloned.OwnerId = clonedEntityIds.at(component.OwnerId);
+				clone.EntityComponentSystem.AttachSprite(cloned);
 			}
 
 			for (const auto& component : source.EntityComponentSystem.Texts.View())
 			{
-				clone.EntityComponentSystem.AttachText(component);
+				auto cloned = component;
+				cloned.OwnerId = clonedEntityIds.at(component.OwnerId);
+				clone.EntityComponentSystem.AttachText(cloned);
 			}
 
 			for (const auto& component : source.EntityComponentSystem.Transforms.View())
 			{
-				clone.EntityComponentSystem.AttachTransform(component);
+				auto cloned = component;
+				cloned.OwnerId = clonedEntityIds.at(component.OwnerId);
+				clone.EntityComponentSystem.AttachTransform(cloned);
 			}
 
 			return clone;
@@ -138,7 +157,7 @@ namespace Ludus::Engine::Core
 				return std::nullopt;
 			}
 
-			auto* transformPtr = EntityComponentSystem.Transforms.TryGetByOwnerMutable(cameraPtr->OwnerHandle);
+			auto* transformPtr = EntityComponentSystem.Transforms.TryGetByOwnerMutable(cameraPtr->OwnerId);
 			if (!transformPtr)
 			{
 				return std::nullopt;

--- a/Engine/Include/Ludus/Engine/Core/SceneRegistry.h
+++ b/Engine/Include/Ludus/Engine/Core/SceneRegistry.h
@@ -8,6 +8,7 @@
 #include <utility>
 #include <vector>
 
+#include <Ludus/Engine/Core/Id.h>
 #include <Ludus/Engine/Core/Random.h>
 #include <Ludus/Engine/Core/Scene.h>
 #include <Ludus/Engine/Debug/Debug.h>
@@ -18,7 +19,7 @@ namespace Ludus::Engine::Core
 	{
 	private:
 		std::vector<Ludus::Engine::Core::Scene> m_Scenes;
-		std::unordered_map<Ludus::Engine::Core::SceneHandle, size_t> m_HandleToIndex;
+		std::unordered_map<Ludus::Engine::Core::SceneId, size_t> m_IdToIndex;
 		Ludus::Engine::Core::Random m_Random;
 		static constexpr size_t MaxUniqueIdAttempts = 32;
 
@@ -32,41 +33,50 @@ namespace Ludus::Engine::Core
 				std::swap(m_Scenes[index], m_Scenes[lastIndex]);
 
 				// Fix the indices of the moved scene.
-				const auto movedHandle = m_Scenes[index].Handle;
-				m_HandleToIndex[movedHandle] = index;
+				const auto movedId = m_Scenes[index].Id;
+				m_IdToIndex[movedId] = index;
 			}
 
-			const auto removedHandle = m_Scenes[lastIndex].Handle;
-			m_HandleToIndex.erase(removedHandle);
+			const auto removedId = m_Scenes[lastIndex].Id;
+			m_IdToIndex.erase(removedId);
 
 			m_Scenes.pop_back();
 		}
 
-		Ludus::Engine::Core::SceneHandle CommitScene(Ludus::Engine::Core::Scene scene)
+		Ludus::Engine::Core::SceneId CommitScene(Ludus::Engine::Core::Scene scene)
 		{
-			const auto sceneHandle = scene.Handle;
-			LUDUS_ASSERT(!Contains(sceneHandle), "Scene handle collision.");
+			auto sceneId = scene.Id;
+			if (!sceneId.IsValid())
+			{
+				sceneId = CreateUniqueId();
+			}
+			else
+			{
+				LUDUS_ASSERT(!Contains(sceneId), "Cannot add a scene with a duplicate id.");
+			}
+
+			scene.Id = sceneId;
 
 			m_Scenes.push_back(std::move(scene));
-			m_HandleToIndex[sceneHandle] = m_Scenes.size() - 1;
+			m_IdToIndex[sceneId] = m_Scenes.size() - 1;
 
-			return sceneHandle;
+			return sceneId;
 		}
 
-		Ludus::Engine::Core::SceneHandle CreateUniqueId()
+		Ludus::Engine::Core::SceneId CreateUniqueId()
 		{
 			// Retry a fixed number of times to avoid collision loop.
 			for (size_t attempt = 0; attempt < MaxUniqueIdAttempts; ++attempt)
 			{
-				const auto handle = m_Random.NextId();
-				if (!Contains(handle))
+				const auto id = SceneId { m_Random.NextId() };
+				if (!Contains(id))
 				{
-					return handle;
+					return id;
 				}
 			}
 
-			LUDUS_ASSERT(false, "Failed to generate a unique scene handle.");
-			return 0;
+			LUDUS_ASSERT(false, "Failed to generate a unique scene id.");
+			return SceneId::Invalid();
 		}
 
 	public:
@@ -75,7 +85,7 @@ namespace Ludus::Engine::Core
 		SceneRegistry(std::vector<Ludus::Engine::Core::Scene> scenes)
 		{
 			m_Scenes.reserve(scenes.size());
-			m_HandleToIndex.reserve(scenes.size());
+			m_IdToIndex.reserve(scenes.size());
 
 			for (auto& scene : scenes)
 			{
@@ -96,24 +106,24 @@ namespace Ludus::Engine::Core
 			return { m_Scenes.data(), m_Scenes.size() };
 		}
 
-		bool Contains(Ludus::Engine::Core::SceneHandle handle) const
+		bool Contains(Ludus::Engine::Core::SceneId id) const
 		{
-			return m_HandleToIndex.contains(handle);
+			return m_IdToIndex.contains(id);
 		}
 
-		Ludus::Engine::Core::SceneHandle AddScene(std::string_view name)
+		Ludus::Engine::Core::SceneId AddScene(std::string_view name)
 		{
-			return CommitScene(Ludus::Engine::Core::Scene { CreateUniqueId(), name });
+			return CommitScene(Ludus::Engine::Core::Scene { SceneId::Invalid(), name });
 		}
 
-		Ludus::Engine::Core::SceneHandle AddScene(Ludus::Engine::Core::Scene scene)
+		Ludus::Engine::Core::SceneId AddScene(Ludus::Engine::Core::Scene scene)
 		{
 			return CommitScene(std::move(scene));
 		}
 
-		bool RemoveScene(Ludus::Engine::Core::SceneHandle handle)
+		bool RemoveScene(Ludus::Engine::Core::SceneId id)
 		{
-			if (auto iter = m_HandleToIndex.find(handle); iter != m_HandleToIndex.end())
+			if (auto iter = m_IdToIndex.find(id); iter != m_IdToIndex.end())
 			{
 				RemoveAndReorderIndices(iter->second);
 
@@ -123,9 +133,9 @@ namespace Ludus::Engine::Core
 			return false;
 		}
 
-		Ludus::Engine::Core::Scene* TryGetScene(Ludus::Engine::Core::SceneHandle handle)
+		Ludus::Engine::Core::Scene* TryGetScene(Ludus::Engine::Core::SceneId id)
 		{
-			if (auto iter = m_HandleToIndex.find(handle); iter != m_HandleToIndex.end())
+			if (auto iter = m_IdToIndex.find(id); iter != m_IdToIndex.end())
 			{
 				return &m_Scenes[iter->second];
 			}
@@ -133,9 +143,9 @@ namespace Ludus::Engine::Core
 			return nullptr;
 		}
 
-		const Ludus::Engine::Core::Scene* TryGetScene(Ludus::Engine::Core::SceneHandle handle) const
+		const Ludus::Engine::Core::Scene* TryGetScene(Ludus::Engine::Core::SceneId id) const
 		{
-			if (auto iter = m_HandleToIndex.find(handle); iter != m_HandleToIndex.end())
+			if (auto iter = m_IdToIndex.find(id); iter != m_IdToIndex.end())
 			{
 				return &m_Scenes[iter->second];
 			}
@@ -143,24 +153,24 @@ namespace Ludus::Engine::Core
 			return nullptr;
 		}
 
-		Ludus::Engine::Core::Scene& GetScene(Ludus::Engine::Core::SceneHandle handle)
+		Ludus::Engine::Core::Scene& GetScene(Ludus::Engine::Core::SceneId id)
 		{
-			auto* scene = TryGetScene(handle);
-			LUDUS_ASSERT(scene != nullptr, "Scene handle does not exist.");
+			auto* scene = TryGetScene(id);
+			LUDUS_ASSERT(scene != nullptr, "Scene id does not exist.");
 			return *scene;
 		}
 
-		const Ludus::Engine::Core::Scene& GetScene(Ludus::Engine::Core::SceneHandle handle) const
+		const Ludus::Engine::Core::Scene& GetScene(Ludus::Engine::Core::SceneId id) const
 		{
-			const auto* scene = TryGetScene(handle);
-			LUDUS_ASSERT(scene != nullptr, "Scene handle does not exist.");
+			const auto* scene = TryGetScene(id);
+			LUDUS_ASSERT(scene != nullptr, "Scene id does not exist.");
 			return *scene;
 		}
 
 		void Clear()
 		{
 			m_Scenes.clear();
-			m_HandleToIndex.clear();
+			m_IdToIndex.clear();
 		}
 	};
 }

--- a/Engine/Include/Ludus/Engine/Graphics/NoCameraRenderPass.h
+++ b/Engine/Include/Ludus/Engine/Graphics/NoCameraRenderPass.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Ludus/Engine/Components/Transform2DComponent.h>
+#include <Ludus/Engine/Core/Id.h>
 #include <Ludus/Engine/Graphics/CameraSource.h>
 #include <Ludus/Engine/Graphics/Color.h>
 #include <Ludus/Engine/Graphics/IRenderPass.h>
@@ -21,7 +22,7 @@ namespace Ludus::Engine::Graphics
 
 		virtual bool Enabled(RenderContext2D& context) override
 		{
-			if (!context.RenderView.SceneHandle)
+			if (!context.RenderView.SceneId)
 			{
 				return false;
 			}
@@ -34,7 +35,7 @@ namespace Ludus::Engine::Graphics
 			const auto worldRect = context.RenderView.Camera.GetWorldRect();
 
 			const Ludus::Engine::Components::Transform2DComponent transform(
-				0,
+				Ludus::Engine::Core::EntityId::Invalid(),
 				{ worldRect.Position.X, worldRect.Position.Y },
 				{ 0.03f, 0.03f },
 				0.0f

--- a/Engine/Include/Ludus/Engine/Graphics/RenderView2D.h
+++ b/Engine/Include/Ludus/Engine/Graphics/RenderView2D.h
@@ -2,7 +2,7 @@
 
 #include <optional>
 
-#include <Ludus/Engine/Core/Scene.h>
+#include <Ludus/Engine/Core/Id.h>
 #include <Ludus/Engine/Graphics/Camera2D.h>
 #include <Ludus/Engine/Graphics/CameraSource.h>
 #include <Ludus/Engine/Graphics/RenderTarget.h>
@@ -13,7 +13,7 @@ namespace Ludus::Engine::Graphics
 	struct RenderView2D
 	{
 		Ludus::Engine::Graphics::Camera2D Camera;
-		std::optional<Ludus::Engine::Core::SceneHandle> SceneHandle;
+		std::optional<Ludus::Engine::Core::SceneId> SceneId;
 		Ludus::Engine::Graphics::RenderTarget* Target = nullptr;
 		Ludus::Engine::Math::Rect ViewportRect;
 		Ludus::Engine::Graphics::CameraSource CameraSource = Ludus::Engine::Graphics::CameraSource::None;

--- a/Engine/Include/Ludus/Engine/Graphics/RenderViewRequest2D.h
+++ b/Engine/Include/Ludus/Engine/Graphics/RenderViewRequest2D.h
@@ -2,7 +2,7 @@
 
 #include <optional>
 
-#include <Ludus/Engine/Core/Scene.h>
+#include <Ludus/Engine/Core/Id.h>
 #include <Ludus/Engine/Graphics/Camera2D.h>
 #include <Ludus/Engine/Graphics/RenderTarget.h>
 #include <Ludus/Engine/Math/Rect.h>
@@ -12,7 +12,7 @@ namespace Ludus::Engine::Graphics
 	struct RenderViewRequest2D
 	{
 		std::optional<Ludus::Engine::Graphics::Camera2D> Camera;
-		std::optional<Ludus::Engine::Core::SceneHandle> SceneHandle;
+		std::optional<Ludus::Engine::Core::SceneId> SceneId;
 		RenderTarget* Target = nullptr;
 		Ludus::Engine::Math::Rect ViewportRect;
 	};

--- a/Engine/Include/Ludus/Engine/Graphics/RenderViewSystem.h
+++ b/Engine/Include/Ludus/Engine/Graphics/RenderViewSystem.h
@@ -107,7 +107,7 @@ namespace Ludus::Engine::Graphics
 
 				return {
 					.Camera = camera,
-					.SceneHandle = request.SceneHandle,
+					.SceneId = request.SceneId,
 					.Target = request.Target,
 					.ViewportRect = request.ViewportRect,
 					.CameraSource = Ludus::Engine::Graphics::CameraSource::Explicit
@@ -115,9 +115,9 @@ namespace Ludus::Engine::Graphics
 			}
 
 			// Resolve camera from scene -> Scene primary camera view.
-			if (request.SceneHandle)
+			if (request.SceneId)
 			{
-				auto* scene = sceneRegistry.TryGetScene(*request.SceneHandle);
+				auto* scene = sceneRegistry.TryGetScene(*request.SceneId);
 				if (scene)
 				{
 					if (auto primaryCamera = scene->TryGetPrimaryCamera2D(); primaryCamera)
@@ -130,7 +130,7 @@ namespace Ludus::Engine::Graphics
 
 						return {
 							.Camera = camera,
-							.SceneHandle = request.SceneHandle,
+							.SceneId = request.SceneId,
 							.Target = request.Target,
 							.ViewportRect = request.ViewportRect,
 							.CameraSource = Ludus::Engine::Graphics::CameraSource::Scene
@@ -141,7 +141,7 @@ namespace Ludus::Engine::Graphics
 				// Scene exists but no camera component -> default empty view.
 				return {
 					.Camera = CreateDefaultCamera(targetWidth, targetHeight),
-					.SceneHandle = request.SceneHandle,
+					.SceneId = request.SceneId,
 					.Target = request.Target,
 					.ViewportRect = request.ViewportRect,
 					.CameraSource = Ludus::Engine::Graphics::CameraSource::None
@@ -151,7 +151,7 @@ namespace Ludus::Engine::Graphics
 			// No camera and no scene -> Overlay and no-scene views.
 			return {
 				.Camera = CreateDefaultCamera(targetWidth, targetHeight),
-				.SceneHandle = std::nullopt,
+				.SceneId = std::nullopt,
 				.Target = request.Target,
 				.ViewportRect = request.ViewportRect,
 				.CameraSource = Ludus::Engine::Graphics::CameraSource::None

--- a/Engine/Include/Ludus/Engine/Graphics/SceneRenderPass.h
+++ b/Engine/Include/Ludus/Engine/Graphics/SceneRenderPass.h
@@ -20,18 +20,18 @@ namespace Ludus::Engine::Graphics
 
 		virtual bool Enabled(Ludus::Engine::Graphics::RenderContext2D& context) override
 		{
-			return context.RenderView.SceneHandle
+			return context.RenderView.SceneId.has_value()
 				&& context.RenderView.CameraSource != CameraSource::None;
 		};
 
 		virtual void Execute(Ludus::Engine::Graphics::RenderContext2D& context, Ludus::Engine::Graphics::Renderer2D& renderer) override
 		{
-			if (!context.RenderView.SceneHandle)
+			if (!context.RenderView.SceneId)
 			{
 				return;
 			}
 
-			const auto* scene = context.SceneRegistry.TryGetScene(*context.RenderView.SceneHandle);
+			const auto* scene = context.SceneRegistry.TryGetScene(*context.RenderView.SceneId);
 			if (!scene)
 			{
 				return;
@@ -45,7 +45,7 @@ namespace Ludus::Engine::Graphics
 			const auto& ecs = scene->EntityComponentSystem;
 			for (const auto& sprite : ecs.Sprites.View())
 			{
-				const auto* transform = ecs.Transforms.TryGetByOwner(sprite.OwnerHandle);
+				const auto* transform = ecs.Transforms.TryGetByOwner(sprite.OwnerId);
 				if (!transform)
 				{
 					continue;
@@ -64,7 +64,7 @@ namespace Ludus::Engine::Graphics
 
 			for (const auto& text : ecs.Texts.View())
 			{
-				const auto* transform = ecs.Transforms.TryGetByOwner(text.OwnerHandle);
+				const auto* transform = ecs.Transforms.TryGetByOwner(text.OwnerId);
 				if (transform)
 				{
 					renderer.DrawText(*transform, text.Text, text.Color, text.HorizontalTextAlignment);

--- a/Engine/Include/Ludus/Engine/Physics/Core/PhysicsSystem2D.h
+++ b/Engine/Include/Ludus/Engine/Physics/Core/PhysicsSystem2D.h
@@ -54,19 +54,19 @@ namespace Ludus::Engine::Physics::Core
 
 			for (auto& body : rigidBodies)
 			{
-				auto* transform = entityComponentSystem.Transforms.TryGetByOwnerMutable(body.OwnerHandle);
+				auto* transform = entityComponentSystem.Transforms.TryGetByOwnerMutable(body.OwnerId);
 				if (!transform)
 				{
 					continue;
 				}
 
-				auto* collider = entityComponentSystem.Colliders.TryGetByOwnerMutable(body.OwnerHandle);
+				auto* collider = entityComponentSystem.Colliders.TryGetByOwnerMutable(body.OwnerId);
 				if (!collider)
 				{
 					continue;
 				}
 
-				m_PhysicsWorld.Entities.push_back(body.OwnerHandle);
+				m_PhysicsWorld.Entities.push_back(body.OwnerId);
 				m_PhysicsWorld.Colliders.push_back(collider);
 				m_PhysicsWorld.RigidBodies.push_back(&body);
 				m_PhysicsWorld.Transforms.push_back(transform);

--- a/Engine/Include/Ludus/Engine/Physics/Core/PhysicsWorld2D.h
+++ b/Engine/Include/Ludus/Engine/Physics/Core/PhysicsWorld2D.h
@@ -3,12 +3,13 @@
 #include <Ludus/Engine/Components/Collider2DComponent.h>
 #include <Ludus/Engine/Components/RigidBody2DComponent.h>
 #include <Ludus/Engine/Components/Transform2DComponent.h>
+#include <Ludus/Engine/Core/Id.h>
 
 namespace Ludus::Engine::Physics::Core
 {
 	struct PhysicsWorld2D
 	{
-		std::vector<Ludus::Engine::Core::EntityHandle> Entities;
+		std::vector<Ludus::Engine::Core::EntityId> Entities;
 		std::vector<Ludus::Engine::Components::Collider2DComponent*> Colliders;
 		std::vector<Ludus::Engine::Components::RigidBody2DComponent*> RigidBodies;
 		std::vector<Ludus::Engine::Components::Transform2DComponent*> Transforms;

--- a/Engine/Include/Ludus/Engine/Physics/Narrowphase/ContactPair2D.h
+++ b/Engine/Include/Ludus/Engine/Physics/Narrowphase/ContactPair2D.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <Ludus/Engine/Core/Entity.h>
+#include <Ludus/Engine/Core/Id.h>
 #include <Ludus/Engine/Math/Vector2D.h>
 #include <Ludus/Engine/Physics/Narrowphase/ContactPoint2D.h>
 
@@ -8,8 +8,8 @@ namespace Ludus::Engine::Physics::Narrowphase
 {
 	struct ContactPair2D
 	{
-		Ludus::Engine::Core::EntityHandle EntityHandleA;
-		Ludus::Engine::Core::EntityHandle EntityHandleB;
+		Ludus::Engine::Core::EntityId EntityIdA;
+		Ludus::Engine::Core::EntityId EntityIdB;
 		size_t WorldIndexA;
 		size_t WorldIndexB;
 		ContactPoint2D Point;

--- a/Engine/Include/Ludus/Engine/Physics/Narrowphase/NaiveNarrowphase2D.h
+++ b/Engine/Include/Ludus/Engine/Physics/Narrowphase/NaiveNarrowphase2D.h
@@ -48,7 +48,7 @@ namespace Ludus::Engine::Physics::Narrowphase
 
 				const auto isTrigger = colliderA->IsTrigger || colliderB->IsTrigger;
 
-				outContacts.push_back({ colliderA->OwnerHandle, colliderB->OwnerHandle, i, j, contactPoint, isTrigger });
+				outContacts.push_back({ colliderA->OwnerId, colliderB->OwnerId, i, j, contactPoint, isTrigger });
 			}
 		}
 	};

--- a/Engine/Include/Ludus/Engine/Physics/Queries/IPhysicsQueryCache2D.h
+++ b/Engine/Include/Ludus/Engine/Physics/Queries/IPhysicsQueryCache2D.h
@@ -3,12 +3,12 @@
 #include <span>
 #include <vector>
 
-#include <Ludus/Engine/Core/Entity.h>
+#include <Ludus/Engine/Core/Id.h>
 #include <Ludus/Engine/Physics/Narrowphase/ContactPair2D.h>
 
 namespace Ludus::Engine::Physics::Queries
 {
-	using EntityHandle = Ludus::Engine::Core::EntityHandle;
+	using EntityId = Ludus::Engine::Core::EntityId;
 
 	class IPhysicsQueryCache2D
 	{
@@ -16,13 +16,13 @@ namespace Ludus::Engine::Physics::Queries
 		virtual ~IPhysicsQueryCache2D() = default;
 
 		virtual void UpdateFromContacts(const std::vector <Ludus::Engine::Physics::Narrowphase::ContactPair2D> contactPairs) = 0;
-		virtual std::span<const Ludus::Engine::Physics::Narrowphase::ContactPair2D> GetContacts(EntityHandle handle) const = 0;
+		virtual std::span<const Ludus::Engine::Physics::Narrowphase::ContactPair2D> GetContacts(EntityId id) const = 0;
 
-		virtual bool IsColliding(EntityHandle a) const = 0;
-		virtual bool IsColliding(EntityHandle a, EntityHandle b) const = 0;
+		virtual bool IsColliding(EntityId a) const = 0;
+		virtual bool IsColliding(EntityId a, EntityId b) const = 0;
 
-		virtual bool IsTriggering(EntityHandle a) const = 0;
-		virtual bool IsTriggering(EntityHandle a, EntityHandle b) const = 0;
+		virtual bool IsTriggering(EntityId a) const = 0;
+		virtual bool IsTriggering(EntityId a, EntityId b) const = 0;
 
 		virtual void Clear() = 0;
 	};

--- a/Engine/Include/Ludus/Engine/Physics/Queries/PhysicsQueryCache2D.h
+++ b/Engine/Include/Ludus/Engine/Physics/Queries/PhysicsQueryCache2D.h
@@ -4,24 +4,24 @@
 #include <unordered_map>
 #include <vector>
 
-#include <Ludus/Engine/Core/Entity.h>
+#include <Ludus/Engine/Core/Id.h>
 #include <Ludus/Engine/Physics/Narrowphase/ContactPair2D.h>
 #include <Ludus/Engine/Physics/Queries/IPhysicsQueryCache2D.h>
 
 namespace Ludus::Engine::Physics::Queries
 {
-	using EntityHandle = Ludus::Engine::Core::EntityHandle;
+	using EntityId = Ludus::Engine::Core::EntityId;
 	using ContactPair2D = Ludus::Engine::Physics::Narrowphase::ContactPair2D;
 
 	class PhysicsQueryCache2D : public Ludus::Engine::Physics::Queries::IPhysicsQueryCache2D
 	{
 	private:
-		std::unordered_map<EntityHandle, std::vector<ContactPair2D>> m_ContactsByEntity;
+		std::unordered_map<EntityId, std::vector<ContactPair2D>> m_ContactsByEntity;
 
-		static bool PairInvolves(const ContactPair2D& pair, EntityHandle a, EntityHandle b)
+		static bool PairInvolves(const ContactPair2D& pair, EntityId a, EntityId b)
 		{
-			return (pair.EntityHandleA == a && pair.EntityHandleB == b) ||
-				(pair.EntityHandleA == b && pair.EntityHandleB == a);
+			return (pair.EntityIdA == a && pair.EntityIdB == b) ||
+				(pair.EntityIdA == b && pair.EntityIdB == a);
 		}
 
 	public:
@@ -33,17 +33,17 @@ namespace Ludus::Engine::Physics::Queries
 
 			for (const auto& contact : contactPairs)
 			{
-				const EntityHandle handleA = contact.EntityHandleA;
-				const EntityHandle handleB = contact.EntityHandleB;
+				const EntityId idA = contact.EntityIdA;
+				const EntityId idB = contact.EntityIdB;
 
-				m_ContactsByEntity[handleA].push_back(contact);
-				m_ContactsByEntity[handleB].push_back(contact);
+				m_ContactsByEntity[idA].push_back(contact);
+				m_ContactsByEntity[idB].push_back(contact);
 			}
 		}
 
-		virtual std::span<const ContactPair2D> GetContacts(EntityHandle handle) const override
+		virtual std::span<const ContactPair2D> GetContacts(EntityId id) const override
 		{
-			auto iter = m_ContactsByEntity.find(handle);
+			auto iter = m_ContactsByEntity.find(id);
 			if (iter == m_ContactsByEntity.end())
 			{
 				return { };
@@ -52,9 +52,9 @@ namespace Ludus::Engine::Physics::Queries
 			return iter->second;
 		}
 
-		virtual bool IsColliding(EntityHandle handle) const override
+		virtual bool IsColliding(EntityId id) const override
 		{
-			auto iter = m_ContactsByEntity.find(handle);
+			auto iter = m_ContactsByEntity.find(id);
 			if (iter == m_ContactsByEntity.end())
 			{
 				return false;
@@ -63,9 +63,9 @@ namespace Ludus::Engine::Physics::Queries
 			return !iter->second.empty();
 		}
 
-		virtual bool IsColliding(EntityHandle handleA, EntityHandle handleB) const override
+		virtual bool IsColliding(EntityId idA, EntityId idB) const override
 		{
-			auto iter = m_ContactsByEntity.find(handleA);
+			auto iter = m_ContactsByEntity.find(idA);
 			if (iter == m_ContactsByEntity.end())
 			{
 				return false;
@@ -75,16 +75,16 @@ namespace Ludus::Engine::Physics::Queries
 			return std::any_of(
 				contacts.begin(),
 				contacts.end(),
-				[handleA, handleB](const ContactPair2D& pair)
+				[idA, idB](const ContactPair2D& pair)
 			{
-				return PairInvolves(pair, handleA, handleB);
+				return PairInvolves(pair, idA, idB);
 			}
 			);
 		}
 
-		virtual bool IsTriggering(EntityHandle handle) const override
+		virtual bool IsTriggering(EntityId id) const override
 		{
-			auto iter = m_ContactsByEntity.find(handle);
+			auto iter = m_ContactsByEntity.find(id);
 			if (iter == m_ContactsByEntity.end())
 			{
 				return false;
@@ -101,9 +101,9 @@ namespace Ludus::Engine::Physics::Queries
 			);
 		}
 
-		virtual bool IsTriggering(EntityHandle handleA, EntityHandle handleB) const override
+		virtual bool IsTriggering(EntityId idA, EntityId idB) const override
 		{
-			auto iter = m_ContactsByEntity.find(handleA);
+			auto iter = m_ContactsByEntity.find(idA);
 			if (iter == m_ContactsByEntity.end())
 			{
 				return false;
@@ -114,9 +114,9 @@ namespace Ludus::Engine::Physics::Queries
 			return std::any_of(
 				contacts.begin(),
 				contacts.end(),
-				[handleA, handleB](const ContactPair2D& pair)
+				[idA, idB](const ContactPair2D& pair)
 			{
-				return pair.IsTriggerPair && PairInvolves(pair, handleA, handleB);
+				return pair.IsTriggerPair && PairInvolves(pair, idA, idB);
 			}
 			);
 		}

--- a/Engine/Include/Ludus/Engine/Platform/Guid.h
+++ b/Engine/Include/Ludus/Engine/Platform/Guid.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <array>
+#include <compare>
+#include <cstdint>
+#include <functional>
+#include <optional>
+#include <string>
+#include <string_view>
+
+namespace Ludus::Engine::Platform
+{
+	struct Guid
+	{
+		std::array<std::uint8_t, 16> Bytes { };
+
+		bool IsEmpty() const;
+
+		// Format: lowercase 8-4-4-4-12.
+		std::string ToString() const;
+
+		// Use std::array default comparison.
+		auto operator<=>(const Guid&) const = default;
+	};
+
+	Guid CreateGuid();
+
+	std::optional<Guid> TryParse(std::string_view text);
+}
+
+template<>
+struct std::hash<Ludus::Engine::Platform::Guid>
+{
+	std::size_t operator()(const Ludus::Engine::Platform::Guid& guid) const noexcept
+	{
+		std::size_t hash = 0;
+		for (auto byte : guid.Bytes)
+		{
+			hash = hash * 37 + byte;
+		}
+		return hash;
+	}
+};

--- a/Engine/Include/Ludus/Engine/Runtime/RuntimeManifest.h
+++ b/Engine/Include/Ludus/Engine/Runtime/RuntimeManifest.h
@@ -5,22 +5,21 @@
 #include <utility>
 #include <vector>
 
-#include <Ludus/Engine/Components/ScriptComponent.h>
-#include <Ludus/Engine/Core/Scene.h>
+#include <Ludus/Engine/Core/Id.h>
 #include <Ludus/Engine/Core/Version.h>
 
 namespace Ludus::Engine::Runtime
 {
 	struct SceneReference
 	{
-		Ludus::Engine::Core::SceneHandle Handle = 0;
+		Ludus::Engine::Core::SceneId Id { Ludus::Engine::Core::SceneId::Invalid() };
 		std::string Name;
 		std::filesystem::path Path;
 	};
 
 	struct ScriptReference
 	{
-		Ludus::Engine::Components::ScriptHandle Handle = 0;
+		Ludus::Engine::Core::ScriptId Id { Ludus::Engine::Core::ScriptId::Invalid() };
 		std::string Name;
 	};
 
@@ -29,22 +28,35 @@ namespace Ludus::Engine::Runtime
 		inline static constexpr Ludus::Engine::Core::Version CurrentVersion = { 0, 2, 0 };
 
 		Ludus::Engine::Core::Version Version = CurrentVersion;
-		Ludus::Engine::Core::SceneHandle EntrySceneHandle = 0;
+		Ludus::Engine::Core::SceneId EntrySceneId { Ludus::Engine::Core::SceneId::Invalid() };
 		std::vector<SceneReference> Scenes;
 		std::vector<ScriptReference> Scripts;
 
 		static RuntimeManifest Create(
-			Ludus::Engine::Core::SceneHandle entrySceneHandle = 0,
+			Ludus::Engine::Core::SceneId entrySceneId = Ludus::Engine::Core::SceneId::Invalid(),
 			std::vector<SceneReference> scenes = { },
 			std::vector<ScriptReference> scripts = { }
 		)
 		{
 			return {
 				.Version = CurrentVersion,
-				.EntrySceneHandle = entrySceneHandle,
+				.EntrySceneId = entrySceneId,
 				.Scenes = std::move(scenes),
 				.Scripts = std::move(scripts)
 			};
+		}
+
+		const ScriptReference* TryGetScriptReference(Ludus::Engine::Core::ScriptId id) const
+		{
+			for (const auto& scriptReference : Scripts)
+			{
+				if (scriptReference.Id == id)
+				{
+					return &scriptReference;
+				}
+			}
+
+			return nullptr;
 		}
 	};
 }

--- a/Engine/Include/Ludus/Engine/Runtime/ScenePresentationState.h
+++ b/Engine/Include/Ludus/Engine/Runtime/ScenePresentationState.h
@@ -1,11 +1,11 @@
 #pragma once
 
-#include <Ludus/Engine/Core/Scene.h>
+#include <Ludus/Engine/Core/Id.h>
 
 namespace Ludus::Engine::Runtime
 {
 	struct ScenePresentationState
 	{
-		Ludus::Engine::Core::SceneHandle CurrentSceneHandle;
+		Ludus::Engine::Core::SceneId CurrentSceneId;
 	};
 }

--- a/Engine/Include/Ludus/Engine/Scripting/ScriptBindings.h
+++ b/Engine/Include/Ludus/Engine/Scripting/ScriptBindings.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <Ludus/Engine/Core/Scene.h>
+#include <Ludus/Engine/Core/Id.h>
 #include <Ludus/Scripting/ABI/ScriptContext.h>
 #include <Ludus/Scripting/ABI/Types.h>
 
@@ -21,14 +21,14 @@ namespace Ludus::Engine::Scripting
 	ScriptBindingsState* CreateScriptBindingsState(
 		Ludus::Engine::Core::SceneRegistry& sceneRegistry,
 		Ludus::Engine::Windowing::Input& input,
-		Ludus::Engine::Core::SceneHandle activeSceneHandle
+		Ludus::Engine::Core::SceneId activeSceneId
 	);
 
 	void DestroyScriptBindingsState(ScriptBindingsState* state);
 
 	void SetActiveScene(
 		ScriptBindingsState* state,
-		Ludus::Engine::Core::SceneHandle sceneHandle
+		Ludus::Engine::Core::SceneId sceneId
 	);
 
 	const Ludus::Scripting::ABI::ScriptAPI* GetScriptAPI(

--- a/Engine/Include/Ludus/Engine/Scripting/ScriptEngine.h
+++ b/Engine/Include/Ludus/Engine/Scripting/ScriptEngine.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <Ludus/Engine/Core/Scene.h>
+#include <Ludus/Engine/Core/Id.h>
 #include <Ludus/Engine/Scripting/ScriptBindings.h>
 #include <Ludus/Scripting/ABI/ScriptContext.h>
 #include <Ludus/Scripting/ABI/Types.h>
@@ -30,13 +30,13 @@ namespace Ludus::Engine::Scripting
 		ScriptEngine(
 			Ludus::Engine::Core::SceneRegistry& sceneRegistry,
 			Ludus::Engine::Windowing::Input& input,
-			Ludus::Engine::Core::SceneHandle activeSceneHandle
+			Ludus::Engine::Core::SceneId activeSceneId
 		);
 
 		~ScriptEngine();
 
 		Ludus::Scripting::ABI::ScriptContext* GetContext();
 
-		void SetActiveScene(Ludus::Engine::Core::SceneHandle sceneHandle);
+		void SetActiveScene(Ludus::Engine::Core::SceneId sceneId);
 	};
 }

--- a/Engine/Include/Ludus/Engine/Scripting/ScriptInstanceState.h
+++ b/Engine/Include/Ludus/Engine/Scripting/ScriptInstanceState.h
@@ -3,8 +3,7 @@
 #include <cstdint>
 #include <unordered_map>
 
-#include <Ludus/Engine/Core/Entity.h>
-#include <Ludus/Engine/Core/Scene.h>
+#include <Ludus/Engine/Core/Id.h>
 #include <Ludus/Engine/Scripting/LoadedScriptDefinition.h>
 #include <Ludus/Scripting/ABI/Types.h>
 
@@ -12,11 +11,11 @@ namespace Ludus::Engine::Scripting
 {
 	struct ScriptInstanceState
 	{
-		Ludus::Engine::Core::SceneHandle SceneHandle;
-		Ludus::Engine::Core::EntityHandle OwnerHandle;
+		Ludus::Engine::Core::SceneId SceneId;
+		Ludus::Engine::Core::EntityId OwnerId;
 		const LoadedScriptDefinition* Definition = nullptr;
 		bool HasCreated = false;
-		std::unordered_map<Ludus::Engine::Core::EntityHandle, Ludus::Scripting::ABI::Collision2DData> ActiveCollisions;
+		std::unordered_map<Ludus::Engine::Core::EntityId, Ludus::Scripting::ABI::Collision2DData> ActiveCollisions;
 		std::uint64_t LastSeenFrame = 0;
 	};
 }

--- a/Engine/Include/Ludus/Engine/Scripting/ScriptSystem.h
+++ b/Engine/Include/Ludus/Engine/Scripting/ScriptSystem.h
@@ -2,15 +2,17 @@
 
 #include <cstdint>
 #include <filesystem>
+#include <string>
+#include <unordered_map>
 #include <vector>
 
-#include <Ludus/Engine/Core/Entity.h>
 #include <Ludus/Engine/Core/ExecutionFlags.h>
-#include <Ludus/Engine/Core/Scene.h>
+#include <Ludus/Engine/Core/Id.h>
 #include <Ludus/Engine/Core/SceneRegistry.h>
 #include <Ludus/Engine/Physics/Queries/IPhysicsQueryCache2D.h>
 #include <Ludus/Engine/Runtime/IHostContext.h>
 #include <Ludus/Engine/Runtime/ISystem.h>
+#include <Ludus/Engine/Runtime/RuntimeManifest.h>
 #include <Ludus/Engine/Scripting/LoadedScriptModule.h>
 #include <Ludus/Engine/Scripting/ScriptEngine.h>
 #include <Ludus/Engine/Scripting/ScriptInstanceState.h>
@@ -23,6 +25,8 @@ namespace Ludus::Engine::Scripting
 		Ludus::Engine::Runtime::IHostContext& m_HostContext;
 		std::filesystem::path m_ScriptModulePath;
 		Ludus::Engine::Core::SceneRegistry& m_SceneRegistry;
+		std::vector<Ludus::Engine::Runtime::ScriptReference> m_ScriptReferences;
+		std::unordered_map<Ludus::Engine::Core::ScriptId, const LoadedScriptDefinition*> m_DefinitionsById;
 		Ludus::Engine::Physics::Queries::IPhysicsQueryCache2D* m_QueryCache;
 		ScriptEngine m_ScriptEngine;
 		LoadedScriptModule m_LoadedScriptModule;
@@ -31,12 +35,14 @@ namespace Ludus::Engine::Scripting
 		std::uint64_t m_FrameCounter = 0;
 		bool m_IsModuleLoaded = false;
 
+		void BuildDefinitions();
+
 		bool LoadModule();
 		bool UnloadModule();
 
 		ScriptInstanceState& FindOrCreateInstanceState(
-			Ludus::Engine::Core::SceneHandle sceneHandle,
-			Ludus::Engine::Core::EntityHandle ownerHandle
+			Ludus::Engine::Core::SceneId sceneId,
+			Ludus::Engine::Core::EntityId ownerId
 		);
 		void DestroyInactiveInstances(std::uint64_t currentFrame);
 		void DestroyInstance(const ScriptInstanceState& state);
@@ -48,7 +54,8 @@ namespace Ludus::Engine::Scripting
 		ScriptSystem(
 			Ludus::Engine::Runtime::IHostContext& hostContext,
 			Ludus::Engine::Core::SceneRegistry& sceneRegistry,
-			Ludus::Engine::Core::SceneHandle& activeSceneHandle,
+			std::vector<Ludus::Engine::Runtime::ScriptReference> scriptReferences,
+			Ludus::Engine::Core::SceneId& activeSceneId,
 			Ludus::Engine::Physics::Queries::IPhysicsQueryCache2D* queryCache,
 			const std::filesystem::path& scriptModulePath
 		);

--- a/Engine/Include/Ludus/Engine/Serialization/Schemas/Camera2DComponentSchema.h
+++ b/Engine/Include/Ludus/Engine/Serialization/Schemas/Camera2DComponentSchema.h
@@ -4,8 +4,8 @@
 #include <variant>
 
 #include <Ludus/Engine/Components/Camera2DComponent.h>
-#include <Ludus/Engine/Core/Entity.h>
 #include <Ludus/Engine/Core/Expected.h>
+#include <Ludus/Engine/Core/Id.h>
 #include <Ludus/Engine/Serialization/Core/ITokenStreamReader.h>
 #include <Ludus/Engine/Serialization/Core/ITokenStreamWriter.h>
 #include <Ludus/Engine/Serialization/Core/SerializationException.h>
@@ -25,9 +25,6 @@ namespace Ludus::Engine::Serialization::Schemas
 		{
 			writer.Emit(Token::StartObject { });
 
-			writer.Emit(Token::Key { "OwnerHandle" });
-			writer.Emit(Token::Uint { camera.OwnerHandle });
-
 			writer.Emit(Token::Key { "OrthographicSize" });
 			writer.Emit(Token::Double { camera.OrthographicSize });
 
@@ -37,21 +34,18 @@ namespace Ludus::Engine::Serialization::Schemas
 			writer.Emit(Token::EndObject { });
 		}
 
-		inline static Ludus::Engine::Core::Expected<Camera, SerializationException> Deserialize(ITokenStreamReader& reader)
+		inline static Ludus::Engine::Core::Expected<Camera, SerializationException> Deserialize(
+			ITokenStreamReader& reader,
+			Ludus::Engine::Core::EntityId ownerId
+		)
 		{
 			try
 			{
 				Camera camera;
-				bool hasOwner = false;
+				camera.OwnerId = ownerId;
 
 				Ludus::Engine::Serialization::Core::ReadObject(reader, [&](std::string_view key)
 				{
-					if (key == "OwnerHandle")
-					{
-						camera.OwnerHandle = Ludus::Engine::Serialization::Core::ConsumeUint64Like(reader);
-						hasOwner = true;
-						return;
-					}
 					if (key == "OrthographicSize")
 					{
 						camera.OrthographicSize = Ludus::Engine::Serialization::Core::ConsumeFloatLike(reader);
@@ -65,11 +59,6 @@ namespace Ludus::Engine::Serialization::Schemas
 
 					Ludus::Engine::Serialization::Core::SkipValue(reader);
 				});
-
-				if (!hasOwner)
-				{
-					throw SerializationException("No owner handle found.");
-				}
 
 				return camera;
 			}

--- a/Engine/Include/Ludus/Engine/Serialization/Schemas/Collider2DComponentSchema.h
+++ b/Engine/Include/Ludus/Engine/Serialization/Schemas/Collider2DComponentSchema.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include <Ludus/Engine/Components/Collider2DComponent.h>
-#include <Ludus/Engine/Core/Entity.h>
 #include <Ludus/Engine/Core/Expected.h>
+#include <Ludus/Engine/Core/Id.h>
 #include <Ludus/Engine/Physics/Core/LayerMask.h>
 #include <Ludus/Engine/Serialization/Core/ITokenStreamReader.h>
 #include <Ludus/Engine/Serialization/Core/ITokenStreamWriter.h>
@@ -23,9 +23,6 @@ namespace Ludus::Engine::Serialization::Schemas
 		{
 			writer.Emit(Token::StartObject { });
 
-			writer.Emit(Token::Key { "OwnerHandle" });
-			writer.Emit(Token::Uint { collider.OwnerHandle });
-
 			writer.Emit(Token::Key { "LayerIndex" });
 			writer.Emit(Token::Uint { static_cast<uint32_t>(collider.LayerIndex) });
 
@@ -38,21 +35,18 @@ namespace Ludus::Engine::Serialization::Schemas
 			writer.Emit(Token::EndObject { });
 		}
 
-		inline static Ludus::Engine::Core::Expected<Collider, SerializationException> Deserialize(ITokenStreamReader& reader)
+		inline static Ludus::Engine::Core::Expected<Collider, SerializationException> Deserialize(
+			ITokenStreamReader& reader,
+			Ludus::Engine::Core::EntityId ownerId
+		)
 		{
 			try
 			{
 				Collider collider;
-				bool hasOwner = false;
+				collider.OwnerId = ownerId;
 
 				Ludus::Engine::Serialization::Core::ReadObject(reader, [&](std::string_view key)
 				{
-					if (key == "OwnerHandle")
-					{
-						collider.OwnerHandle = Ludus::Engine::Serialization::Core::ConsumeUint64Like(reader);
-						hasOwner = true;
-						return;
-					}
 					if (key == "LayerIndex")
 					{
 						collider.LayerIndex = static_cast<uint8_t>(Ludus::Engine::Serialization::Core::ConsumeUint32Like(reader));
@@ -73,11 +67,6 @@ namespace Ludus::Engine::Serialization::Schemas
 					Ludus::Engine::Serialization::Core::SkipValue(reader);
 				}
 				);
-
-				if (!hasOwner)
-				{
-					throw SerializationException("No owner handle found.");
-				}
 
 				return collider;
 			}

--- a/Engine/Include/Ludus/Engine/Serialization/Schemas/DisplayNameComponentSchema.h
+++ b/Engine/Include/Ludus/Engine/Serialization/Schemas/DisplayNameComponentSchema.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include <Ludus/Engine/Components/DisplayNameComponent.h>
-#include <Ludus/Engine/Core/Entity.h>
 #include <Ludus/Engine/Core/Expected.h>
+#include <Ludus/Engine/Core/Id.h>
 #include <Ludus/Engine/Serialization/Core/ITokenStreamReader.h>
 #include <Ludus/Engine/Serialization/Core/ITokenStreamWriter.h>
 #include <Ludus/Engine/Serialization/Core/SerializationException.h>
@@ -22,30 +22,24 @@ namespace Ludus::Engine::Serialization::Schemas
 		{
 			writer.Emit(Token::StartObject { });
 
-			writer.Emit(Token::Key { "OwnerHandle" });
-			writer.Emit(Token::Uint { displayName.OwnerHandle });
-
 			writer.Emit(Token::Key { "Name" });
 			writer.Emit(Token::String { displayName.Name });
 
 			writer.Emit(Token::EndObject { });
 		}
 
-		inline static Ludus::Engine::Core::Expected<DisplayName, SerializationException> Deserialize(ITokenStreamReader& reader)
+		inline static Ludus::Engine::Core::Expected<DisplayName, SerializationException> Deserialize(
+			ITokenStreamReader& reader,
+			Ludus::Engine::Core::EntityId ownerId
+		)
 		{
 			try
 			{
 				DisplayName displayName;
-				bool hasOwner = false;
+				displayName.OwnerId = ownerId;
 
 				Ludus::Engine::Serialization::Core::ReadObject(reader, [&](std::string_view key)
 				{
-					if (key == "OwnerHandle")
-					{
-						displayName.OwnerHandle = Ludus::Engine::Serialization::Core::ConsumeUint64Like(reader);
-						hasOwner = true;
-						return;
-					}
 					if (key == "Name")
 					{
 						displayName.Name = std::string(Ludus::Engine::Serialization::Core::ConsumeAs<Token::String>(reader).Data);
@@ -54,11 +48,6 @@ namespace Ludus::Engine::Serialization::Schemas
 
 					Ludus::Engine::Serialization::Core::SkipValue(reader);
 				});
-
-				if (!hasOwner)
-				{
-					throw SerializationException("No owner handle found.");
-				}
 
 				return displayName;
 			}

--- a/Engine/Include/Ludus/Engine/Serialization/Schemas/RigidBody2DComponentSchema.h
+++ b/Engine/Include/Ludus/Engine/Serialization/Schemas/RigidBody2DComponentSchema.h
@@ -3,9 +3,9 @@
 #include <string>
 
 #include <Ludus/Engine/Components/RigidBody2DComponent.h>
-#include <Ludus/Engine/Core/Entity.h>
 #include <Ludus/Engine/Core/Enums.h>
 #include <Ludus/Engine/Core/Expected.h>
+#include <Ludus/Engine/Core/Id.h>
 #include <Ludus/Engine/Physics/Core/BodyType.h>
 #include <Ludus/Engine/Serialization/Core/ITokenStreamReader.h>
 #include <Ludus/Engine/Serialization/Core/ITokenStreamWriter.h>
@@ -25,9 +25,6 @@ namespace Ludus::Engine::Serialization::Schemas
 		inline static void Serialize(ITokenStreamWriter& writer, const RigidBody& rigidBody)
 		{
 			writer.Emit(Token::StartObject { });
-
-			writer.Emit(Token::Key { "OwnerHandle" });
-			writer.Emit(Token::Uint { rigidBody.OwnerHandle });
 
 			{
 				writer.Emit(Token::Key { "Velocity" });
@@ -52,21 +49,18 @@ namespace Ludus::Engine::Serialization::Schemas
 			writer.Emit(Token::EndObject { });
 		}
 
-		inline static Ludus::Engine::Core::Expected<RigidBody, SerializationException> Deserialize(ITokenStreamReader& reader)
+		inline static Ludus::Engine::Core::Expected<RigidBody, SerializationException> Deserialize(
+			ITokenStreamReader& reader,
+			Ludus::Engine::Core::EntityId ownerId
+		)
 		{
 			try
 			{
 				RigidBody rigidBody;
-				bool hasOwner = false;
+				rigidBody.OwnerId = ownerId;
 
 				Ludus::Engine::Serialization::Core::ReadObject(reader, [&](std::string_view key)
 				{
-					if (key == "OwnerHandle")
-					{
-						rigidBody.OwnerHandle = Ludus::Engine::Serialization::Core::ConsumeUint64Like(reader);
-						hasOwner = true;
-						return;
-					}
 					if (key == "Velocity")
 					{
 						Ludus::Engine::Serialization::Core::ReadObject(reader,
@@ -111,11 +105,6 @@ namespace Ludus::Engine::Serialization::Schemas
 
 					Ludus::Engine::Serialization::Core::SkipValue(reader);
 				});
-
-				if (!hasOwner)
-				{
-					throw SerializationException("No owner handle found.");
-				}
 
 				return rigidBody;
 			}

--- a/Engine/Include/Ludus/Engine/Serialization/Schemas/ScriptComponentSchema.h
+++ b/Engine/Include/Ludus/Engine/Serialization/Schemas/ScriptComponentSchema.h
@@ -1,12 +1,10 @@
 #pragma once
 
-#include <cstdint>
-#include <filesystem>
-#include <string>
+#include <string_view>
 
 #include <Ludus/Engine/Components/ScriptComponent.h>
-#include <Ludus/Engine/Core/Entity.h>
 #include <Ludus/Engine/Core/Expected.h>
+#include <Ludus/Engine/Core/Id.h>
 #include <Ludus/Engine/Serialization/Core/ITokenStreamReader.h>
 #include <Ludus/Engine/Serialization/Core/ITokenStreamWriter.h>
 #include <Ludus/Engine/Serialization/Core/SerializationException.h>
@@ -26,57 +24,42 @@ namespace Ludus::Engine::Serialization::Schemas
 		{
 			writer.Emit(Token::StartObject { });
 
-			writer.Emit(Token::Key { "OwnerHandle" });
-			writer.Emit(Token::Uint { script.OwnerHandle });
-
-			writer.Emit(Token::Key { "Handle" });
-			writer.Emit(Token::Uint { script.Handle });
-
-			writer.Emit(Token::Key { "Name" });
-			writer.Emit(Token::String { script.Name });
+			writer.Emit(Token::Key { "Id" });
+			writer.Emit(Token::Uint { script.Id.Value });
 
 			writer.Emit(Token::EndObject { });
 		}
 
-		inline static Ludus::Engine::Core::Expected<Script, SerializationException> Deserialize(ITokenStreamReader& reader)
+		inline static Ludus::Engine::Core::Expected<Script, SerializationException> Deserialize(
+			ITokenStreamReader& reader,
+			Ludus::Engine::Core::EntityId ownerId
+		)
 		{
 			try
 			{
 				Script script;
-				bool hasOwner = false;
-				bool hasHandle = false;
+				script.OwnerId = ownerId;
+				bool hasId = false;
 
 				Ludus::Engine::Serialization::Core::ReadObject(reader, [&](std::string_view key)
 				{
-					if (key == "OwnerHandle")
+					if (key == "Id")
 					{
-						script.OwnerHandle = Ludus::Engine::Serialization::Core::ConsumeUint64Like(reader);
-						hasOwner = true;
-						return;
-					}
-					if (key == "Handle")
-					{
-						script.Handle = Ludus::Engine::Serialization::Core::ConsumeUint64Like(reader);
-						hasHandle = true;
-						return;
-					}
-					if (key == "Name")
-					{
-						script.Name = std::string(Ludus::Engine::Serialization::Core::ConsumeAs<Token::String>(reader).Data);
+						script.Id = { Ludus::Engine::Serialization::Core::ConsumeUint64Like(reader) };
+						if (!script.Id.IsValid())
+						{
+							throw SerializationException("Invalid script id.");
+						}
+						hasId = true;
 						return;
 					}
 
 					Ludus::Engine::Serialization::Core::SkipValue(reader);
 				});
 
-				if (!hasOwner)
+				if (!hasId)
 				{
-					throw SerializationException("No owner handle found.");
-				}
-
-				if (!hasHandle)
-				{
-					throw SerializationException("No script handle found.");
+					throw SerializationException("No script id found.");
 				}
 
 				return script;

--- a/Engine/Include/Ludus/Engine/Serialization/Schemas/Sprite2DComponentSchema.h
+++ b/Engine/Include/Ludus/Engine/Serialization/Schemas/Sprite2DComponentSchema.h
@@ -5,6 +5,7 @@
 #include <Ludus/Engine/Components/Sprite2DComponent.h>
 #include <Ludus/Engine/Core/Enums.h>
 #include <Ludus/Engine/Core/Expected.h>
+#include <Ludus/Engine/Core/Id.h>
 #include <Ludus/Engine/Graphics/Shape.h>
 #include <Ludus/Engine/Serialization/Core/ITokenStreamReader.h>
 #include <Ludus/Engine/Serialization/Core/ITokenStreamWriter.h>
@@ -24,9 +25,6 @@ namespace Ludus::Engine::Serialization::Schemas
 		inline static void Serialize(ITokenStreamWriter& writer, const Sprite& sprite)
 		{
 			writer.Emit(Token::StartObject { });
-
-			writer.Emit(Token::Key { "OwnerHandle" });
-			writer.Emit(Token::Uint { sprite.OwnerHandle });
 
 			const std::string shape = Ludus::Engine::Core::Enums::GetDisplayName(sprite.Shape);
 			writer.Emit(Token::Key { "Shape" });
@@ -54,21 +52,18 @@ namespace Ludus::Engine::Serialization::Schemas
 			writer.Emit(Token::EndObject { });
 		}
 
-		inline static Ludus::Engine::Core::Expected<Sprite, SerializationException> Deserialize(ITokenStreamReader& reader)
+		inline static Ludus::Engine::Core::Expected<Sprite, SerializationException> Deserialize(
+			ITokenStreamReader& reader,
+			Ludus::Engine::Core::EntityId ownerId
+		)
 		{
 			try
 			{
 				Sprite sprite;
-				bool hasOwner = false;
+				sprite.OwnerId = ownerId;
 
 				Ludus::Engine::Serialization::Core::ReadObject(reader, [&](std::string_view key)
 				{
-					if (key == "OwnerHandle")
-					{
-						sprite.OwnerHandle = Ludus::Engine::Serialization::Core::ConsumeUint64Like(reader);
-						hasOwner = true;
-						return;
-					}
 					if (key == "Shape")
 					{
 						std::string shapeValue = std::string(
@@ -118,11 +113,6 @@ namespace Ludus::Engine::Serialization::Schemas
 
 					Ludus::Engine::Serialization::Core::SkipValue(reader);
 				});
-
-				if (!hasOwner)
-				{
-					throw SerializationException("No owner handle found.");
-				}
 
 				return sprite;
 			}

--- a/Engine/Include/Ludus/Engine/Serialization/Schemas/Text2DComponentSchema.h
+++ b/Engine/Include/Ludus/Engine/Serialization/Schemas/Text2DComponentSchema.h
@@ -3,9 +3,9 @@
 #include <string>
 
 #include <Ludus/Engine/Components/Text2DComponent.h>
-#include <Ludus/Engine/Core/Entity.h>
 #include <Ludus/Engine/Core/Enums.h>
 #include <Ludus/Engine/Core/Expected.h>
+#include <Ludus/Engine/Core/Id.h>
 #include <Ludus/Engine/Graphics/Color.h>
 #include <Ludus/Engine/Graphics/HorizontalTextAlignment.h>
 #include <Ludus/Engine/Serialization/Core/ITokenStreamReader.h>
@@ -26,9 +26,6 @@ namespace Ludus::Engine::Serialization::Schemas
 		inline static void Serialize(ITokenStreamWriter& writer, const Text& text)
 		{
 			writer.Emit(Token::StartObject { });
-
-			writer.Emit(Token::Key { "OwnerHandle" });
-			writer.Emit(Token::Uint { text.OwnerHandle });
 
 			writer.Emit(Token::Key { "Text" });
 			writer.Emit(Token::String { text.Text });
@@ -54,21 +51,18 @@ namespace Ludus::Engine::Serialization::Schemas
 			writer.Emit(Token::EndObject { });
 		}
 
-		inline static Ludus::Engine::Core::Expected<Text, SerializationException> Deserialize(ITokenStreamReader& reader)
+		inline static Ludus::Engine::Core::Expected<Text, SerializationException> Deserialize(
+			ITokenStreamReader& reader,
+			Ludus::Engine::Core::EntityId ownerId
+		)
 		{
 			try
 			{
 				Text text;
-				bool hasOwner = false;
+				text.OwnerId = ownerId;
 
 				Ludus::Engine::Serialization::Core::ReadObject(reader, [&](std::string_view key)
 				{
-					if (key == "OwnerHandle")
-					{
-						text.OwnerHandle = Ludus::Engine::Serialization::Core::ConsumeUint64Like(reader);
-						hasOwner = true;
-						return;
-					}
 					if (key == "Text")
 					{
 						text.Text = std::string(Ludus::Engine::Serialization::Core::ConsumeAs<Token::String>(reader).Data);
@@ -118,11 +112,6 @@ namespace Ludus::Engine::Serialization::Schemas
 
 					Ludus::Engine::Serialization::Core::SkipValue(reader);
 				});
-
-				if (!hasOwner)
-				{
-					throw SerializationException("No owner handle found.");
-				}
 
 				return text;
 			}

--- a/Engine/Include/Ludus/Engine/Serialization/Schemas/Transform2DComponentSchema.h
+++ b/Engine/Include/Ludus/Engine/Serialization/Schemas/Transform2DComponentSchema.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include <Ludus/Engine/Components/Transform2DComponent.h>
-#include <Ludus/Engine/Core/Entity.h>
 #include <Ludus/Engine/Core/Expected.h>
+#include <Ludus/Engine/Core/Id.h>
 #include <Ludus/Engine/Serialization/Core/ITokenStreamReader.h>
 #include <Ludus/Engine/Serialization/Core/ITokenStreamWriter.h>
 #include <Ludus/Engine/Serialization/Core/SerializationException.h>
@@ -21,9 +21,6 @@ namespace Ludus::Engine::Serialization::Schemas
 		inline static void Serialize(ITokenStreamWriter& writer, const Transform& transform)
 		{
 			writer.Emit(Token::StartObject { });
-
-			writer.Emit(Token::Key { "OwnerHandle" });
-			writer.Emit(Token::Uint { transform.OwnerHandle });
 
 			{
 				writer.Emit(Token::Key { "Position" });
@@ -51,21 +48,18 @@ namespace Ludus::Engine::Serialization::Schemas
 			writer.Emit(Token::EndObject { });
 		}
 
-		inline static Ludus::Engine::Core::Expected<Transform, SerializationException> Deserialize(ITokenStreamReader& reader)
+		inline static Ludus::Engine::Core::Expected<Transform, SerializationException> Deserialize(
+			ITokenStreamReader& reader,
+			Ludus::Engine::Core::EntityId ownerId
+		)
 		{
 			try
 			{
 				Transform transform;
-				bool hasOwner = false;
+				transform.OwnerId = ownerId;
 
 				Ludus::Engine::Serialization::Core::ReadObject(reader, [&](std::string_view key)
 				{
-					if (key == "OwnerHandle")
-					{
-						transform.OwnerHandle = Ludus::Engine::Serialization::Core::ConsumeUint64Like(reader);
-						hasOwner = true;
-						return;
-					}
 					if (key == "Position")
 					{
 						Ludus::Engine::Serialization::Core::ReadObject(reader,
@@ -114,11 +108,6 @@ namespace Ludus::Engine::Serialization::Schemas
 
 					Ludus::Engine::Serialization::Core::SkipValue(reader);
 				});
-
-				if (!hasOwner)
-				{
-					throw SerializationException("No owner handle found.");
-				}
 
 				return transform;
 			}

--- a/Engine/Source/Ludus/Engine/Graphics/MainRenderViewSystem.cpp
+++ b/Engine/Source/Ludus/Engine/Graphics/MainRenderViewSystem.cpp
@@ -1,5 +1,6 @@
 #include "pch.h"
 
+#include <Ludus/Engine/Core/Id.h>
 #include <Ludus/Engine/Graphics/MainRenderViewSystem.h>
 
 namespace Ludus::Engine::Graphics
@@ -21,7 +22,7 @@ namespace Ludus::Engine::Graphics
 
 		Ludus::Engine::Graphics::RenderViewRequest2D renderViewRequest {
 			.Camera = std::nullopt,
-			.SceneHandle = m_ScenePresentationState.CurrentSceneHandle,
+			.SceneId = m_ScenePresentationState.CurrentSceneId,
 			.Target = &target,
 			.ViewportRect = Ludus::Engine::Math::Rect::Create(
 				{ 0.0f, 0.0f },

--- a/Engine/Source/Ludus/Engine/Graphics/Renderer2D.cpp
+++ b/Engine/Source/Ludus/Engine/Graphics/Renderer2D.cpp
@@ -190,7 +190,7 @@ namespace Ludus::Engine::Graphics
 			const Ludus::Engine::Math::Vector2D quadScale { width, height };
 
 			DrawQuadInternal(
-				Ludus::Engine::Components::Transform2DComponent(transform.OwnerHandle, quadCenter, quadScale, transform.Rotation),
+				Ludus::Engine::Components::Transform2DComponent(transform.OwnerId, quadCenter, quadScale, transform.Rotation),
 				color,
 				&const_cast<Glyph*>(glyph)->Texture,
 				0,

--- a/Engine/Source/Ludus/Engine/Platform/Windows/Guid.Windows.cpp
+++ b/Engine/Source/Ludus/Engine/Platform/Windows/Guid.Windows.cpp
@@ -1,0 +1,191 @@
+#include "pch.h"
+
+#include <array>
+#include <compare>
+#include <cstdint>
+#include <cstring>
+#include <functional>
+#include <iomanip>
+#include <optional>
+#include <ostream>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <combaseapi.h>
+
+#include <Ludus/Engine/Platform/Guid.h>
+
+namespace Ludus::Engine::Platform
+{
+	namespace
+	{
+		std::optional<std::uint8_t> ParseHexChar(char c)
+		{
+			if (c >= '0' && c <= '9')
+			{
+				return static_cast<std::uint8_t>(c - '0');
+			}
+
+			if (c >= 'a' && c <= 'f')
+			{
+				return static_cast<std::uint8_t>(10 + (c - 'a'));
+			}
+
+			if (c >= 'A' && c <= 'F')
+			{
+				return static_cast<std::uint8_t>(10 + (c - 'A'));
+			}
+
+			return std::nullopt;
+		}
+
+		std::optional<std::uint8_t> ParseByte(char high, char low)
+		{
+			const auto highNibble = ParseHexChar(high);
+			const auto lowNibble = ParseHexChar(low);
+			if (!highNibble || !lowNibble)
+			{
+				return std::nullopt;
+			}
+
+			return static_cast<std::uint8_t>((*highNibble << 4) | *lowNibble);
+		}
+	}
+
+	Guid CreateGuid()
+	{
+		GUID guid;
+		auto hr = CoCreateGuid(&guid);
+		if (FAILED(hr))
+		{
+			throw std::runtime_error("Failed to generate GUID.");
+		}
+
+		static_assert(sizeof(::GUID) == 16);
+		static_assert(sizeof(((::GUID*)nullptr)->Data1) == 4);
+		static_assert(sizeof(((::GUID*)nullptr)->Data2) == 2);
+		static_assert(sizeof(((::GUID*)nullptr)->Data3) == 2);
+		static_assert(sizeof(((::GUID*)nullptr)->Data4) == 8);
+
+		Guid result { };
+
+		size_t offset = 0;
+		std::memcpy(&result.Bytes[offset], &guid.Data1, sizeof(guid.Data1));
+		offset += sizeof(guid.Data1);
+
+		std::memcpy(&result.Bytes[offset], &guid.Data2, sizeof(guid.Data2));
+		offset += sizeof(guid.Data2);
+
+		std::memcpy(&result.Bytes[offset], &guid.Data3, sizeof(guid.Data3));
+		offset += sizeof(guid.Data3);
+
+		std::memcpy(&result.Bytes[offset], &guid.Data4, sizeof(guid.Data4));
+
+		return result;
+	}
+
+	std::optional<Guid> TryParse(std::string_view text)
+	{
+		if (text.size() != 36)
+		{
+			return std::nullopt;
+		}
+
+		if (text[8] != '-' || text[13] != '-' || text[18] != '-' || text[23] != '-')
+		{
+			return std::nullopt;
+		}
+
+		Guid result { };
+
+		const auto b0 = ParseByte(text[6], text[7]);
+		const auto b1 = ParseByte(text[4], text[5]);
+		const auto b2 = ParseByte(text[2], text[3]);
+		const auto b3 = ParseByte(text[0], text[1]);
+
+		const auto b4 = ParseByte(text[11], text[12]);
+		const auto b5 = ParseByte(text[9], text[10]);
+
+		const auto b6 = ParseByte(text[16], text[17]);
+		const auto b7 = ParseByte(text[14], text[15]);
+
+		const auto b8 = ParseByte(text[19], text[20]);
+		const auto b9 = ParseByte(text[21], text[22]);
+
+		const auto b10 = ParseByte(text[24], text[25]);
+		const auto b11 = ParseByte(text[26], text[27]);
+		const auto b12 = ParseByte(text[28], text[29]);
+		const auto b13 = ParseByte(text[30], text[31]);
+		const auto b14 = ParseByte(text[32], text[33]);
+		const auto b15 = ParseByte(text[34], text[35]);
+
+		if (!b0 || !b1 || !b2 || !b3 || !b4 || !b5 || !b6 || !b7 ||
+			!b8 || !b9 || !b10 || !b11 || !b12 || !b13 || !b14 || !b15)
+		{
+			return std::nullopt;
+		}
+
+		result.Bytes[0] = *b0;
+		result.Bytes[1] = *b1;
+		result.Bytes[2] = *b2;
+		result.Bytes[3] = *b3;
+		result.Bytes[4] = *b4;
+		result.Bytes[5] = *b5;
+		result.Bytes[6] = *b6;
+		result.Bytes[7] = *b7;
+		result.Bytes[8] = *b8;
+		result.Bytes[9] = *b9;
+		result.Bytes[10] = *b10;
+		result.Bytes[11] = *b11;
+		result.Bytes[12] = *b12;
+		result.Bytes[13] = *b13;
+		result.Bytes[14] = *b14;
+		result.Bytes[15] = *b15;
+
+		return result;
+	}
+
+	bool Guid::IsEmpty() const
+	{
+		return Bytes == std::array<std::uint8_t, 16> {};
+	}
+
+	std::string Guid::ToString() const
+	{
+		// See https://devblogs.microsoft.com/oldnewthing/20220928-00/?p=107221 for GUID format and endianness.
+
+		std::ostringstream os;
+		os << std::hex << std::setfill('0') << std::nouppercase;
+
+		os << std::setw(2) << static_cast<int>(Bytes[3]);
+		os << std::setw(2) << static_cast<int>(Bytes[2]);
+		os << std::setw(2) << static_cast<int>(Bytes[1]);
+		os << std::setw(2) << static_cast<int>(Bytes[0]);
+		os << '-';
+
+		os << std::setw(2) << static_cast<int>(Bytes[5]);
+		os << std::setw(2) << static_cast<int>(Bytes[4]);
+		os << '-';
+
+		os << std::setw(2) << static_cast<int>(Bytes[7]);
+		os << std::setw(2) << static_cast<int>(Bytes[6]);
+		os << '-';
+
+		os << std::setw(2) << static_cast<int>(Bytes[8]);
+		os << std::setw(2) << static_cast<int>(Bytes[9]);
+		os << '-';
+
+		os << std::setw(2) << static_cast<int>(Bytes[10]);
+		os << std::setw(2) << static_cast<int>(Bytes[11]);
+		os << std::setw(2) << static_cast<int>(Bytes[12]);
+		os << std::setw(2) << static_cast<int>(Bytes[13]);
+		os << std::setw(2) << static_cast<int>(Bytes[14]);
+		os << std::setw(2) << static_cast<int>(Bytes[15]);
+
+		return os.str();
+	}
+}

--- a/Engine/Source/Ludus/Engine/Runtime/RuntimeInstance.cpp
+++ b/Engine/Source/Ludus/Engine/Runtime/RuntimeInstance.cpp
@@ -43,13 +43,12 @@ namespace Ludus::Engine::Runtime
 		if (initialSceneMode == InitialSceneMode::Entry)
 		{
 			LUDUS_ASSERT(
-				m_RuntimeManifest.EntrySceneHandle == initialScene.Handle,
+				m_RuntimeManifest.EntrySceneId == initialScene.Id,
 				"The initial scene must respect the runtime manifest when InitialSceneMode is Entry."
 			);
 		}
 
-		m_ScenePresentationState.CurrentSceneHandle = initialScene.Handle;
-		m_SceneRegistry.AddScene(std::move(initialScene));
+		m_ScenePresentationState.CurrentSceneId = m_SceneRegistry.AddScene(std::move(initialScene));
 	}
 
 	RuntimeInstance::~RuntimeInstance() = default;
@@ -92,7 +91,7 @@ namespace Ludus::Engine::Runtime
 	void RuntimeInstance::Initialize()
 	{
 		LUDUS_ASSERT(
-			m_SceneRegistry.Contains(m_ScenePresentationState.CurrentSceneHandle),
+			m_SceneRegistry.Contains(m_ScenePresentationState.CurrentSceneId),
 			"The current scene was not found in the scene registry."
 		);
 

--- a/Engine/Source/Ludus/Engine/Runtime/RuntimeInstanceBuilder.cpp
+++ b/Engine/Source/Ludus/Engine/Runtime/RuntimeInstanceBuilder.cpp
@@ -111,7 +111,8 @@ namespace Ludus::Engine::Runtime
 			auto scriptingSystem = std::make_unique<Ludus::Engine::Scripting::ScriptSystem>(
 				runtime->GetHostContext(),
 				runtime->GetSceneRegistry(),
-				runtime->GetScenePresentationState().CurrentSceneHandle,
+				runtime->GetRuntimeManifest().Scripts,
+				runtime->GetScenePresentationState().CurrentSceneId,
 				runtime->GetPhysicsConfiguration().QueryCache.get(),
 				runtime->GetRuntimeEnvironment().ScriptModulePath
 			);

--- a/Engine/Source/Ludus/Engine/Runtime/RuntimeLauncher.cpp
+++ b/Engine/Source/Ludus/Engine/Runtime/RuntimeLauncher.cpp
@@ -31,20 +31,48 @@ namespace
 		};
 	}
 
-	const Ludus::Engine::Runtime::SceneReference& FindEntrySceneReference(
+	Ludus::Engine::Core::Scene LoadEntryScene(
+		Ludus::Engine::Persistence::IScenePersistence& scenePersistence,
+		const Ludus::Engine::Runtime::RuntimeEnvironment& runtimeEnvironment,
 		const Ludus::Engine::Runtime::RuntimeManifest& runtimeManifest
 	)
 	{
-		for (const auto& scene : runtimeManifest.Scenes)
+		const Ludus::Engine::Runtime::SceneReference* entrySceneReference = nullptr;
+		if (runtimeManifest.EntrySceneId.IsValid())
 		{
-			if (scene.Handle == runtimeManifest.EntrySceneHandle)
+			for (const auto& sceneReference : runtimeManifest.Scenes)
 			{
-				return scene;
+				if (sceneReference.Id == runtimeManifest.EntrySceneId)
+				{
+					entrySceneReference = &sceneReference;
+					break;
+				}
 			}
 		}
 
-		throw std::runtime_error("Runtime manifest entry scene was not found.");
+		if (!entrySceneReference)
+		{
+			throw std::runtime_error("Runtime manifest entry scene was not found.");
+		}
+
+		const auto scenePath = Ludus::Engine::Persistence::Paths::ResolveRuntimeScenePath(
+			runtimeEnvironment.RuntimeRootDirectory,
+			entrySceneReference->Path
+		);
+
+		auto scene = scenePersistence.Load(scenePath);
+
+		for (const auto& script : scene.EntityComponentSystem.Scripts.View())
+		{
+			if (!runtimeManifest.TryGetScriptReference(script.Id))
+			{
+				throw std::runtime_error("Scene contains script id that is not present in the runtime manifest.");
+			}
+		}
+
+		return scene;
 	}
+
 }
 
 namespace Ludus::Engine::Runtime
@@ -56,14 +84,12 @@ namespace Ludus::Engine::Runtime
 		Ludus::Engine::Persistence::LmlRuntimeManifestPersistence runtimeManifestPersistence;
 		const auto runtimeManifest = runtimeManifestPersistence.Load(runtimeEnvironment.RuntimeManifestPath);
 
-		const auto& entrySceneReference = FindEntrySceneReference(runtimeManifest);
-		const auto entryScenePath = Ludus::Engine::Persistence::Paths::ResolveRuntimeScenePath(
-			runtimeEnvironment.RuntimeRootDirectory,
-			entrySceneReference.Path
-		);
-
 		Ludus::Engine::Persistence::LmlScenePersistence scenePersistence;
-		auto entryScene = scenePersistence.Load(entryScenePath);
+		auto entryScene = ::LoadEntryScene(
+			scenePersistence,
+			runtimeEnvironment,
+			runtimeManifest
+		);
 
 		Ludus::Engine::Windowing::WindowOptions windowOptions;
 		windowOptions.Title = runtimeName;

--- a/Engine/Source/Ludus/Engine/Scripting/ScriptBindings.cpp
+++ b/Engine/Source/Ludus/Engine/Scripting/ScriptBindings.cpp
@@ -2,6 +2,7 @@
 
 #include <string>
 
+#include <Ludus/Engine/Core/Id.h>
 #include <Ludus/Engine/Core/Scene.h>
 #include <Ludus/Engine/Core/SceneRegistry.h>
 #include <Ludus/Engine/Scripting/ScriptBindings.h>
@@ -13,7 +14,7 @@ namespace Ludus::Engine::Scripting
 {
 	using ScriptContext = Ludus::Scripting::ABI::ScriptContext;
 	using ScriptAPI = Ludus::Scripting::ABI::ScriptAPI;
-	using EntityHandle = Ludus::Scripting::ABI::EntityHandle;
+	using ABIEntityId = Ludus::Scripting::ABI::EntityHandle;
 	using Key = Ludus::Scripting::ABI::Key;
 	using MouseButton = Ludus::Scripting::ABI::MouseButton;
 	using DisplayNameData = Ludus::Scripting::ABI::DisplayNameData;
@@ -26,7 +27,7 @@ namespace Ludus::Engine::Scripting
 	{
 		Ludus::Engine::Core::SceneRegistry& SceneRegistry;
 		Ludus::Engine::Windowing::Input& Input;
-		Ludus::Engine::Core::SceneHandle ActiveSceneHandle;
+		Ludus::Engine::Core::SceneId ActiveSceneId;
 	};
 
 	struct ScriptBindingsState
@@ -50,15 +51,25 @@ namespace Ludus::Engine::Scripting
 
 		Ludus::Engine::Core::Scene& ResolveScene(const ScriptHost& host)
 		{
-			return host.SceneRegistry.GetScene(host.ActiveSceneHandle);
+			return host.SceneRegistry.GetScene(host.ActiveSceneId);
+		}
+
+		Ludus::Engine::Core::EntityId FromABI(ABIEntityId id)
+		{
+			return Ludus::Engine::Core::EntityId { id };
+		}
+
+		ABIEntityId ToABI(Ludus::Engine::Core::EntityId id)
+		{
+			return id.Value;
 		}
 
 #pragma region Entity bindings
 
-		static bool GetEntityByName(ScriptContext* context, const char* name, EntityHandle* entityHandle)
+		static bool GetEntityByName(ScriptContext* context, const char* name, ABIEntityId* entityId)
 		{
-			LUDUS_ASSERT(entityHandle != nullptr, "Script binding output entity handle must not be null.");
-			if (!entityHandle)
+			LUDUS_ASSERT(entityId != nullptr, "Script binding output entity id must not be null.");
+			if (!entityId)
 			{
 				return false;
 			}
@@ -70,7 +81,7 @@ namespace Ludus::Engine::Scripting
 			{
 				if (displayName.Name == name)
 				{
-					*entityHandle = displayName.OwnerHandle;
+					*entityId = ToABI(displayName.OwnerId);
 					return true;
 				}
 			}
@@ -146,7 +157,7 @@ namespace Ludus::Engine::Scripting
 			destination.Name = source.Name;
 		}
 
-		static bool OnGetDisplayName(ScriptContext* context, EntityHandle entityHandle, DisplayNameData* displayNameOut)
+		static bool OnGetDisplayName(ScriptContext* context, ABIEntityId entityId, DisplayNameData* displayNameOut)
 		{
 			LUDUS_ASSERT(displayNameOut != nullptr, "Script binding output display name must not be null.");
 			if (!displayNameOut)
@@ -157,7 +168,7 @@ namespace Ludus::Engine::Scripting
 			auto& host = ResolveHost(context);
 			const auto& scene = ResolveScene(host);
 
-			const auto* displayName = scene.EntityComponentSystem.DisplayNames.TryGetByOwner(entityHandle);
+			const auto* displayName = scene.EntityComponentSystem.DisplayNames.TryGetByOwner(FromABI(entityId));
 			if (!displayName)
 			{
 				return false;
@@ -168,7 +179,7 @@ namespace Ludus::Engine::Scripting
 			return true;
 		}
 
-		static bool OnSetDisplayName(ScriptContext* context, EntityHandle entityHandle, const DisplayNameData* displayNameIn)
+		static bool OnSetDisplayName(ScriptContext* context, ABIEntityId entityId, const DisplayNameData* displayNameIn)
 		{
 			LUDUS_ASSERT(displayNameIn != nullptr, "Script binding input display name must not be null.");
 			if (!displayNameIn)
@@ -179,7 +190,7 @@ namespace Ludus::Engine::Scripting
 			auto& host = ResolveHost(context);
 			auto& scene = ResolveScene(host);
 
-			auto* displayName = scene.EntityComponentSystem.DisplayNames.TryGetByOwnerMutable(entityHandle);
+			auto* displayName = scene.EntityComponentSystem.DisplayNames.TryGetByOwnerMutable(FromABI(entityId));
 			if (!displayName)
 			{
 				return false;
@@ -216,7 +227,7 @@ namespace Ludus::Engine::Scripting
 			destination.BodyType = static_cast<Ludus::Engine::Physics::Core::BodyType>(source.BodyType);
 		}
 
-		static bool OnGetRigidBody(ScriptContext* context, EntityHandle entityHandle, RigidBody2DData* rigidBodyOut)
+		static bool OnGetRigidBody(ScriptContext* context, ABIEntityId entityId, RigidBody2DData* rigidBodyOut)
 		{
 			LUDUS_ASSERT(rigidBodyOut != nullptr, "Script binding output rigid body must not be null.");
 			if (!rigidBodyOut)
@@ -227,7 +238,7 @@ namespace Ludus::Engine::Scripting
 			auto& host = ResolveHost(context);
 			const auto& scene = ResolveScene(host);
 
-			const auto* rigidBody = scene.EntityComponentSystem.RigidBodies.TryGetByOwner(entityHandle);
+			const auto* rigidBody = scene.EntityComponentSystem.RigidBodies.TryGetByOwner(FromABI(entityId));
 			if (!rigidBody)
 			{
 				return false;
@@ -238,7 +249,7 @@ namespace Ludus::Engine::Scripting
 			return true;
 		}
 
-		static bool OnSetRigidBody(ScriptContext* context, EntityHandle entityHandle, const RigidBody2DData* rigidBodyIn)
+		static bool OnSetRigidBody(ScriptContext* context, ABIEntityId entityId, const RigidBody2DData* rigidBodyIn)
 		{
 			LUDUS_ASSERT(rigidBodyIn != nullptr, "Script binding input rigid body must not be null.");
 			if (!rigidBodyIn)
@@ -249,7 +260,7 @@ namespace Ludus::Engine::Scripting
 			auto& host = ResolveHost(context);
 			auto& scene = ResolveScene(host);
 
-			auto* rigidBody = scene.EntityComponentSystem.RigidBodies.TryGetByOwnerMutable(entityHandle);
+			auto* rigidBody = scene.EntityComponentSystem.RigidBodies.TryGetByOwnerMutable(FromABI(entityId));
 			if (!rigidBody)
 			{
 				return false;
@@ -284,7 +295,7 @@ namespace Ludus::Engine::Scripting
 			destination.HorizontalTextAlignment = static_cast<Ludus::Engine::Graphics::HorizontalTextAlignment>(source.HorizontalTextAlignment);
 		}
 
-		static bool OnGetText(ScriptContext* context, EntityHandle entityHandle, Text2DData* textOut)
+		static bool OnGetText(ScriptContext* context, ABIEntityId entityId, Text2DData* textOut)
 		{
 			LUDUS_ASSERT(textOut != nullptr, "Script binding output text must not be null.");
 			if (!textOut)
@@ -295,7 +306,7 @@ namespace Ludus::Engine::Scripting
 			auto& host = ResolveHost(context);
 			const auto& scene = ResolveScene(host);
 
-			const auto* text = scene.EntityComponentSystem.Texts.TryGetByOwner(entityHandle);
+			const auto* text = scene.EntityComponentSystem.Texts.TryGetByOwner(FromABI(entityId));
 			if (!text)
 			{
 				return false;
@@ -306,7 +317,7 @@ namespace Ludus::Engine::Scripting
 			return true;
 		}
 
-		static bool OnSetText(ScriptContext* context, EntityHandle entityHandle, const Text2DData* textIn)
+		static bool OnSetText(ScriptContext* context, ABIEntityId entityId, const Text2DData* textIn)
 		{
 			LUDUS_ASSERT(textIn != nullptr, "Script binding input text must not be null.");
 			if (!textIn)
@@ -317,7 +328,7 @@ namespace Ludus::Engine::Scripting
 			auto& host = ResolveHost(context);
 			auto& scene = ResolveScene(host);
 
-			auto* text = scene.EntityComponentSystem.Texts.TryGetByOwnerMutable(entityHandle);
+			auto* text = scene.EntityComponentSystem.Texts.TryGetByOwnerMutable(FromABI(entityId));
 			if (!text)
 			{
 				return false;
@@ -352,7 +363,7 @@ namespace Ludus::Engine::Scripting
 			destination.Rotation = source.Rotation;
 		}
 
-		static bool OnGetTransform(ScriptContext* context, EntityHandle entityHandle, Transform2DData* transformOut)
+		static bool OnGetTransform(ScriptContext* context, ABIEntityId entityId, Transform2DData* transformOut)
 		{
 			LUDUS_ASSERT(transformOut != nullptr, "Script binding output transform must not be null.");
 			if (!transformOut)
@@ -363,7 +374,7 @@ namespace Ludus::Engine::Scripting
 			auto& host = ResolveHost(context);
 			const auto& scene = ResolveScene(host);
 
-			const auto* transform = scene.EntityComponentSystem.Transforms.TryGetByOwner(entityHandle);
+			const auto* transform = scene.EntityComponentSystem.Transforms.TryGetByOwner(FromABI(entityId));
 			if (!transform)
 			{
 				return false;
@@ -374,7 +385,7 @@ namespace Ludus::Engine::Scripting
 			return true;
 		}
 
-		static bool OnSetTransform(ScriptContext* context, EntityHandle entityHandle, const Transform2DData* transformIn)
+		static bool OnSetTransform(ScriptContext* context, ABIEntityId entityId, const Transform2DData* transformIn)
 		{
 			LUDUS_ASSERT(transformIn != nullptr, "Script binding input transform must not be null.");
 			if (!transformIn)
@@ -385,7 +396,7 @@ namespace Ludus::Engine::Scripting
 			auto& host = ResolveHost(context);
 			auto& scene = ResolveScene(host);
 
-			auto* transform = scene.EntityComponentSystem.Transforms.TryGetByOwnerMutable(entityHandle);
+			auto* transform = scene.EntityComponentSystem.Transforms.TryGetByOwnerMutable(FromABI(entityId));
 			if (!transform)
 			{
 				return false;
@@ -403,12 +414,12 @@ namespace Ludus::Engine::Scripting
 	ScriptBindingsState* CreateScriptBindingsState(
 		Ludus::Engine::Core::SceneRegistry& sceneRegistry,
 		Ludus::Engine::Windowing::Input& input,
-		Ludus::Engine::Core::SceneHandle activeSceneHandle
+		Ludus::Engine::Core::SceneId activeSceneId
 	)
 	{
 		auto* state = new ScriptBindingsState
 		{
-			.Host = { sceneRegistry, input, activeSceneHandle },
+			.Host = { sceneRegistry, input, activeSceneId },
 			.API = {
 				.Version = Ludus::Scripting::ABI::CurrentAPIVersion,
 				.GetEntityByName = &GetEntityByName,
@@ -438,9 +449,9 @@ namespace Ludus::Engine::Scripting
 		delete state;
 	}
 
-	void SetActiveScene(ScriptBindingsState* state, Ludus::Engine::Core::SceneHandle sceneHandle)
+	void SetActiveScene(ScriptBindingsState* state, Ludus::Engine::Core::SceneId sceneId)
 	{
-		state->Host.ActiveSceneHandle = sceneHandle;
+		state->Host.ActiveSceneId = sceneId;
 	}
 
 	const ScriptAPI* GetScriptAPI(const ScriptBindingsState* state)

--- a/Engine/Source/Ludus/Engine/Scripting/ScriptEngine.cpp
+++ b/Engine/Source/Ludus/Engine/Scripting/ScriptEngine.cpp
@@ -1,5 +1,6 @@
 #include "pch.h"
 
+#include <Ludus/Engine/Core/Id.h>
 #include <Ludus/Engine/Core/Scene.h>
 #include <Ludus/Engine/Core/SceneRegistry.h>
 #include <Ludus/Engine/Scripting/ScriptBindings.h>
@@ -27,8 +28,8 @@ namespace Ludus::Engine::Scripting
 	ScriptEngine::ScriptEngine(
 		Ludus::Engine::Core::SceneRegistry& sceneRegistry,
 		Ludus::Engine::Windowing::Input& input,
-		Ludus::Engine::Core::SceneHandle activeSceneHandle
-	) : m_BindingsState(CreateScriptBindingsState(sceneRegistry, input, activeSceneHandle))
+		Ludus::Engine::Core::SceneId activeSceneId
+	) : m_BindingsState(CreateScriptBindingsState(sceneRegistry, input, activeSceneId))
 	{
 		CreateContext();
 	}
@@ -45,8 +46,8 @@ namespace Ludus::Engine::Scripting
 		return m_ScriptContext;
 	}
 
-	void ScriptEngine::SetActiveScene(Ludus::Engine::Core::SceneHandle sceneHandle)
+	void ScriptEngine::SetActiveScene(Ludus::Engine::Core::SceneId sceneId)
 	{
-		Ludus::Engine::Scripting::SetActiveScene(m_BindingsState, sceneHandle);
+		Ludus::Engine::Scripting::SetActiveScene(m_BindingsState, sceneId);
 	}
 }

--- a/Engine/Source/Ludus/Engine/Scripting/ScriptSystem.cpp
+++ b/Engine/Source/Ludus/Engine/Scripting/ScriptSystem.cpp
@@ -2,6 +2,7 @@
 
 #include <unordered_map>
 
+#include <Ludus/Engine/Core/Id.h>
 #include <Ludus/Engine/Core/Mask.h>
 #include <Ludus/Engine/Debug/Debug.h>
 #include <Ludus/Engine/Scripting/ScriptSystem.h>
@@ -16,7 +17,7 @@ namespace Ludus::Engine::Scripting
 			return;
 		}
 
-		state.Definition->OnDestroy(m_ScriptEngine.GetContext(), state.OwnerHandle);
+		state.Definition->OnDestroy(m_ScriptEngine.GetContext(), state.OwnerId.Value);
 	}
 
 	void ScriptSystem::DestroyAllInstances()
@@ -47,16 +48,16 @@ namespace Ludus::Engine::Scripting
 			return;
 		}
 
-		std::unordered_map<Ludus::Engine::Core::EntityHandle, Ludus::Scripting::ABI::Collision2DData> currentCollisions;
+		std::unordered_map<Ludus::Engine::Core::EntityId, Ludus::Scripting::ABI::Collision2DData> currentCollisions;
 
-		for (const auto& contact : m_QueryCache->GetContacts(state.OwnerHandle))
+		for (const auto& contact : m_QueryCache->GetContacts(state.OwnerId))
 		{
-			const auto selfIsA = contact.EntityHandleA == state.OwnerHandle;
-			const auto otherHandle = selfIsA ? contact.EntityHandleB : contact.EntityHandleA;
+			const auto selfIsA = contact.EntityIdA == state.OwnerId;
+			const auto otherId = selfIsA ? contact.EntityIdB : contact.EntityIdA;
 
 			Ludus::Scripting::ABI::Collision2DData collision
 			{
-				.Other = otherHandle,
+				.Other = otherId.Value,
 				.LocalSelf = {
 					selfIsA ? contact.Point.LocalA.X : contact.Point.LocalB.X,
 					selfIsA ? contact.Point.LocalA.Y : contact.Point.LocalB.Y
@@ -73,18 +74,18 @@ namespace Ludus::Engine::Scripting
 				.IsTrigger = contact.IsTriggerPair
 			};
 
-			currentCollisions[otherHandle] = collision;
+			currentCollisions[otherId] = collision;
 		}
 
 		auto context = m_ScriptEngine.GetContext();
 
-		for (const auto& [otherHandle, collision] : currentCollisions)
+		for (const auto& [otherId, collision] : currentCollisions)
 		{
-			if (!state.ActiveCollisions.contains(otherHandle))
+			if (!state.ActiveCollisions.contains(otherId))
 			{
 				if (state.Definition->OnCollisionEnter)
 				{
-					state.Definition->OnCollisionEnter(context, state.OwnerHandle, &collision);
+					state.Definition->OnCollisionEnter(context, state.OwnerId.Value, &collision);
 				}
 
 				continue;
@@ -92,24 +93,41 @@ namespace Ludus::Engine::Scripting
 
 			if (state.Definition->OnCollisionStay)
 			{
-				state.Definition->OnCollisionStay(context, state.OwnerHandle, &collision);
+				state.Definition->OnCollisionStay(context, state.OwnerId.Value, &collision);
 			}
 		}
 
-		for (const auto& [otherHandle, collision] : state.ActiveCollisions)
+		for (const auto& [otherId, collision] : state.ActiveCollisions)
 		{
-			if (currentCollisions.contains(otherHandle))
+			if (currentCollisions.contains(otherId))
 			{
 				continue;
 			}
 
 			if (state.Definition->OnCollisionExit)
 			{
-				state.Definition->OnCollisionExit(context, state.OwnerHandle, &collision);
+				state.Definition->OnCollisionExit(context, state.OwnerId.Value, &collision);
 			}
 		}
 
 		state.ActiveCollisions = std::move(currentCollisions);
+	}
+
+	void ScriptSystem::BuildDefinitions()
+	{
+		m_DefinitionsById.clear();
+		m_DefinitionsById.reserve(m_ScriptReferences.size());
+
+		for (const auto& scriptReference : m_ScriptReferences)
+		{
+			const auto* definition = m_LoadedScriptModule.TryFindDefinition(scriptReference.Name);
+			if (!definition)
+			{
+				continue;
+			}
+
+			m_DefinitionsById.emplace(scriptReference.Id, definition);
+		}
 	}
 
 	bool ScriptSystem::LoadModule()
@@ -120,6 +138,11 @@ namespace Ludus::Engine::Scripting
 		}
 
 		m_IsModuleLoaded = m_LoadedScriptModule.LoadScriptModule(m_ScriptModulePath);
+		if (m_IsModuleLoaded)
+		{
+			BuildDefinitions();
+		}
+
 		return m_IsModuleLoaded;
 	}
 
@@ -133,18 +156,19 @@ namespace Ludus::Engine::Scripting
 		DestroyAllInstances();
 
 		const auto success = m_LoadedScriptModule.UnloadScriptModule();
+		m_DefinitionsById.clear();
 		m_IsModuleLoaded = false;
 		return success;
 	}
 
 	ScriptInstanceState& ScriptSystem::FindOrCreateInstanceState(
-		Ludus::Engine::Core::SceneHandle sceneHandle,
-		Ludus::Engine::Core::EntityHandle ownerHandle
+		Ludus::Engine::Core::SceneId sceneId,
+		Ludus::Engine::Core::EntityId ownerId
 	)
 	{
 		for (auto& state : m_InstanceStates)
 		{
-			if (state.SceneHandle == sceneHandle && state.OwnerHandle == ownerHandle)
+			if (state.SceneId == sceneId && state.OwnerId == ownerId)
 			{
 				return state;
 			}
@@ -152,8 +176,8 @@ namespace Ludus::Engine::Scripting
 
 		m_InstanceStates.push_back(ScriptInstanceState
 			{
-				.SceneHandle = sceneHandle,
-				.OwnerHandle = ownerHandle,
+				.SceneId = sceneId,
+				.OwnerId = ownerId,
 				.Definition = nullptr,
 				.HasCreated = false,
 				.ActiveCollisions = { },
@@ -182,13 +206,15 @@ namespace Ludus::Engine::Scripting
 	ScriptSystem::ScriptSystem(
 		Ludus::Engine::Runtime::IHostContext& hostContext,
 		Ludus::Engine::Core::SceneRegistry& sceneRegistry,
-		Ludus::Engine::Core::SceneHandle& activeSceneHandle,
+		std::vector<Ludus::Engine::Runtime::ScriptReference> scriptReferences,
+		Ludus::Engine::Core::SceneId& activeSceneId,
 		Ludus::Engine::Physics::Queries::IPhysicsQueryCache2D* queryCache,
 		const std::filesystem::path& scriptModulePath
 	) :
 		m_HostContext(hostContext),
 		m_SceneRegistry(sceneRegistry),
-		m_ScriptEngine(m_SceneRegistry, m_HostContext.GetInput(), activeSceneHandle),
+		m_ScriptReferences(std::move(scriptReferences)),
+		m_ScriptEngine(m_SceneRegistry, m_HostContext.GetInput(), activeSceneId),
 		m_QueryCache(queryCache),
 		m_ScriptModulePath(scriptModulePath)
 	{ }
@@ -236,18 +262,24 @@ namespace Ludus::Engine::Scripting
 
 		for (auto& scene : m_SceneRegistry.ViewMutable())
 		{
-			m_ScriptEngine.SetActiveScene(scene.Handle);
+			m_ScriptEngine.SetActiveScene(scene.Id);
 			auto* context = m_ScriptEngine.GetContext();
 
 			for (auto& script : scene.EntityComponentSystem.Scripts.ViewMutable())
 			{
-				const auto* definition = m_LoadedScriptModule.TryFindDefinition(script.Name);
+				const auto iter = m_DefinitionsById.find(script.Id);
+				if (iter == m_DefinitionsById.end())
+				{
+					continue;
+				}
+
+				const auto* definition = iter->second;
 				if (!definition)
 				{
 					continue;
 				}
 
-				auto& state = FindOrCreateInstanceState(scene.Handle, script.OwnerHandle);
+				auto& state = FindOrCreateInstanceState(scene.Id, script.OwnerId);
 				state.LastSeenFrame = currentFrame;
 
 				if (state.Definition != definition)
@@ -262,7 +294,7 @@ namespace Ludus::Engine::Scripting
 				{
 					if (definition->OnCreate)
 					{
-						definition->OnCreate(context, script.OwnerHandle);
+						definition->OnCreate(context, script.OwnerId.Value);
 					}
 					state.HasCreated = true;
 				}
@@ -271,7 +303,7 @@ namespace Ludus::Engine::Scripting
 
 				if (definition->OnUpdate)
 				{
-					definition->OnUpdate(context, script.OwnerHandle, deltaTime);
+					definition->OnUpdate(context, script.OwnerId.Value, deltaTime);
 				}
 			}
 		}

--- a/Engine/Source/Ludus/Engine/Serialization/Codecs/LmlDomCodec.cpp
+++ b/Engine/Source/Ludus/Engine/Serialization/Codecs/LmlDomCodec.cpp
@@ -24,6 +24,20 @@ namespace
 	constexpr size_t InlineObjectMaxPairs = 2;
 	constexpr size_t MaxLineLength = 100;
 
+	std::string_view StripUtf8Bom(std::string_view input)
+	{
+		// Be tolerant of text files touched by external tools or shell commands that may add a UTF-8 BOM.
+		if (input.size() >= 3 &&
+			static_cast<unsigned char>(input[0]) == 0xEF &&
+			static_cast<unsigned char>(input[1]) == 0xBB &&
+			static_cast<unsigned char>(input[2]) == 0xBF)
+		{
+			input.remove_prefix(3);
+		}
+
+		return input;
+	}
+
 	struct WriterContext
 	{
 		std::string Text;
@@ -600,11 +614,11 @@ namespace
 
 			auto trimView = [](std::string_view raw)
 			{
-				while (!raw.empty() && raw.front() == ' ')
+				while (!raw.empty() && (raw.front() == ' ' || raw.front() == '\r'))
 				{
 					raw.remove_prefix(1);
 				}
-				while (!raw.empty() && raw.back() == ' ')
+				while (!raw.empty() && (raw.back() == ' ' || raw.back() == '\r'))
 				{
 					raw.remove_suffix(1);
 				}
@@ -612,6 +626,10 @@ namespace
 			};
 
 			std::string_view line = Input.substr(lineStart + indent, lineLimit - (lineStart + indent));
+			if (!line.empty() && line.back() == '\r')
+			{
+				line.remove_suffix(1);
+			}
 			if (!line.empty() && line.front() == '-')
 			{
 				std::string_view value = { };
@@ -709,11 +727,11 @@ namespace
 	private:
 		static std::string_view TrimView(std::string_view raw)
 		{
-			while (!raw.empty() && raw.front() == ' ')
+			while (!raw.empty() && (raw.front() == ' ' || raw.front() == '\r'))
 			{
 				raw.remove_prefix(1);
 			}
-			while (!raw.empty() && raw.back() == ' ')
+			while (!raw.empty() && (raw.back() == ' ' || raw.back() == '\r'))
 			{
 				raw.remove_suffix(1);
 			}
@@ -1183,7 +1201,7 @@ namespace Ludus::Engine::Serialization::Codecs
 
 	Ludus::Engine::Serialization::Core::DomNode LmlDomCodec::Decode(const std::string& data)
 	{
-		Parser parser(data);
+		Parser parser(StripUtf8Bom(data));
 		return parser.ReadRoot();
 	}
 }

--- a/Engine/Source/Ludus/Engine/Serialization/Schemas/RuntimeManifestSchema.cpp
+++ b/Engine/Source/Ludus/Engine/Serialization/Schemas/RuntimeManifestSchema.cpp
@@ -30,8 +30,8 @@ namespace Ludus::Engine::Serialization::Schemas
 		writer.Emit(Token::Uint { runtimeManifest.Version.Patch });
 		writer.Emit(Token::EndObject { });
 
-		writer.Emit(Token::Key { "EntrySceneHandle" });
-		writer.Emit(Token::Uint { runtimeManifest.EntrySceneHandle });
+		writer.Emit(Token::Key { "EntrySceneId" });
+		writer.Emit(Token::Uint { runtimeManifest.EntrySceneId.Value });
 
 		writer.Emit(Token::Key { "Scenes" });
 		writer.Emit(Token::StartArray { });
@@ -40,8 +40,8 @@ namespace Ludus::Engine::Serialization::Schemas
 		{
 			writer.Emit(Token::StartObject { });
 
-			writer.Emit(Token::Key { "Handle" });
-			writer.Emit(Token::Uint { scene.Handle });
+			writer.Emit(Token::Key { "Id" });
+			writer.Emit(Token::Uint { scene.Id.Value });
 			writer.Emit(Token::Key { "Name" });
 			writer.Emit(Token::String { scene.Name });
 
@@ -61,8 +61,8 @@ namespace Ludus::Engine::Serialization::Schemas
 		{
 			writer.Emit(Token::StartObject { });
 
-			writer.Emit(Token::Key { "Handle" });
-			writer.Emit(Token::Uint { script.Handle });
+			writer.Emit(Token::Key { "Id" });
+			writer.Emit(Token::Uint { script.Id.Value });
 			writer.Emit(Token::Key { "Name" });
 			writer.Emit(Token::String { script.Name });
 
@@ -81,6 +81,7 @@ namespace Ludus::Engine::Serialization::Schemas
 		try
 		{
 			bool hasVersion = false;
+			bool hasEntrySceneId = false;
 
 			Ludus::Engine::Serialization::Core::ReadObject(reader, [&](std::string_view key)
 			{
@@ -118,6 +119,12 @@ namespace Ludus::Engine::Serialization::Schemas
 					{
 						throw SerializationException("RuntimeManifest version is incomplete.");
 					}
+					if (runtimeManifest.Version.Major != RuntimeManifest::CurrentVersion.Major ||
+						runtimeManifest.Version.Minor != RuntimeManifest::CurrentVersion.Minor ||
+						runtimeManifest.Version.Patch != RuntimeManifest::CurrentVersion.Patch)
+					{
+						throw SerializationException("RuntimeManifest version does not match the current schema version.");
+					}
 
 					hasVersion = true;
 					return;
@@ -129,16 +136,20 @@ namespace Ludus::Engine::Serialization::Schemas
 					while (!Ludus::Engine::Serialization::Core::Is<Token::EndArray>(reader.Peek()))
 					{
 						SceneReference scene;
-						bool hasHandle = false;
+						bool hasId = false;
 						bool hasName = false;
 						bool hasPath = false;
 
 						Ludus::Engine::Serialization::Core::ReadObject(reader, [&](std::string_view sceneKey)
 						{
-							if (sceneKey == "Handle")
+							if (sceneKey == "Id")
 							{
-								scene.Handle = Ludus::Engine::Serialization::Core::ConsumeUint64Like(reader);
-								hasHandle = true;
+								scene.Id = { Ludus::Engine::Serialization::Core::ConsumeUint64Like(reader) };
+								if (!scene.Id.IsValid())
+								{
+									throw SerializationException("RuntimeManifest scene id is invalid.");
+								}
+								hasId = true;
 								return;
 							}
 							if (sceneKey == "Name")
@@ -159,7 +170,7 @@ namespace Ludus::Engine::Serialization::Schemas
 							Ludus::Engine::Serialization::Core::SkipValue(reader);
 						});
 
-						if (!hasHandle || !hasName || !hasPath)
+						if (!hasId || !hasName || !hasPath)
 						{
 							throw SerializationException("RuntimeManifest scene entry is incomplete.");
 						}
@@ -170,9 +181,10 @@ namespace Ludus::Engine::Serialization::Schemas
 					Ludus::Engine::Serialization::Core::ConsumeAs<Token::EndArray>(reader);
 					return;
 				}
-				if (key == "EntrySceneHandle")
+				if (key == "EntrySceneId")
 				{
-					runtimeManifest.EntrySceneHandle = Ludus::Engine::Serialization::Core::ConsumeUint64Like(reader);
+					runtimeManifest.EntrySceneId = { Ludus::Engine::Serialization::Core::ConsumeUint64Like(reader) };
+					hasEntrySceneId = true;
 					return;
 				}
 				if (key == "Scripts")
@@ -182,15 +194,19 @@ namespace Ludus::Engine::Serialization::Schemas
 					while (!Ludus::Engine::Serialization::Core::Is<Token::EndArray>(reader.Peek()))
 					{
 						ScriptReference script;
-						bool hasHandle = false;
+						bool hasId = false;
 						bool hasName = false;
 
 						Ludus::Engine::Serialization::Core::ReadObject(reader, [&](std::string_view scriptKey)
 						{
-							if (scriptKey == "Handle")
+							if (scriptKey == "Id")
 							{
-								script.Handle = Ludus::Engine::Serialization::Core::ConsumeUint64Like(reader);
-								hasHandle = true;
+								script.Id = { Ludus::Engine::Serialization::Core::ConsumeUint64Like(reader) };
+								if (!script.Id.IsValid())
+								{
+									throw SerializationException("RuntimeManifest script id is invalid.");
+								}
+								hasId = true;
 								return;
 							}
 							if (scriptKey == "Name")
@@ -203,7 +219,7 @@ namespace Ludus::Engine::Serialization::Schemas
 							Ludus::Engine::Serialization::Core::SkipValue(reader);
 						});
 
-						if (!hasHandle || !hasName)
+						if (!hasId || !hasName)
 						{
 							throw SerializationException("RuntimeManifest script entry is incomplete.");
 						}
@@ -222,8 +238,24 @@ namespace Ludus::Engine::Serialization::Schemas
 			{
 				throw SerializationException("RuntimeManifest version not found.");
 			}
+			if (!hasEntrySceneId)
+			{
+				throw SerializationException("RuntimeManifest entry scene id not found.");
+			}
+			if (!runtimeManifest.EntrySceneId.IsValid())
+			{
+				return runtimeManifest;
+			}
 
-			return runtimeManifest;
+			for (const auto& scene : runtimeManifest.Scenes)
+			{
+				if (scene.Id == runtimeManifest.EntrySceneId)
+				{
+					return runtimeManifest;
+				}
+			}
+
+			throw SerializationException("RuntimeManifest entry scene id was not found in scene references.");
 		}
 		catch (const SerializationException& ex)
 		{

--- a/Engine/Source/Ludus/Engine/Serialization/Schemas/SceneSchema.cpp
+++ b/Engine/Source/Ludus/Engine/Serialization/Schemas/SceneSchema.cpp
@@ -13,6 +13,8 @@
 #include <Ludus/Engine/Components/Sprite2DComponent.h>
 #include <Ludus/Engine/Components/Text2DComponent.h>
 #include <Ludus/Engine/Components/Transform2DComponent.h>
+#include <Ludus/Engine/Core/Id.h>
+#include <Ludus/Engine/Core/Random.h>
 #include <Ludus/Engine/Debug/Debug.h>
 #include <Ludus/Engine/Serialization/Core/TokenRead.h>
 #include <Ludus/Engine/Serialization/Schemas/Camera2DComponentSchema.h>
@@ -43,7 +45,7 @@ namespace
 	};
 
 	template <class SlotT, class LoaderT>
-	bool TryReadComponent(
+	void TryReadComponent(
 		ITokenStreamReader& reader,
 		SlotT& componentSlot,
 		LoaderT loader,
@@ -53,7 +55,7 @@ namespace
 		if (!Ludus::Engine::Serialization::Core::Is<Token::StartObject>(reader.Peek()))
 		{
 			Ludus::Engine::Serialization::Core::SkipValue(reader);
-			return false;
+			return;
 		}
 
 		const auto result = loader(reader);
@@ -70,11 +72,10 @@ namespace
 			{
 				Ludus::Engine::Serialization::Core::SkipValue(reader);
 			}
-			return false;
+			return;
 		}
 
 		componentSlot = std::move(result.GetValue());
-		return true;
 	}
 }
 
@@ -84,8 +85,8 @@ namespace Ludus::Engine::Serialization::Schemas
 	{
 		writer.Emit(Token::StartObject { });
 
-		writer.Emit(Token::Key { "Handle" });
-		writer.Emit(Token::Uint { scene.Handle });
+		writer.Emit(Token::Key { "Id" });
+		writer.Emit(Token::Uint { scene.Id.Value });
 
 		writer.Emit(Token::Key { "Name" });
 		writer.Emit(Token::String { scene.Name });
@@ -98,52 +99,52 @@ namespace Ludus::Engine::Serialization::Schemas
 		{
 			writer.Emit(Token::StartObject { });
 
-			writer.Emit(Token::Key { "Handle" });
-			writer.Emit(Token::Uint { entity.Handle });
+			writer.Emit(Token::Key { "Id" });
+			writer.Emit(Token::Uint { entity.Id.Value });
 
-			if (const auto* camera = ecs.Cameras.TryGetByOwner(entity.Handle))
+			if (const auto* camera = ecs.Cameras.TryGetByOwner(entity.Id))
 			{
 				writer.Emit(Token::Key { Camera2DString });
 				Camera2DComponentSchema::Serialize(writer, *camera);
 			}
 
-			if (const auto* collider = ecs.Colliders.TryGetByOwner(entity.Handle))
+			if (const auto* collider = ecs.Colliders.TryGetByOwner(entity.Id))
 			{
 				writer.Emit(Token::Key { Collider2DString });
 				Collider2DComponentSchema::Serialize(writer, *collider);
 			}
 
-			if (const auto* displayName = ecs.DisplayNames.TryGetByOwner(entity.Handle))
+			if (const auto* displayName = ecs.DisplayNames.TryGetByOwner(entity.Id))
 			{
 				writer.Emit(Token::Key { DisplayNameString });
 				DisplayNameComponentSchema::Serialize(writer, *displayName);
 			}
 
-			if (const auto* rigidBody = ecs.RigidBodies.TryGetByOwner(entity.Handle))
+			if (const auto* rigidBody = ecs.RigidBodies.TryGetByOwner(entity.Id))
 			{
 				writer.Emit(Token::Key { RigidBody2DString });
 				RigidBody2DComponentSchema::Serialize(writer, *rigidBody);
 			}
 
-			if (const auto* script = ecs.Scripts.TryGetByOwner(entity.Handle))
+			if (const auto* script = ecs.Scripts.TryGetByOwner(entity.Id))
 			{
 				writer.Emit(Token::Key { ScriptString });
 				ScriptComponentSchema::Serialize(writer, *script);
 			}
 
-			if (const auto* sprite = ecs.Sprites.TryGetByOwner(entity.Handle))
+			if (const auto* sprite = ecs.Sprites.TryGetByOwner(entity.Id))
 			{
 				writer.Emit(Token::Key { Sprite2DString });
 				Sprite2DComponentSchema::Serialize(writer, *sprite);
 			}
 
-			if (const auto* text = ecs.Texts.TryGetByOwner(entity.Handle))
+			if (const auto* text = ecs.Texts.TryGetByOwner(entity.Id))
 			{
 				writer.Emit(Token::Key { Text2DString });
 				Text2DComponentSchema::Serialize(writer, *text);
 			}
 
-			if (const auto* transform = ecs.Transforms.TryGetByOwner(entity.Handle))
+			if (const auto* transform = ecs.Transforms.TryGetByOwner(entity.Id))
 			{
 				writer.Emit(Token::Key { Transform2DString });
 				Transform2DComponentSchema::Serialize(writer, *transform);
@@ -158,18 +159,22 @@ namespace Ludus::Engine::Serialization::Schemas
 
 	Ludus::Engine::Core::Expected<Scene, SerializationException> SceneSchema::Deserialize(ITokenStreamReader& reader)
 	{
-		Scene scene { 0 };
-
+		Scene scene { };
 		try
 		{
-			bool hasHandle = false;
+			bool hasId = false;
 
 			Ludus::Engine::Serialization::Core::ReadObject(reader, [&](std::string_view key)
 			{
-				if (key == "Handle")
+				if (key == "Id")
 				{
-					scene.Handle = Ludus::Engine::Serialization::Core::ConsumeUint64Like(reader);
-					hasHandle = true;
+					scene.Id = { Ludus::Engine::Serialization::Core::ConsumeUint64Like(reader) };
+					if (!scene.Id.IsValid())
+					{
+						throw SerializationException("Scene id is invalid.");
+					}
+
+					hasId = true;
 					return;
 				}
 				if (key == "Name")
@@ -184,168 +189,157 @@ namespace Ludus::Engine::Serialization::Schemas
 					while (!Ludus::Engine::Serialization::Core::Is<Token::EndArray>(reader.Peek()))
 					{
 						StagedComponents stagedComponents;
-						uint64_t entityHandle = 0;
-						bool entityValid = true;
-						bool hasEntityHandle = false;
+						Ludus::Engine::Core::EntityId entityId { Ludus::Engine::Core::EntityId::Invalid() };
+						bool hasEntityId = false;
 
 						Ludus::Engine::Serialization::Core::ReadObject(reader, [&](std::string_view entityKey)
 						{
-							if (entityKey == "Handle")
+							if (entityKey == "Id")
 							{
-								entityHandle = Ludus::Engine::Serialization::Core::ConsumeUint64Like(reader);
-								hasEntityHandle = true;
+								entityId = { Ludus::Engine::Serialization::Core::ConsumeUint64Like(reader) };
+								if (!entityId.IsValid())
+								{
+									throw SerializationException("Entity id is invalid.");
+								}
+								hasEntityId = true;
 								return;
 							}
 							if (entityKey == Camera2DString)
 							{
-								if (!TryReadComponent(reader, stagedComponents.Camera, Camera2DComponentSchema::Deserialize, "Camera2D"))
-								{
-									entityValid = false;
-								}
+								TryReadComponent(
+									reader,
+									stagedComponents.Camera,
+									[](auto& componentReader) { return Camera2DComponentSchema::Deserialize(componentReader, Ludus::Engine::Core::EntityId::Invalid()); },
+									"Camera2D"
+								);
 								return;
 							}
 							if (entityKey == Collider2DString)
 							{
-								if (!TryReadComponent(reader, stagedComponents.Collider, Collider2DComponentSchema::Deserialize, "Collider2D"))
-								{
-									entityValid = false;
-								}
+								TryReadComponent(
+									reader,
+									stagedComponents.Collider,
+									[](auto& componentReader) { return Collider2DComponentSchema::Deserialize(componentReader, Ludus::Engine::Core::EntityId::Invalid()); },
+									"Collider2D"
+								);
 								return;
 							}
 							if (entityKey == DisplayNameString)
 							{
-								if (!TryReadComponent(reader, stagedComponents.DisplayName, DisplayNameComponentSchema::Deserialize, "DisplayName"))
-								{
-									entityValid = false;
-								}
+								TryReadComponent(
+									reader,
+									stagedComponents.DisplayName,
+									[](auto& componentReader) { return DisplayNameComponentSchema::Deserialize(componentReader, Ludus::Engine::Core::EntityId::Invalid()); },
+									"DisplayName"
+								);
 								return;
 							}
 							if (entityKey == RigidBody2DString)
 							{
-								if (!TryReadComponent(reader, stagedComponents.RigidBody, RigidBody2DComponentSchema::Deserialize, "RigidBody2D"))
-								{
-									entityValid = false;
-								}
+								TryReadComponent(
+									reader,
+									stagedComponents.RigidBody,
+									[](auto& componentReader) { return RigidBody2DComponentSchema::Deserialize(componentReader, Ludus::Engine::Core::EntityId::Invalid()); },
+									"RigidBody2D"
+								);
 								return;
 							}
 							if (entityKey == ScriptString)
 							{
-								if (!TryReadComponent(reader, stagedComponents.Script, ScriptComponentSchema::Deserialize, "Script"))
-								{
-									entityValid = false;
-								}
+								TryReadComponent(
+									reader,
+									stagedComponents.Script,
+									[](auto& componentReader) { return ScriptComponentSchema::Deserialize(componentReader, Ludus::Engine::Core::EntityId::Invalid()); },
+									"Script"
+								);
 								return;
 							}
 							if (entityKey == Sprite2DString)
 							{
-								if (!TryReadComponent(reader, stagedComponents.Sprite, Sprite2DComponentSchema::Deserialize, "Sprite2D"))
-								{
-									entityValid = false;
-								}
+								TryReadComponent(
+									reader,
+									stagedComponents.Sprite,
+									[](auto& componentReader) { return Sprite2DComponentSchema::Deserialize(componentReader, Ludus::Engine::Core::EntityId::Invalid()); },
+									"Sprite2D"
+								);
 								return;
 							}
 							if (entityKey == Text2DString)
 							{
-								if (!TryReadComponent(reader, stagedComponents.Text, Text2DComponentSchema::Deserialize, "Text2D"))
-								{
-									entityValid = false;
-								}
+								TryReadComponent(
+									reader,
+									stagedComponents.Text,
+									[](auto& componentReader) { return Text2DComponentSchema::Deserialize(componentReader, Ludus::Engine::Core::EntityId::Invalid()); },
+									"Text2D"
+								);
 								return;
 							}
 							if (entityKey == Transform2DString)
 							{
-								if (!TryReadComponent(reader, stagedComponents.Transform, Transform2DComponentSchema::Deserialize, "Transform2D"))
-								{
-									entityValid = false;
-								}
+								TryReadComponent(
+									reader,
+									stagedComponents.Transform,
+									[](auto& componentReader) { return Transform2DComponentSchema::Deserialize(componentReader, Ludus::Engine::Core::EntityId::Invalid()); },
+									"Transform2D"
+								);
 								return;
 							}
 
 							Ludus::Engine::Serialization::Core::SkipValue(reader);
 						});
 
-						if (!hasEntityHandle)
+						if (!hasEntityId)
 						{
 							continue;
 						}
 
-						if (stagedComponents.Camera && stagedComponents.Camera->OwnerHandle != entityHandle)
-						{
-							entityValid = false;
-						}
-						if (stagedComponents.Collider && stagedComponents.Collider->OwnerHandle != entityHandle)
-						{
-							entityValid = false;
-						}
-						if (stagedComponents.DisplayName && stagedComponents.DisplayName->OwnerHandle != entityHandle)
-						{
-							entityValid = false;
-						}
-						if (stagedComponents.RigidBody && stagedComponents.RigidBody->OwnerHandle != entityHandle)
-						{
-							entityValid = false;
-						}
-						if (stagedComponents.Script && stagedComponents.Script->OwnerHandle != entityHandle)
-						{
-							entityValid = false;
-						}
-						if (stagedComponents.Sprite && stagedComponents.Sprite->OwnerHandle != entityHandle)
-						{
-							entityValid = false;
-						}
-						if (stagedComponents.Text && stagedComponents.Text->OwnerHandle != entityHandle)
-						{
-							entityValid = false;
-						}
-						if (stagedComponents.Transform && stagedComponents.Transform->OwnerHandle != entityHandle)
-						{
-							entityValid = false;
-						}
-
-						if (!entityValid)
-						{
-							continue;
-						}
-
-						scene.EntityComponentSystem.RestoreEntity(entityHandle);
+						scene.EntityComponentSystem.RestoreEntity(entityId);
 
 						if (stagedComponents.Camera)
 						{
+							stagedComponents.Camera->OwnerId = entityId;
 							scene.EntityComponentSystem.AttachCamera(*stagedComponents.Camera);
 						}
 
 						if (stagedComponents.Collider)
 						{
+							stagedComponents.Collider->OwnerId = entityId;
 							scene.EntityComponentSystem.AttachCollider(*stagedComponents.Collider);
 						}
 
 						if (stagedComponents.DisplayName)
 						{
+							stagedComponents.DisplayName->OwnerId = entityId;
 							scene.EntityComponentSystem.AttachDisplayName(*stagedComponents.DisplayName);
 						}
 
 						if (stagedComponents.RigidBody)
 						{
+							stagedComponents.RigidBody->OwnerId = entityId;
 							scene.EntityComponentSystem.AttachRigidBody(*stagedComponents.RigidBody);
 						}
 
 						if (stagedComponents.Script)
 						{
+							stagedComponents.Script->OwnerId = entityId;
 							scene.EntityComponentSystem.AttachScript(*stagedComponents.Script);
 						}
 
 						if (stagedComponents.Sprite)
 						{
+							stagedComponents.Sprite->OwnerId = entityId;
 							scene.EntityComponentSystem.AttachSprite(*stagedComponents.Sprite);
 						}
 
 						if (stagedComponents.Text)
 						{
+							stagedComponents.Text->OwnerId = entityId;
 							scene.EntityComponentSystem.AttachText(*stagedComponents.Text);
 						}
 
 						if (stagedComponents.Transform)
 						{
+							stagedComponents.Transform->OwnerId = entityId;
 							scene.EntityComponentSystem.AttachTransform(*stagedComponents.Transform);
 						}
 					}
@@ -357,9 +351,9 @@ namespace Ludus::Engine::Serialization::Schemas
 				Ludus::Engine::Serialization::Core::SkipValue(reader);
 			});
 
-			if (!hasHandle)
+			if (!hasId)
 			{
-				throw SerializationException("No scene handle found.");
+				throw SerializationException("No scene id found.");
 			}
 		}
 		catch (const SerializationException& ex)

--- a/EngineTests/EngineTests.vcxproj
+++ b/EngineTests/EngineTests.vcxproj
@@ -118,6 +118,7 @@
     <ClCompile Include="Ludus\EngineTests\Events\EventBusTests.cpp" />
     <ClCompile Include="Ludus\EngineTests\IO\FileSystemTests.cpp" />
     <ClCompile Include="Ludus\EngineTests\Math\Vector2DTests.cpp" />
+    <ClCompile Include="Ludus\EngineTests\Platform\GuidTests.cpp" />
     <ClCompile Include="Ludus\EngineTests\Persistence\PathsTests.cpp" />
     <ClCompile Include="Ludus\EngineTests\Persistence\LmlRuntimeManifestPersistenceTests.cpp" />
     <ClCompile Include="Ludus\EngineTests\SmokeTests.cpp" />

--- a/EngineTests/Ludus/EngineTests/Events/EventBusTests.cpp
+++ b/EngineTests/Ludus/EngineTests/Events/EventBusTests.cpp
@@ -273,7 +273,7 @@ namespace Ludus::EngineTests::Events
 		auto event = ConcreteEventA();
 		auto handler = ConcreteHandler();
 
-		// Act && Assert.
+		// Act & Assert.
 		EXPECT_NO_THROW(bus.Unsubscribe(event.Type, handler));
 	}
 

--- a/EngineTests/Ludus/EngineTests/Persistence/LmlRuntimeManifestPersistenceTests.cpp
+++ b/EngineTests/Ludus/EngineTests/Persistence/LmlRuntimeManifestPersistenceTests.cpp
@@ -4,6 +4,7 @@
 #include <stdexcept>
 #include <string_view>
 
+#include <Ludus/Engine/Core/Id.h>
 #include <Ludus/Engine/FileSystem/FileSystem.h>
 #include <Ludus/Engine/Persistence/IRuntimeManifestPersistence.h>
 #include <Ludus/Engine/Persistence/LmlRuntimeManifestPersistence.h>
@@ -11,11 +12,13 @@
 
 namespace Ludus::EngineTests::Persistence
 {
+	using LmlRuntimeManifestPersistence = Ludus::Engine::Persistence::LmlRuntimeManifestPersistence;
 	using RuntimeManifest = Ludus::Engine::Runtime::RuntimeManifest;
+	using RuntimeManifestPersistence = Ludus::Engine::Persistence::IRuntimeManifestPersistence;
 	using SceneReference = Ludus::Engine::Runtime::SceneReference;
 	using ScriptReference = Ludus::Engine::Runtime::ScriptReference;
-	using RuntimeManifestPersistence = Ludus::Engine::Persistence::IRuntimeManifestPersistence;
-	using LmlRuntimeManifestPersistence = Ludus::Engine::Persistence::LmlRuntimeManifestPersistence;
+	using SceneId = Ludus::Engine::Core::SceneId;
+	using ScriptId = Ludus::Engine::Core::ScriptId;
 	namespace FileSystem = Ludus::Engine::FileSystem;
 
 	static std::filesystem::path MakeUniqueTempDir()
@@ -28,34 +31,40 @@ namespace Ludus::EngineTests::Persistence
 		return FileSystem::DirectoryDeleteScope { MakeUniqueTempDir() };
 	}
 
-	static SceneReference MakeSceneReference(uint64_t sceneHandle, std::string_view name, std::string_view path)
+	static SceneReference MakeSceneReference(
+		SceneId id,
+		std::string_view name,
+		std::string_view path
+	)
 	{
-		SceneReference reference;
-		reference.Handle = sceneHandle;
-		reference.Name = std::string(name);
-		reference.Path = std::filesystem::path(path);
-		return reference;
+		return {
+			.Id = id,
+			.Name = std::string(name),
+			.Path = std::filesystem::path(path)
+		};
 	}
 
-	static ScriptReference MakeScriptReference(uint64_t scriptHandle, std::string_view name)
+	static ScriptReference MakeScriptReference(ScriptId id, std::string_view name)
 	{
-		ScriptReference reference;
-		reference.Handle = scriptHandle;
-		reference.Name = std::string(name);
-		return reference;
+		return {
+			.Id = id,
+			.Name = std::string(name)
+		};
 	}
 
 	static RuntimeManifest MakeRuntimeManifest()
 	{
+		auto scenes = std::vector<SceneReference> {
+			MakeSceneReference({ 1 }, "MainMenu", "Scenes/MainMenu.ludus.scene"),
+			MakeSceneReference({ 2 }, "Gameplay", "Scenes/Gameplay.ludus.scene")
+		};
+
 		return RuntimeManifest::Create(
-			222,
+			SceneId { 2 },
+			std::move(scenes),
 			{
-				MakeSceneReference(111, "MainMenu", "Scenes/MainMenu.ludus.scene"),
-				MakeSceneReference(222, "Gameplay", "Scenes/Gameplay.ludus.scene")
-			},
-			{
-				MakeScriptReference(1001, "PlayerScript"),
-				MakeScriptReference(1002, "CameraScript")
+				MakeScriptReference({ 11 }, "PlayerScript"),
+				MakeScriptReference({ 12 }, "CameraScript")
 			}
 		);
 	}
@@ -77,32 +86,9 @@ namespace Ludus::EngineTests::Persistence
 		const auto loaded = persistence.Load(runtimeManifestPath);
 
 		// Assert.
-		ASSERT_EQ(loaded.EntrySceneHandle, runtimeManifest.EntrySceneHandle);
+		ASSERT_EQ(loaded.EntrySceneId, runtimeManifest.EntrySceneId);
 		ASSERT_EQ(loaded.Scenes.size(), runtimeManifest.Scenes.size());
 		ASSERT_EQ(loaded.Scripts.size(), runtimeManifest.Scripts.size());
-	}
-
-	TEST(LmlRuntimeManifestPersistence, SaveAndLoad_PreservesEntrySceneHandle_When_RuntimeManifestIsValid)
-	{
-		// Arrange.
-		const auto tempDirectoryScoped = CreateTestDirectory();
-		std::filesystem::create_directories(tempDirectoryScoped.Path);
-		const auto runtimeManifestPath = tempDirectoryScoped.Path / "Game.ludus.runtime";
-
-		auto runtimeManifest = RuntimeManifest::Create(
-			777,
-			{ MakeSceneReference(777, "MainMenu", "Scenes/MainMenu.ludus.scene") }
-		);
-
-		LmlRuntimeManifestPersistence implementation;
-		RuntimeManifestPersistence& persistence = implementation;
-
-		// Act.
-		persistence.Save(runtimeManifest, runtimeManifestPath);
-		const auto loaded = persistence.Load(runtimeManifestPath);
-
-		// Assert.
-		ASSERT_EQ(loaded.EntrySceneHandle, runtimeManifest.EntrySceneHandle);
 	}
 
 	TEST(LmlRuntimeManifestPersistence, SaveAndLoad_PreservesSceneReferences_When_RuntimeManifestIsValid)
@@ -112,13 +98,7 @@ namespace Ludus::EngineTests::Persistence
 		std::filesystem::create_directories(tempDirectoryScoped.Path);
 		const auto runtimeManifestPath = tempDirectoryScoped.Path / "Game.ludus.runtime";
 
-		auto runtimeManifest = RuntimeManifest::Create(
-			111,
-			{
-				MakeSceneReference(111, "MainMenu", "Scenes/MainMenu.ludus.scene"),
-				MakeSceneReference(222, "Gameplay", "Scenes/Gameplay.ludus.scene")
-			}
-		);
+		const auto runtimeManifest = MakeRuntimeManifest();
 
 		LmlRuntimeManifestPersistence implementation;
 		RuntimeManifestPersistence& persistence = implementation;
@@ -132,7 +112,7 @@ namespace Ludus::EngineTests::Persistence
 
 		for (size_t i = 0; i < runtimeManifest.Scenes.size(); ++i)
 		{
-			ASSERT_EQ(loaded.Scenes[i].Handle, runtimeManifest.Scenes[i].Handle);
+			ASSERT_EQ(loaded.Scenes[i].Id, runtimeManifest.Scenes[i].Id);
 			ASSERT_EQ(loaded.Scenes[i].Name, runtimeManifest.Scenes[i].Name);
 			ASSERT_EQ(loaded.Scenes[i].Path, runtimeManifest.Scenes[i].Path);
 		}
@@ -145,14 +125,7 @@ namespace Ludus::EngineTests::Persistence
 		std::filesystem::create_directories(tempDirectoryScoped.Path);
 		const auto runtimeManifestPath = tempDirectoryScoped.Path / "Game.ludus.runtime";
 
-		auto runtimeManifest = RuntimeManifest::Create(
-			0,
-			{ },
-			{
-				MakeScriptReference(1001, "PlayerScript"),
-				MakeScriptReference(1002, "CameraScript")
-			}
-		);
+		const auto runtimeManifest = MakeRuntimeManifest();
 
 		LmlRuntimeManifestPersistence implementation;
 		RuntimeManifestPersistence& persistence = implementation;
@@ -166,7 +139,7 @@ namespace Ludus::EngineTests::Persistence
 
 		for (size_t i = 0; i < runtimeManifest.Scripts.size(); ++i)
 		{
-			ASSERT_EQ(loaded.Scripts[i].Handle, runtimeManifest.Scripts[i].Handle);
+			ASSERT_EQ(loaded.Scripts[i].Id, runtimeManifest.Scripts[i].Id);
 			ASSERT_EQ(loaded.Scripts[i].Name, runtimeManifest.Scripts[i].Name);
 		}
 	}
@@ -178,7 +151,7 @@ namespace Ludus::EngineTests::Persistence
 		std::filesystem::create_directories(tempDirectoryScoped.Path);
 		const auto runtimeManifestPath = tempDirectoryScoped.Path / "Game.ludus.runtime";
 
-		FileSystem::WriteAllText(runtimeManifestPath, "EntrySceneHandle: 1, Scenes: [], Scripts: []");
+		FileSystem::WriteAllText(runtimeManifestPath, "EntrySceneId: 1, Scenes: [], Scripts: []");
 
 		LmlRuntimeManifestPersistence implementation;
 		RuntimeManifestPersistence& persistence = implementation;
@@ -204,7 +177,7 @@ namespace Ludus::EngineTests::Persistence
 		const auto loaded = persistence.Load(runtimeManifestPath);
 
 		// Assert.
-		ASSERT_EQ(loaded.EntrySceneHandle, runtimeManifest.EntrySceneHandle);
+		ASSERT_EQ(loaded.EntrySceneId, runtimeManifest.EntrySceneId);
 		ASSERT_TRUE(loaded.Scenes.empty());
 		ASSERT_TRUE(loaded.Scripts.empty());
 	}

--- a/EngineTests/Ludus/EngineTests/Platform/GuidTests.cpp
+++ b/EngineTests/Ludus/EngineTests/Platform/GuidTests.cpp
@@ -1,0 +1,72 @@
+#include "pch.h"
+
+#include <string_view>
+
+#include <Ludus/Engine/Platform/Guid.h>
+
+namespace Ludus::EngineTests::Platform
+{
+	using Guid = Ludus::Engine::Platform::Guid;
+
+	TEST(Guid, DefaultConstructedGuid_IsEmpty)
+	{
+		// Arrange.
+		const Guid guid { };
+
+		// Act & Assert.
+		ASSERT_TRUE(guid.IsEmpty());
+		EXPECT_EQ(guid.ToString(), "00000000-0000-0000-0000-000000000000");
+	}
+
+	TEST(Guid, TryParse_ReturnsGuid_When_TextIsValidLowercaseGuid)
+	{
+		// Arrange.
+		const auto text = std::string_view("00112233-4455-6677-8899-aabbccddeeff");
+
+		// Act.
+		const auto guid = Ludus::Engine::Platform::TryParse(text);
+
+		// Assert.
+		ASSERT_TRUE(guid.has_value());
+		EXPECT_EQ(guid->ToString(), text);
+		EXPECT_FALSE(guid->IsEmpty());
+	}
+
+	TEST(Guid, TryParse_ReturnsGuid_When_TextIsValidUppercaseGuid)
+	{
+		// Arrange.
+		const auto text = std::string_view("00112233-4455-6677-8899-AABBCCDDEEFF");
+
+		// Act.
+		const auto guid = Ludus::Engine::Platform::TryParse(text);
+
+		// Assert.
+		ASSERT_TRUE(guid.has_value());
+		EXPECT_EQ(guid->ToString(), "00112233-4455-6677-8899-aabbccddeeff");
+	}
+
+	TEST(Guid, TryParse_ReturnsNullopt_When_TextIsInvalid)
+	{
+		// Arrange.
+		const auto text = std::string_view("not-a-guid");
+
+		// Act.
+		const auto guid = Ludus::Engine::Platform::TryParse(text);
+
+		// Assert.
+		EXPECT_FALSE(guid.has_value());
+	}
+
+	TEST(Guid, CreateGuid_ReturnsNonEmptyGuidThatRoundTripsThroughString)
+	{
+		// Arrange & Act.
+		const auto guid = Ludus::Engine::Platform::CreateGuid();
+		const auto guidText = guid.ToString();
+		const auto reparsedGuid = Ludus::Engine::Platform::TryParse(guidText);
+
+		// Assert.
+		EXPECT_FALSE(guid.IsEmpty());
+		ASSERT_TRUE(reparsedGuid.has_value());
+		EXPECT_EQ(*reparsedGuid, guid);
+	}
+}

--- a/EngineTests/Ludus/EngineTests/Serialization/Codecs/LmlDomCodecTests.cpp
+++ b/EngineTests/Ludus/EngineTests/Serialization/Codecs/LmlDomCodecTests.cpp
@@ -590,6 +590,55 @@ namespace Ludus::EngineTests::Serialization::Codecs
 		ExpectIntLikeValue(object[1].second.get(), 2);
 	}
 
+	TEST(LmlDomCodec, Decode_IgnoresUtf8BomAtStartOfDocument)
+	{
+		// Arrange.
+		const auto input = std::string(
+			"\xEF\xBB\xBF"
+			"A: ValueA\n"
+			"B: 2\n"
+		);
+
+		// Act.
+		LmlDomCodec codec;
+		DomNode root = codec.Decode(input);
+
+		// Assert.
+		ASSERT_TRUE(std::holds_alternative<DomObject>(root.NodeData));
+
+		const auto& object = AsObject(root);
+		ASSERT_EQ(object.size(), 2u);
+
+		EXPECT_EQ(object[0].first, "A");
+		ExpectStringValue(object[0].second.get(), "ValueA");
+
+		EXPECT_EQ(object[1].first, "B");
+		ExpectIntLikeValue(object[1].second.get(), 2);
+	}
+
+	TEST(LmlDomCodec, Decode_ParsesCrLfLineEndings)
+	{
+		// Arrange.
+		const auto input = std::string(
+			"Name: Example\r\n"
+			"Enabled: true\r\n"
+			"Value: 0.50\r\n"
+		);
+
+		// Act.
+		LmlDomCodec codec;
+		DomNode root = codec.Decode(input);
+
+		// Assert.
+		ASSERT_TRUE(std::holds_alternative<DomObject>(root.NodeData));
+
+		const auto& object = AsObject(root);
+		ASSERT_EQ(object.size(), 3u);
+		ExpectStringValue(object[0].second.get(), "Example");
+		ExpectBoolValue(object[1].second.get(), true);
+		ExpectFloatValue(object[2].second.get(), 0.5f);
+	}
+
 	TEST(LmlDomCodec, Decode_QuotesAndEscapesStrings)
 	{
 		// Arrange.
@@ -1013,7 +1062,7 @@ namespace Ludus::EngineTests::Serialization::Codecs
 			"   Child: 1\n"
 		);
 
-		// Act + Assert.
+		// Act & Assert.
 		LmlDomCodec codec;
 		ASSERT_THROW(codec.Decode(input), std::runtime_error);
 	}
@@ -1027,7 +1076,7 @@ namespace Ludus::EngineTests::Serialization::Codecs
 			"  Other: 1\n"
 		);
 
-		// Act + Assert.
+		// Act & Assert.
 		LmlDomCodec codec;
 		ASSERT_THROW(codec.Decode(input), std::runtime_error);
 	}
@@ -1039,7 +1088,7 @@ namespace Ludus::EngineTests::Serialization::Codecs
 			"Message: \"unterminated\n"
 		);
 
-		// Act + Assert.
+		// Act & Assert.
 		LmlDomCodec codec;
 		ASSERT_THROW(codec.Decode(input), std::runtime_error);
 	}
@@ -1051,7 +1100,7 @@ namespace Ludus::EngineTests::Serialization::Codecs
 			"Values: [1, 2,]\n"
 		);
 
-		// Act + Assert.
+		// Act & Assert.
 		LmlDomCodec codec;
 		ASSERT_THROW(codec.Decode(input), std::runtime_error);
 	}
@@ -1063,7 +1112,7 @@ namespace Ludus::EngineTests::Serialization::Codecs
 			"Obj: { A: 1, }\n"
 		);
 
-		// Act + Assert.
+		// Act & Assert.
 		LmlDomCodec codec;
 		ASSERT_THROW(codec.Decode(input), std::runtime_error);
 	}
@@ -1075,7 +1124,7 @@ namespace Ludus::EngineTests::Serialization::Codecs
 			"Mixed: [1, { A: 2 }]\n"
 		);
 
-		// Act + Assert.
+		// Act & Assert.
 		LmlDomCodec codec;
 		ASSERT_THROW(codec.Decode(input), std::runtime_error);
 	}

--- a/EngineTests/Ludus/EngineTests/Serialization/Core/DomTokenStreamReaderTests.cpp
+++ b/EngineTests/Ludus/EngineTests/Serialization/Core/DomTokenStreamReaderTests.cpp
@@ -31,9 +31,11 @@ namespace Ludus::EngineTests::Serialization::Core
 
 		DomTokenStreamReader reader(document);
 
-		// Act & Assert.
+		// Act.
 		const auto& firstPeek = reader.Peek();
 		const auto& secondPeek = reader.Peek();
+
+		// Assert.
 		ASSERT_TRUE(std::holds_alternative<Token::StartObject>(firstPeek.Data));
 		ASSERT_TRUE(std::holds_alternative<Token::StartObject>(secondPeek.Data));
 
@@ -70,7 +72,7 @@ namespace Ludus::EngineTests::Serialization::Core
 
 		DomTokenStreamReader reader(document);
 
-		// Act & Assert.
+		// Act.
 		ASSERT_TRUE(std::holds_alternative<Token::StartArray>(reader.Peek().Data));
 		reader.Consume();
 		ASSERT_TRUE(std::holds_alternative<Token::Int>(reader.Peek().Data));
@@ -80,6 +82,7 @@ namespace Ludus::EngineTests::Serialization::Core
 		ASSERT_TRUE(std::holds_alternative<Token::EndArray>(reader.Peek().Data));
 		reader.Consume();
 
+		// Assert.
 		ASSERT_TRUE(reader.IsComplete());
 	}
 
@@ -107,7 +110,7 @@ namespace Ludus::EngineTests::Serialization::Core
 
 		DomTokenStreamReader reader(document);
 
-		// Act + Assert.
+		// Act.
 		ASSERT_TRUE(std::holds_alternative<Token::StartObject>(reader.Peek().Data));
 		reader.Consume();
 		ASSERT_TRUE(std::holds_alternative<Token::Key>(reader.Peek().Data));
@@ -141,6 +144,7 @@ namespace Ludus::EngineTests::Serialization::Core
 		ASSERT_TRUE(std::holds_alternative<Token::EndObject>(reader.Peek().Data));
 		reader.Consume();
 
+		// Assert.
 		ASSERT_TRUE(reader.IsComplete());
 	}
 
@@ -150,7 +154,7 @@ namespace Ludus::EngineTests::Serialization::Core
 		// Arrange.
 		DomDocument document;
 
-		// Act + Assert.
+		// Act & Assert.
 		ASSERT_DEATH({ DomTokenStreamReader reader(document); }, R"(The DOM document is empty\.)");
 	}
 
@@ -168,7 +172,7 @@ namespace Ludus::EngineTests::Serialization::Core
 		reader.Consume();
 		ASSERT_TRUE(reader.IsComplete());
 
-		// Act + Assert.
+		// Act & Assert.
 		ASSERT_DEATH({ reader.Peek(); }, R"(Peek cannot be called on a completed DOM document\.)");
 	}
 #endif

--- a/EngineTests/Ludus/EngineTests/Serialization/Core/DomTokenStreamWriterTests.cpp
+++ b/EngineTests/Ludus/EngineTests/Serialization/Core/DomTokenStreamWriterTests.cpp
@@ -174,7 +174,7 @@ namespace Ludus::EngineTests::Serialization::Core
 		DomDocument document;
 		DomTokenStreamWriter writer(document);
 
-		// Act + Assert.
+		// Act & Assert.
 		ASSERT_DEATH({ writer.Emit(Token::Key { "oops" }); }, R"(Key requires an active object\.)");
 	}
 
@@ -184,7 +184,7 @@ namespace Ludus::EngineTests::Serialization::Core
 		DomDocument document;
 		DomTokenStreamWriter writer(document);
 
-		// Act + Assert.
+		// Act & Assert.
 		ASSERT_DEATH({ writer.Emit(Token::EndObject { }); }, R"(EndObject requires an active object\.)");
 	}
 #endif

--- a/EngineTests/Ludus/EngineTests/Serialization/Schemas/Camera2DComponentSchemaTests.cpp
+++ b/EngineTests/Ludus/EngineTests/Serialization/Schemas/Camera2DComponentSchemaTests.cpp
@@ -3,6 +3,7 @@
 #include <cstdint>
 
 #include <Ludus/Engine/Components/Camera2DComponent.h>
+#include <Ludus/Engine/Core/Id.h>
 #include <Ludus/Engine/Serialization/Core/DomDocument.h>
 #include <Ludus/Engine/Serialization/Core/DomTokenStreamReader.h>
 #include <Ludus/Engine/Serialization/Core/DomTokenStreamWriter.h>
@@ -11,6 +12,7 @@
 
 namespace Ludus::EngineTests::Serialization::Schemas
 {
+	using EntityId = Ludus::Engine::Core::EntityId;
 	using DomDocument = Ludus::Engine::Serialization::Core::DomDocument;
 	using DomTokenStreamWriter = Ludus::Engine::Serialization::Core::DomTokenStreamWriter;
 	using DomTokenStreamReader = Ludus::Engine::Serialization::Core::DomTokenStreamReader;
@@ -36,7 +38,7 @@ namespace Ludus::EngineTests::Serialization::Schemas
 	TEST(Camera2DComponentSchema, Serialize_WritesExpectedComponentValues)
 	{
 		// Arrange.
-		Ludus::Engine::Components::Camera2DComponent camera(1, 10.0f, -1);
+		Ludus::Engine::Components::Camera2DComponent camera(EntityId { 1 }, 10.0f, -1);
 		DomDocument document;
 		DomTokenStreamWriter writer(document);
 
@@ -48,19 +50,15 @@ namespace Ludus::EngineTests::Serialization::Schemas
 		ASSERT_NE(root, nullptr);
 
 		const auto& cameraObject = AsObject(*root);
-		const auto* ownerNode = FindMember(cameraObject, "OwnerHandle");
 		const auto* sizeNode = FindMember(cameraObject, "OrthographicSize");
 		const auto* priorityNode = FindMember(cameraObject, "Priority");
 
-		ASSERT_NE(ownerNode, nullptr);
 		ASSERT_NE(sizeNode, nullptr);
 		ASSERT_NE(priorityNode, nullptr);
 
-		const auto ownerHandle = std::get<uint64_t>(AsValue(*ownerNode));
 		const auto orthographicSize = std::get<double>(AsValue(*sizeNode));
 		const auto priority = std::get<int64_t>(AsValue(*priorityNode));
 
-		ASSERT_EQ(ownerHandle, 1u);
 		ASSERT_EQ(orthographicSize, 10.0f);
 		ASSERT_EQ(priority, -1);
 	}
@@ -68,15 +66,13 @@ namespace Ludus::EngineTests::Serialization::Schemas
 	TEST(Camera2DComponentSchema, Deserialize_ReadsFields_When_ComponentHasValues)
 	{
 		// Arrange.
-		const auto ownerHandle = 1;
+		const auto ownerId = EntityId { 1 };
 		const auto orthographicSize = 10.0f;
 		const auto priority = -1;
 
 		DomDocument document;
 		DomTokenStreamWriter writer(document);
 		writer.Emit(Token::StartObject { });
-		writer.Emit(Token::Key { "OwnerHandle" });
-		writer.Emit(Token::Int { static_cast<int>(ownerHandle) });
 		writer.Emit(Token::Key { "OrthographicSize" });
 		writer.Emit(Token::Double { orthographicSize });
 		writer.Emit(Token::Key { "Priority" });
@@ -85,13 +81,13 @@ namespace Ludus::EngineTests::Serialization::Schemas
 		DomTokenStreamReader reader(document);
 
 		// Act.
-		const auto& result = Camera2DComponentSchema::Deserialize(reader);
+		const auto& result = Camera2DComponentSchema::Deserialize(reader, ownerId);
 
 		// Assert.
 		ASSERT_TRUE(result.HasValue());
 
 		const auto& cameraResult = result.GetValue();
-		ASSERT_EQ(cameraResult.OwnerHandle, ownerHandle);
+		ASSERT_EQ(cameraResult.OwnerId, ownerId);
 		ASSERT_EQ(cameraResult.OrthographicSize, orthographicSize);
 		ASSERT_EQ(cameraResult.Priority, priority);
 	}
@@ -102,26 +98,25 @@ namespace Ludus::EngineTests::Serialization::Schemas
 		DomDocument document;
 		DomTokenStreamWriter writer(document);
 		writer.Emit(Token::StartObject { });
-		writer.Emit(Token::Key { "OwnerHandle" });
-		writer.Emit(Token::Int { 1 });
 		writer.Emit(Token::EndObject { });
 		DomTokenStreamReader reader(document);
 
 		// Act.
-		const auto result = Camera2DComponentSchema::Deserialize(reader);
+		const auto result = Camera2DComponentSchema::Deserialize(reader, EntityId { 1 });
 
 		// Assert.
 		ASSERT_TRUE(result.HasValue());
 
 		const auto& cameraResult = result.GetValue();
-		ASSERT_EQ(cameraResult.OwnerHandle, 1);
+		ASSERT_EQ(cameraResult.OwnerId.Value, 1u);
 		ASSERT_EQ(cameraResult.OrthographicSize, 10.0f);
 		ASSERT_EQ(cameraResult.Priority, -1);
 	}
 
-	TEST(Camera2DComponentSchema, Deserialize_Fails_When_RequiredFieldsAreMissing)
+	TEST(Camera2DComponentSchema, Deserialize_DefaultsFields_When_AllPayloadFieldsAreMissing)
 	{
 		// Arrange.
+		const auto ownerId = EntityId { 1 };
 		DomDocument document;
 		DomTokenStreamWriter writer(document);
 		writer.Emit(Token::StartObject { });
@@ -129,10 +124,13 @@ namespace Ludus::EngineTests::Serialization::Schemas
 		DomTokenStreamReader reader(document);
 
 		// Act.
-		const auto result = Camera2DComponentSchema::Deserialize(reader);
+		const auto result = Camera2DComponentSchema::Deserialize(reader, ownerId);
 
 		// Assert.
-		ASSERT_FALSE(result.HasValue());
+		ASSERT_TRUE(result.HasValue());
+		ASSERT_EQ(result.GetValue().OwnerId, ownerId);
+		ASSERT_EQ(result.GetValue().OrthographicSize, 10.0f);
+		ASSERT_EQ(result.GetValue().Priority, -1);
 	}
 
 	TEST(Camera2DComponentSchema, Deserialize_Fails_When_ObjectStartIsMissing)
@@ -144,7 +142,7 @@ namespace Ludus::EngineTests::Serialization::Schemas
 		DomTokenStreamReader reader(document);
 
 		// Act.
-		const auto result = Camera2DComponentSchema::Deserialize(reader);
+		const auto result = Camera2DComponentSchema::Deserialize(reader, EntityId { 1 });
 
 		// Assert.
 		ASSERT_FALSE(result.HasValue());

--- a/EngineTests/Ludus/EngineTests/Serialization/Schemas/Collider2DComponentSchemaTests.cpp
+++ b/EngineTests/Ludus/EngineTests/Serialization/Schemas/Collider2DComponentSchemaTests.cpp
@@ -3,6 +3,7 @@
 #include <cstdint>
 
 #include <Ludus/Engine/Components/Collider2DComponent.h>
+#include <Ludus/Engine/Core/Id.h>
 #include <Ludus/Engine/Physics/Core/LayerMask.h>
 #include <Ludus/Engine/Serialization/Core/DomDocument.h>
 #include <Ludus/Engine/Serialization/Core/DomNode.h>
@@ -13,6 +14,7 @@
 
 namespace Ludus::EngineTests::Serialization::Schemas
 {
+	using EntityId = Ludus::Engine::Core::EntityId;
 	using DomDocument = Ludus::Engine::Serialization::Core::DomDocument;
 	using DomTokenStreamWriter = Ludus::Engine::Serialization::Core::DomTokenStreamWriter;
 	using DomTokenStreamReader = Ludus::Engine::Serialization::Core::DomTokenStreamReader;
@@ -41,7 +43,7 @@ namespace Ludus::EngineTests::Serialization::Schemas
 	{
 		// Arrange.
 		Ludus::Engine::Components::Collider2DComponent collider(
-			1, 3, Ludus::Engine::Physics::Core::LayerMask(0xFF), true
+			EntityId { 1 }, 3, Ludus::Engine::Physics::Core::LayerMask(0xFF), true
 		);
 		DomDocument document;
 		DomTokenStreamWriter writer(document);
@@ -55,22 +57,18 @@ namespace Ludus::EngineTests::Serialization::Schemas
 
 		const auto& colliderObject = AsObject(*root);
 
-		const auto* ownerNode = FindMember(colliderObject, "OwnerHandle");
 		const auto* layerNode = FindMember(colliderObject, "LayerIndex");
 		const auto* collidesNode = FindMember(colliderObject, "CollidesWith");
 		const auto* triggerNode = FindMember(colliderObject, "IsTrigger");
 
-		ASSERT_NE(ownerNode, nullptr);
 		ASSERT_NE(layerNode, nullptr);
 		ASSERT_NE(collidesNode, nullptr);
 		ASSERT_NE(triggerNode, nullptr);
 
-		const auto ownerHandle = std::get<uint64_t>(AsValue(*ownerNode));
 		const auto layerIndex = std::get<uint64_t>(AsValue(*layerNode));
 		const auto collidesWith = std::get<uint64_t>(AsValue(*collidesNode));
 		const auto isTrigger = std::get<bool>(AsValue(*triggerNode));
 
-		ASSERT_EQ(ownerHandle, 1u);
 		ASSERT_EQ(layerIndex, 3u);
 		ASSERT_EQ(collidesWith, 0xFFu);
 		ASSERT_EQ(isTrigger, true);
@@ -79,11 +77,10 @@ namespace Ludus::EngineTests::Serialization::Schemas
 	TEST(Collider2DComponentSchema, Deserialize_ReadsFields_When_ComponentHasValues)
 	{
 		// Arrange.
+		const EntityId ownerId { 1 };
 		DomDocument document;
 		DomTokenStreamWriter writer(document);
 		writer.Emit(Token::StartObject { });
-		writer.Emit(Token::Key { "OwnerHandle" });
-		writer.Emit(Token::Int { 1 });
 		writer.Emit(Token::Key { "LayerIndex" });
 		writer.Emit(Token::Int { 2 });
 		writer.Emit(Token::Key { "CollidesWith" });
@@ -94,13 +91,13 @@ namespace Ludus::EngineTests::Serialization::Schemas
 		DomTokenStreamReader reader(document);
 
 		// Act.
-		const auto result = Collider2DComponentSchema::Deserialize(reader);
+		const auto result = Collider2DComponentSchema::Deserialize(reader, ownerId);
 
 		// Assert.
 		ASSERT_TRUE(result.HasValue());
 
 		const auto& colliderResult = result.GetValue();
-		ASSERT_EQ(colliderResult.OwnerHandle, 1u);
+		ASSERT_EQ(colliderResult.OwnerId, ownerId);
 		ASSERT_EQ(colliderResult.LayerIndex, 2);
 		ASSERT_EQ(colliderResult.CollidesWith.Value, 0xAAu);
 		ASSERT_EQ(colliderResult.IsTrigger, true);
@@ -109,30 +106,30 @@ namespace Ludus::EngineTests::Serialization::Schemas
 	TEST(Collider2DComponentSchema, Deserialize_DefaultsOptionalFields_When_Missing)
 	{
 		// Arrange.
+		const EntityId ownerId { 1 };
 		DomDocument document;
 		DomTokenStreamWriter writer(document);
 		writer.Emit(Token::StartObject { });
-		writer.Emit(Token::Key { "OwnerHandle" });
-		writer.Emit(Token::Int { 1 });
 		writer.Emit(Token::EndObject { });
 		DomTokenStreamReader reader(document);
 
 		// Act.
-		const auto result = Collider2DComponentSchema::Deserialize(reader);
+		const auto result = Collider2DComponentSchema::Deserialize(reader, ownerId);
 
 		// Assert.
 		ASSERT_TRUE(result.HasValue());
 
 		const auto& colliderResult = result.GetValue();
-		ASSERT_EQ(colliderResult.OwnerHandle, 1u);
+		ASSERT_EQ(colliderResult.OwnerId, ownerId);
 		ASSERT_EQ(colliderResult.LayerIndex, 0);
 		ASSERT_EQ(colliderResult.CollidesWith.Value, Ludus::Engine::Physics::Core::LayerMask::GetEmpty().Value);
 		ASSERT_EQ(colliderResult.IsTrigger, false);
 	}
 
-	TEST(Collider2DComponentSchema, Deserialize_Fails_When_RequiredFieldsAreMissing)
+	TEST(Collider2DComponentSchema, Deserialize_DefaultsFields_When_AllPayloadFieldsAreMissing)
 	{
 		// Arrange.
+		const EntityId ownerId { 1 };
 		DomDocument document;
 		DomTokenStreamWriter writer(document);
 		writer.Emit(Token::StartObject { });
@@ -140,22 +137,27 @@ namespace Ludus::EngineTests::Serialization::Schemas
 		DomTokenStreamReader reader(document);
 
 		// Act.
-		const auto result = Collider2DComponentSchema::Deserialize(reader);
+		const auto result = Collider2DComponentSchema::Deserialize(reader, ownerId);
 
 		// Assert.
-		ASSERT_FALSE(result.HasValue());
+		ASSERT_TRUE(result.HasValue());
+		ASSERT_EQ(result.GetValue().OwnerId, ownerId);
+		ASSERT_EQ(result.GetValue().LayerIndex, 0);
+		ASSERT_EQ(result.GetValue().CollidesWith.Value, Ludus::Engine::Physics::Core::LayerMask::GetEmpty().Value);
+		ASSERT_EQ(result.GetValue().IsTrigger, false);
 	}
 
 	TEST(Collider2DComponentSchema, Deserialize_Fails_When_ComponentHeaderIsMissing)
 	{
 		// Arrange.
+		const EntityId ownerId { 1 };
 		DomDocument document;
 		DomTokenStreamWriter writer(document);
 		writer.Emit(Token::Int { 1 });
 		DomTokenStreamReader reader(document);
 
 		// Act.
-		const auto result = Collider2DComponentSchema::Deserialize(reader);
+		const auto result = Collider2DComponentSchema::Deserialize(reader, ownerId);
 
 		// Assert.
 		ASSERT_FALSE(result.HasValue());

--- a/EngineTests/Ludus/EngineTests/Serialization/Schemas/DisplayNameComponentSchemaTests.cpp
+++ b/EngineTests/Ludus/EngineTests/Serialization/Schemas/DisplayNameComponentSchemaTests.cpp
@@ -4,6 +4,7 @@
 #include <string>
 
 #include <Ludus/Engine/Components/DisplayNameComponent.h>
+#include <Ludus/Engine/Core/Id.h>
 #include <Ludus/Engine/Serialization/Core/DomDocument.h>
 #include <Ludus/Engine/Serialization/Core/DomNode.h>
 #include <Ludus/Engine/Serialization/Core/DomTokenStreamReader.h>
@@ -13,6 +14,7 @@
 
 namespace Ludus::EngineTests::Serialization::Schemas
 {
+	using EntityId = Ludus::Engine::Core::EntityId;
 	using DomDocument = Ludus::Engine::Serialization::Core::DomDocument;
 	using DomTokenStreamWriter = Ludus::Engine::Serialization::Core::DomTokenStreamWriter;
 	using DomTokenStreamReader = Ludus::Engine::Serialization::Core::DomTokenStreamReader;
@@ -40,7 +42,7 @@ namespace Ludus::EngineTests::Serialization::Schemas
 	TEST(DisplayNameComponentSchema, Serialize_WritesExpectedComponentValues)
 	{
 		// Arrange.
-		Ludus::Engine::Components::DisplayNameComponent displayName(1, "Name");
+		Ludus::Engine::Components::DisplayNameComponent displayName(EntityId { 1 }, "Name");
 		DomDocument document;
 		DomTokenStreamWriter writer(document);
 
@@ -52,68 +54,63 @@ namespace Ludus::EngineTests::Serialization::Schemas
 		ASSERT_NE(root, nullptr);
 
 		const auto& displayNameObject = AsObject(*root);
-		const auto* ownerNode = FindMember(displayNameObject, "OwnerHandle");
 		const auto* nameNode = FindMember(displayNameObject, "Name");
 
-		ASSERT_NE(ownerNode, nullptr);
 		ASSERT_NE(nameNode, nullptr);
 
-		const auto ownerHandle = std::get<uint64_t>(AsValue(*ownerNode));
 		const auto value = std::get<std::string>(AsValue(*nameNode));
 
-		ASSERT_EQ(ownerHandle, 1u);
 		ASSERT_EQ(value, "Name");
 	}
 
 	TEST(DisplayNameComponentSchema, Deserialize_ReadsFields_When_ComponentHasValues)
 	{
 		// Arrange.
+		const EntityId ownerId { 1 };
 		DomDocument document;
 		DomTokenStreamWriter writer(document);
 		writer.Emit(Token::StartObject { });
-		writer.Emit(Token::Key { "OwnerHandle" });
-		writer.Emit(Token::Int { 1 });
 		writer.Emit(Token::Key { "Name" });
 		writer.Emit(Token::String { "Name" });
 		writer.Emit(Token::EndObject { });
 		DomTokenStreamReader reader(document);
 
 		// Act.
-		const auto result = DisplayNameComponentSchema::Deserialize(reader);
+		const auto result = DisplayNameComponentSchema::Deserialize(reader, ownerId);
 
 		// Assert.
 		ASSERT_TRUE(result.HasValue());
 
 		const auto& displayNameResult = result.GetValue();
-		ASSERT_EQ(displayNameResult.OwnerHandle, 1u);
+		ASSERT_EQ(displayNameResult.OwnerId, ownerId);
 		ASSERT_EQ(displayNameResult.Name, "Name");
 	}
 
 	TEST(DisplayNameComponentSchema, Deserialize_DefaultsOptionalFields_When_Missing)
 	{
 		// Arrange.
+		const EntityId ownerId { 1 };
 		DomDocument document;
 		DomTokenStreamWriter writer(document);
 		writer.Emit(Token::StartObject { });
-		writer.Emit(Token::Key { "OwnerHandle" });
-		writer.Emit(Token::Int { 1 });
 		writer.Emit(Token::EndObject { });
 		DomTokenStreamReader reader(document);
 
 		// Act.
-		const auto result = DisplayNameComponentSchema::Deserialize(reader);
+		const auto result = DisplayNameComponentSchema::Deserialize(reader, ownerId);
 
 		// Assert.
 		ASSERT_TRUE(result.HasValue());
 
 		const auto& displayNameResult = result.GetValue();
-		ASSERT_EQ(displayNameResult.OwnerHandle, 1u);
+		ASSERT_EQ(displayNameResult.OwnerId, ownerId);
 		ASSERT_EQ(displayNameResult.Name, "");
 	}
 
-	TEST(DisplayNameComponentSchema, Deserialize_Fails_When_RequiredFieldsAreMissing)
+	TEST(DisplayNameComponentSchema, Deserialize_DefaultsFields_When_AllPayloadFieldsAreMissing)
 	{
 		// Arrange.
+		const EntityId ownerId { 1 };
 		DomDocument document;
 		DomTokenStreamWriter writer(document);
 		writer.Emit(Token::StartObject { });
@@ -121,22 +118,25 @@ namespace Ludus::EngineTests::Serialization::Schemas
 		DomTokenStreamReader reader(document);
 
 		// Act.
-		const auto result = DisplayNameComponentSchema::Deserialize(reader);
+		const auto result = DisplayNameComponentSchema::Deserialize(reader, ownerId);
 
 		// Assert.
-		ASSERT_FALSE(result.HasValue());
+		ASSERT_TRUE(result.HasValue());
+		ASSERT_EQ(result.GetValue().OwnerId, ownerId);
+		ASSERT_EQ(result.GetValue().Name, "");
 	}
 
 	TEST(DisplayNameComponentSchema, Deserialize_Fails_When_ComponentHeaderIsMissing)
 	{
 		// Arrange.
+		const EntityId ownerId { 1 };
 		DomDocument document;
 		DomTokenStreamWriter writer(document);
 		writer.Emit(Token::Int { 1 });
 		DomTokenStreamReader reader(document);
 
 		// Act.
-		const auto result = DisplayNameComponentSchema::Deserialize(reader);
+		const auto result = DisplayNameComponentSchema::Deserialize(reader, ownerId);
 
 		// Assert.
 		ASSERT_FALSE(result.HasValue());

--- a/EngineTests/Ludus/EngineTests/Serialization/Schemas/RigidBody2DComponentSchemaTests.cpp
+++ b/EngineTests/Ludus/EngineTests/Serialization/Schemas/RigidBody2DComponentSchemaTests.cpp
@@ -4,6 +4,7 @@
 #include <string>
 
 #include <Ludus/Engine/Components/RigidBody2DComponent.h>
+#include <Ludus/Engine/Core/Id.h>
 #include <Ludus/Engine/Physics/Core/BodyType.h>
 #include <Ludus/Engine/Serialization/Core/DomDocument.h>
 #include <Ludus/Engine/Serialization/Core/DomNode.h>
@@ -14,6 +15,7 @@
 
 namespace Ludus::EngineTests::Serialization::Schemas
 {
+	using EntityId = Ludus::Engine::Core::EntityId;
 	using DomDocument = Ludus::Engine::Serialization::Core::DomDocument;
 	using DomTokenStreamWriter = Ludus::Engine::Serialization::Core::DomTokenStreamWriter;
 	using DomTokenStreamReader = Ludus::Engine::Serialization::Core::DomTokenStreamReader;
@@ -60,19 +62,16 @@ namespace Ludus::EngineTests::Serialization::Schemas
 
 		const auto& rigidBodyObject = AsObject(*root);
 
-		const auto* ownerNode = FindMember(rigidBodyObject, "OwnerHandle");
 		const auto* velocityNode = FindMember(rigidBodyObject, "Velocity");
 		const auto* gravityNode = FindMember(rigidBodyObject, "GravityScale");
 		const auto* massNode = FindMember(rigidBodyObject, "Mass");
 		const auto* typeNode = FindMember(rigidBodyObject, "BodyType");
 
-		ASSERT_NE(ownerNode, nullptr);
 		ASSERT_NE(velocityNode, nullptr);
 		ASSERT_NE(gravityNode, nullptr);
 		ASSERT_NE(massNode, nullptr);
 		ASSERT_NE(typeNode, nullptr);
 
-		const auto ownerHandle = std::get<uint64_t>(AsValue(*ownerNode));
 		const auto gravityScale = std::get<double>(AsValue(*gravityNode));
 		const auto mass = std::get<double>(AsValue(*massNode));
 		const auto typeValue = std::get<std::string>(AsValue(*typeNode));
@@ -81,7 +80,6 @@ namespace Ludus::EngineTests::Serialization::Schemas
 		const auto velocityX = std::get<double>(AsValue(*FindMember(velocityObject, "X")));
 		const auto velocityY = std::get<double>(AsValue(*FindMember(velocityObject, "Y")));
 
-		ASSERT_EQ(ownerHandle, 1u);
 		ASSERT_EQ(velocityX, 3.0f);
 		ASSERT_EQ(velocityY, 4.0f);
 		ASSERT_EQ(gravityScale, 2.0f);
@@ -92,11 +90,10 @@ namespace Ludus::EngineTests::Serialization::Schemas
 	TEST(RigidBody2DComponentSchema, Deserialize_ReadsFields_When_ComponentHasValues)
 	{
 		// Arrange.
+		const EntityId ownerId { 1 };
 		DomDocument document;
 		DomTokenStreamWriter writer(document);
 		writer.Emit(Token::StartObject { });
-		writer.Emit(Token::Key { "OwnerHandle" });
-		writer.Emit(Token::Int { 1 });
 		writer.Emit(Token::Key { "Velocity" });
 		writer.Emit(Token::StartObject { });
 		writer.Emit(Token::Key { "X" });
@@ -114,13 +111,13 @@ namespace Ludus::EngineTests::Serialization::Schemas
 		DomTokenStreamReader reader(document);
 
 		// Act.
-		const auto result = RigidBody2DComponentSchema::Deserialize(reader);
+		const auto result = RigidBody2DComponentSchema::Deserialize(reader, ownerId);
 
 		// Assert.
 		ASSERT_TRUE(result.HasValue());
 
 		const auto& rigidBodyResult = result.GetValue();
-		ASSERT_EQ(rigidBodyResult.OwnerHandle, 1u);
+		ASSERT_EQ(rigidBodyResult.OwnerId, ownerId);
 		ASSERT_EQ(rigidBodyResult.Velocity.X, 3.0f);
 		ASSERT_EQ(rigidBodyResult.Velocity.Y, 4.0f);
 		ASSERT_EQ(rigidBodyResult.GravityScale, 2.0f);
@@ -131,31 +128,31 @@ namespace Ludus::EngineTests::Serialization::Schemas
 	TEST(RigidBody2DComponentSchema, Deserialize_DefaultsOptionalFields_When_Missing)
 	{
 		// Arrange.
+		const EntityId ownerId { 1 };
 		DomDocument document;
 		DomTokenStreamWriter writer(document);
 		writer.Emit(Token::StartObject { });
-		writer.Emit(Token::Key { "OwnerHandle" });
-		writer.Emit(Token::Int { 1 });
 		writer.Emit(Token::EndObject { });
 		DomTokenStreamReader reader(document);
 
 		// Act.
-		const auto result = RigidBody2DComponentSchema::Deserialize(reader);
+		const auto result = RigidBody2DComponentSchema::Deserialize(reader, ownerId);
 
 		// Assert.
 		ASSERT_TRUE(result.HasValue());
 
 		const auto& rigidBodyResult = result.GetValue();
-		ASSERT_EQ(rigidBodyResult.OwnerHandle, 1u);
+		ASSERT_EQ(rigidBodyResult.OwnerId, ownerId);
 		ASSERT_EQ(rigidBodyResult.Velocity.X, 0.0f);
 		ASSERT_EQ(rigidBodyResult.Velocity.Y, 0.0f);
 		ASSERT_EQ(rigidBodyResult.GravityScale, 1.0f);
 		ASSERT_EQ(rigidBodyResult.Mass, 1.0f);
 	}
 
-	TEST(RigidBody2DComponentSchema, Deserialize_Fails_When_RequiredFieldsAreMissing)
+	TEST(RigidBody2DComponentSchema, Deserialize_DefaultsFields_When_AllPayloadFieldsAreMissing)
 	{
 		// Arrange.
+		const EntityId ownerId { 1 };
 		DomDocument document;
 		DomTokenStreamWriter writer(document);
 		writer.Emit(Token::StartObject { });
@@ -163,22 +160,28 @@ namespace Ludus::EngineTests::Serialization::Schemas
 		DomTokenStreamReader reader(document);
 
 		// Act.
-		const auto result = RigidBody2DComponentSchema::Deserialize(reader);
+		const auto result = RigidBody2DComponentSchema::Deserialize(reader, ownerId);
 
 		// Assert.
-		ASSERT_FALSE(result.HasValue());
+		ASSERT_TRUE(result.HasValue());
+		ASSERT_EQ(result.GetValue().OwnerId, ownerId);
+		ASSERT_EQ(result.GetValue().Velocity.X, 0.0f);
+		ASSERT_EQ(result.GetValue().Velocity.Y, 0.0f);
+		ASSERT_EQ(result.GetValue().GravityScale, 1.0f);
+		ASSERT_EQ(result.GetValue().Mass, 1.0f);
 	}
 
 	TEST(RigidBody2DComponentSchema, Deserialize_Fails_When_ComponentHeaderIsMissing)
 	{
 		// Arrange.
+		const EntityId ownerId { 1 };
 		DomDocument document;
 		DomTokenStreamWriter writer(document);
 		writer.Emit(Token::Int { 1 });
 		DomTokenStreamReader reader(document);
 
 		// Act.
-		const auto result = RigidBody2DComponentSchema::Deserialize(reader);
+		const auto result = RigidBody2DComponentSchema::Deserialize(reader, ownerId);
 
 		// Assert.
 		ASSERT_FALSE(result.HasValue());

--- a/EngineTests/Ludus/EngineTests/Serialization/Schemas/RuntimeManifestSchemaTests.cpp
+++ b/EngineTests/Ludus/EngineTests/Serialization/Schemas/RuntimeManifestSchemaTests.cpp
@@ -1,10 +1,10 @@
 #include "pch.h"
 
-#include <cstdint>
 #include <filesystem>
 #include <string>
 #include <string_view>
 
+#include <Ludus/Engine/Core/Id.h>
 #include <Ludus/Engine/Runtime/RuntimeManifest.h>
 #include <Ludus/Engine/Serialization/Core/DomDocument.h>
 #include <Ludus/Engine/Serialization/Core/DomNode.h>
@@ -16,20 +16,21 @@
 namespace Ludus::EngineTests::Serialization::Schemas
 {
 	using DomDocument = Ludus::Engine::Serialization::Core::DomDocument;
-	using DomTokenStreamWriter = Ludus::Engine::Serialization::Core::DomTokenStreamWriter;
+	using DomNode = Ludus::Engine::Serialization::Core::DomNode;
+	using DomObject = Ludus::Engine::Serialization::Core::DomObject;
 	using DomTokenStreamReader = Ludus::Engine::Serialization::Core::DomTokenStreamReader;
-	using Token = Ludus::Engine::Serialization::Core::Token;
-
+	using DomTokenStreamWriter = Ludus::Engine::Serialization::Core::DomTokenStreamWriter;
 	using RuntimeManifest = Ludus::Engine::Runtime::RuntimeManifest;
+	using RuntimeManifestSchema = Ludus::Engine::Serialization::Schemas::RuntimeManifestSchema;
 	using SceneReference = Ludus::Engine::Runtime::SceneReference;
 	using ScriptReference = Ludus::Engine::Runtime::ScriptReference;
-	using RuntimeManifestSchema = Ludus::Engine::Serialization::Schemas::RuntimeManifestSchema;
+	using SceneId = Ludus::Engine::Core::SceneId;
+	using ScriptId = Ludus::Engine::Core::ScriptId;
+	using Token = Ludus::Engine::Serialization::Core::Token;
 
 	using Ludus::Engine::Serialization::Core::AsArray;
 	using Ludus::Engine::Serialization::Core::AsObject;
 	using Ludus::Engine::Serialization::Core::AsValue;
-	using Ludus::Engine::Serialization::Core::DomNode;
-	using Ludus::Engine::Serialization::Core::DomObject;
 
 	static const DomNode* FindMember(const DomObject& object, std::string_view key)
 	{
@@ -44,32 +45,43 @@ namespace Ludus::EngineTests::Serialization::Schemas
 		return nullptr;
 	}
 
-	static SceneReference MakeSceneReference(uint64_t sceneHandle, std::string_view name, std::string_view path)
+	static SceneReference MakeSceneReference(
+		SceneId id,
+		std::string_view name,
+		std::string_view path
+	)
 	{
-		SceneReference reference;
-		reference.Handle = sceneHandle;
-		reference.Name = std::string(name);
-		reference.Path = std::filesystem::path(path);
-		return reference;
+		return {
+			.Id = id,
+			.Name = std::string(name),
+			.Path = std::filesystem::path(path)
+		};
 	}
 
-	static ScriptReference MakeScriptReference(uint64_t scriptHandle, std::string_view name)
+	static ScriptReference MakeScriptReference(
+		ScriptId id,
+		std::string_view name
+	)
 	{
-		ScriptReference reference;
-		reference.Handle = scriptHandle;
-		reference.Name = std::string(name);
-		return reference;
+		return {
+			.Id = id,
+			.Name = std::string(name)
+		};
 	}
 
 	static RuntimeManifest MakeRuntimeManifest()
 	{
-		RuntimeManifest manifest;
-		manifest.EntrySceneHandle = 222;
-		manifest.Scenes.push_back(MakeSceneReference(111, "Bootstrap", "Scenes/Bootstrap.ludus.scene"));
-		manifest.Scenes.push_back(MakeSceneReference(222, "Gameplay", "Scenes/Gameplay.ludus.scene"));
-		manifest.Scripts.push_back(MakeScriptReference(1001, "PlayerScript"));
-		manifest.Scripts.push_back(MakeScriptReference(1002, "CameraScript"));
-		return manifest;
+		return RuntimeManifest::Create(
+			SceneId { 2 },
+			{
+				MakeSceneReference({ 1 }, "Bootstrap", "Scenes/Bootstrap.ludus.scene"),
+				MakeSceneReference({ 2 }, "Gameplay", "Scenes/Gameplay.ludus.scene")
+			},
+			{
+				MakeScriptReference({ 10 }, "PlayerScript"),
+				MakeScriptReference({ 20 }, "CameraScript")
+			}
+		);
 	}
 
 	static void WriteVersion(DomTokenStreamWriter& writer, int64_t major, int64_t minor, int64_t patch)
@@ -90,161 +102,43 @@ namespace Ludus::EngineTests::Serialization::Schemas
 		// Arrange.
 		DomDocument document;
 		DomTokenStreamWriter writer(document);
-		RuntimeManifest manifest = MakeRuntimeManifest();
-		manifest.Version = { 7, 8, 9 };
+		const RuntimeManifest manifest = MakeRuntimeManifest();
 
 		// Act.
 		RuntimeManifestSchema::Serialize(writer, manifest);
 
 		// Assert.
-		const auto* root = document.GetRoot();
-		ASSERT_NE(root, nullptr);
-
-		const auto& manifestObject = AsObject(*root);
-		const auto* versionNode = FindMember(manifestObject, "Version");
-		ASSERT_NE(versionNode, nullptr);
-
-		const auto& versionObject = AsObject(*versionNode);
-		const auto* majorNode = FindMember(versionObject, "Major");
-		const auto* minorNode = FindMember(versionObject, "Minor");
-		const auto* patchNode = FindMember(versionObject, "Patch");
-
-		ASSERT_NE(majorNode, nullptr);
-		ASSERT_NE(minorNode, nullptr);
-		ASSERT_NE(patchNode, nullptr);
-		ASSERT_EQ(std::get<uint64_t>(AsValue(*majorNode)), manifest.Version.Major);
-		ASSERT_EQ(std::get<uint64_t>(AsValue(*minorNode)), manifest.Version.Minor);
-		ASSERT_EQ(std::get<uint64_t>(AsValue(*patchNode)), manifest.Version.Patch);
+		const auto& manifestObject = AsObject(*document.GetRoot());
+		const auto& versionObject = AsObject(*FindMember(manifestObject, "Version"));
+		ASSERT_EQ(std::get<uint64_t>(AsValue(*FindMember(versionObject, "Major"))), manifest.Version.Major);
+		ASSERT_EQ(std::get<uint64_t>(AsValue(*FindMember(versionObject, "Minor"))), manifest.Version.Minor);
+		ASSERT_EQ(std::get<uint64_t>(AsValue(*FindMember(versionObject, "Patch"))), manifest.Version.Patch);
 	}
 
-	TEST(RuntimeManifestSchema, Serialize_WritesEntrySceneHandle_When_RuntimeManifestHasEntryScene)
+	TEST(RuntimeManifestSchema, Serialize_WritesIds_When_RuntimeManifestHasReferences)
 	{
 		// Arrange.
 		DomDocument document;
 		DomTokenStreamWriter writer(document);
-		RuntimeManifest manifest = MakeRuntimeManifest();
+		const RuntimeManifest manifest = MakeRuntimeManifest();
 
 		// Act.
 		RuntimeManifestSchema::Serialize(writer, manifest);
 
 		// Assert.
-		const auto* root = document.GetRoot();
-		ASSERT_NE(root, nullptr);
+		const auto& manifestObject = AsObject(*document.GetRoot());
+		ASSERT_EQ(std::get<uint64_t>(AsValue(*FindMember(manifestObject, "EntrySceneId"))), manifest.EntrySceneId.Value);
 
-		const auto& manifestObject = AsObject(*root);
-		const auto* entrySceneHandleNode = FindMember(manifestObject, "EntrySceneHandle");
-		ASSERT_NE(entrySceneHandleNode, nullptr);
-		ASSERT_EQ(std::get<uint64_t>(AsValue(*entrySceneHandleNode)), manifest.EntrySceneHandle);
-	}
-
-	TEST(RuntimeManifestSchema, Serialize_WritesSceneReferences_When_RuntimeManifestHasScenes)
-	{
-		// Arrange.
-		DomDocument document;
-		DomTokenStreamWriter writer(document);
-		RuntimeManifest manifest = MakeRuntimeManifest();
-
-		// Act.
-		RuntimeManifestSchema::Serialize(writer, manifest);
-
-		// Assert.
-		const auto* root = document.GetRoot();
-		ASSERT_NE(root, nullptr);
-
-		const auto& manifestObject = AsObject(*root);
-		const auto* scenesNode = FindMember(manifestObject, "Scenes");
-		ASSERT_NE(scenesNode, nullptr);
-
-		const auto& scenesArray = AsArray(*scenesNode);
-		ASSERT_EQ(scenesArray.size(), manifest.Scenes.size());
-
+		const auto& scenesArray = AsArray(*FindMember(manifestObject, "Scenes"));
 		const auto& firstScene = AsObject(*scenesArray[0]);
-		ASSERT_EQ(std::get<uint64_t>(AsValue(*FindMember(firstScene, "Handle"))), manifest.Scenes[0].Handle);
-		ASSERT_EQ(std::get<std::string>(AsValue(*FindMember(firstScene, "Name"))), manifest.Scenes[0].Name);
-		ASSERT_EQ(std::get<std::string>(AsValue(*FindMember(firstScene, "Path"))), manifest.Scenes[0].Path.generic_string());
-	}
+		ASSERT_EQ(std::get<uint64_t>(AsValue(*FindMember(firstScene, "Id"))), manifest.Scenes[0].Id.Value);
 
-	TEST(RuntimeManifestSchema, Serialize_WritesScriptReferences_When_RuntimeManifestHasScripts)
-	{
-		// Arrange.
-		DomDocument document;
-		DomTokenStreamWriter writer(document);
-		RuntimeManifest manifest = MakeRuntimeManifest();
-
-		// Act.
-		RuntimeManifestSchema::Serialize(writer, manifest);
-
-		// Assert.
-		const auto* root = document.GetRoot();
-		ASSERT_NE(root, nullptr);
-
-		const auto& manifestObject = AsObject(*root);
-		const auto* scriptsNode = FindMember(manifestObject, "Scripts");
-		ASSERT_NE(scriptsNode, nullptr);
-
-		const auto& scriptsArray = AsArray(*scriptsNode);
-		ASSERT_EQ(scriptsArray.size(), manifest.Scripts.size());
-
+		const auto& scriptsArray = AsArray(*FindMember(manifestObject, "Scripts"));
 		const auto& firstScript = AsObject(*scriptsArray[0]);
-		ASSERT_EQ(std::get<uint64_t>(AsValue(*FindMember(firstScript, "Handle"))), manifest.Scripts[0].Handle);
-		ASSERT_EQ(std::get<std::string>(AsValue(*FindMember(firstScript, "Name"))), manifest.Scripts[0].Name);
+		ASSERT_EQ(std::get<uint64_t>(AsValue(*FindMember(firstScript, "Id"))), manifest.Scripts[0].Id.Value);
 	}
 
-	TEST(RuntimeManifestSchema, Deserialize_ReadsVersion_When_RuntimeManifestIsValid)
-	{
-		// Arrange.
-		DomDocument document;
-		DomTokenStreamWriter writer(document);
-		writer.Emit(Token::StartObject { });
-		WriteVersion(writer, 7, 8, 9);
-		writer.Emit(Token::Key { "EntrySceneHandle" });
-		writer.Emit(Token::Int { 123 });
-		writer.Emit(Token::Key { "Scenes" });
-		writer.Emit(Token::StartArray { });
-		writer.Emit(Token::EndArray { });
-		writer.Emit(Token::Key { "Scripts" });
-		writer.Emit(Token::StartArray { });
-		writer.Emit(Token::EndArray { });
-		writer.Emit(Token::EndObject { });
-		DomTokenStreamReader reader(document);
-
-		// Act.
-		const auto result = RuntimeManifestSchema::Deserialize(reader);
-
-		// Assert.
-		ASSERT_TRUE(result.HasValue());
-		ASSERT_EQ(result.GetValue().Version.Major, 7u);
-		ASSERT_EQ(result.GetValue().Version.Minor, 8u);
-		ASSERT_EQ(result.GetValue().Version.Patch, 9u);
-	}
-
-	TEST(RuntimeManifestSchema, Deserialize_ReadsEntrySceneHandleCorrectly)
-	{
-		// Arrange.
-		DomDocument document;
-		DomTokenStreamWriter writer(document);
-		writer.Emit(Token::StartObject { });
-		WriteVersion(writer, 1, 0, 0);
-		writer.Emit(Token::Key { "EntrySceneHandle" });
-		writer.Emit(Token::Int { 444 });
-		writer.Emit(Token::Key { "Scenes" });
-		writer.Emit(Token::StartArray { });
-		writer.Emit(Token::EndArray { });
-		writer.Emit(Token::Key { "Scripts" });
-		writer.Emit(Token::StartArray { });
-		writer.Emit(Token::EndArray { });
-		writer.Emit(Token::EndObject { });
-		DomTokenStreamReader reader(document);
-
-		// Act.
-		const auto result = RuntimeManifestSchema::Deserialize(reader);
-
-		// Assert.
-		ASSERT_TRUE(result.HasValue());
-		ASSERT_EQ(result.GetValue().EntrySceneHandle, 444u);
-	}
-
-	TEST(RuntimeManifestSchema, Deserialize_LoadsAllScenes_When_ArchiveIsValid)
+	TEST(RuntimeManifestSchema, Deserialize_LoadsManifest_When_RuntimeManifestIsValid)
 	{
 		// Arrange.
 		DomDocument document;
@@ -258,93 +152,23 @@ namespace Ludus::EngineTests::Serialization::Schemas
 
 		// Assert.
 		ASSERT_TRUE(result.HasValue());
-
 		const auto& loadedManifest = result.GetValue();
-		ASSERT_EQ(loadedManifest.Scenes.size(), manifest.Scenes.size());
-
-		for (size_t i = 0; i < manifest.Scenes.size(); ++i)
-		{
-			ASSERT_EQ(loadedManifest.Scenes[i].Handle, manifest.Scenes[i].Handle);
-			ASSERT_EQ(loadedManifest.Scenes[i].Name, manifest.Scenes[i].Name);
-			ASSERT_EQ(loadedManifest.Scenes[i].Path, manifest.Scenes[i].Path);
-		}
-	}
-
-	TEST(RuntimeManifestSchema, Deserialize_LoadsAllScripts_When_ArchiveIsValid)
-	{
-		// Arrange.
-		DomDocument document;
-		DomTokenStreamWriter writer(document);
-		const RuntimeManifest manifest = MakeRuntimeManifest();
-		RuntimeManifestSchema::Serialize(writer, manifest);
-		DomTokenStreamReader reader(document);
-
-		// Act.
-		const auto result = RuntimeManifestSchema::Deserialize(reader);
-
-		// Assert.
-		ASSERT_TRUE(result.HasValue());
-
-		const auto& loadedManifest = result.GetValue();
-		ASSERT_EQ(loadedManifest.Scripts.size(), manifest.Scripts.size());
-
-		for (size_t i = 0; i < manifest.Scripts.size(); ++i)
-		{
-			ASSERT_EQ(loadedManifest.Scripts[i].Handle, manifest.Scripts[i].Handle);
-			ASSERT_EQ(loadedManifest.Scripts[i].Name, manifest.Scripts[i].Name);
-		}
-	}
-
-	TEST(RuntimeManifestSchema, RoundTrip_PreservesEntrySceneScenesAndScripts_When_SerializedAndDeserialized)
-	{
-		// Arrange.
-		DomDocument document;
-		DomTokenStreamWriter writer(document);
-		const RuntimeManifest manifest = MakeRuntimeManifest();
-
-		// Act.
-		RuntimeManifestSchema::Serialize(writer, manifest);
-		DomTokenStreamReader reader(document);
-		const auto result = RuntimeManifestSchema::Deserialize(reader);
-
-		// Assert.
-		ASSERT_TRUE(result.HasValue());
-
-		const auto& loadedManifest = result.GetValue();
-		ASSERT_EQ(loadedManifest.Version.Major, manifest.Version.Major);
-		ASSERT_EQ(loadedManifest.Version.Minor, manifest.Version.Minor);
-		ASSERT_EQ(loadedManifest.Version.Patch, manifest.Version.Patch);
-		ASSERT_EQ(loadedManifest.EntrySceneHandle, manifest.EntrySceneHandle);
+		ASSERT_EQ(loadedManifest.EntrySceneId, manifest.EntrySceneId);
 		ASSERT_EQ(loadedManifest.Scenes.size(), manifest.Scenes.size());
 		ASSERT_EQ(loadedManifest.Scripts.size(), manifest.Scripts.size());
 
 		for (size_t i = 0; i < manifest.Scenes.size(); ++i)
 		{
-			ASSERT_EQ(loadedManifest.Scenes[i].Handle, manifest.Scenes[i].Handle);
+			ASSERT_EQ(loadedManifest.Scenes[i].Id, manifest.Scenes[i].Id);
 			ASSERT_EQ(loadedManifest.Scenes[i].Name, manifest.Scenes[i].Name);
 			ASSERT_EQ(loadedManifest.Scenes[i].Path, manifest.Scenes[i].Path);
 		}
 
 		for (size_t i = 0; i < manifest.Scripts.size(); ++i)
 		{
-			ASSERT_EQ(loadedManifest.Scripts[i].Handle, manifest.Scripts[i].Handle);
+			ASSERT_EQ(loadedManifest.Scripts[i].Id, manifest.Scripts[i].Id);
 			ASSERT_EQ(loadedManifest.Scripts[i].Name, manifest.Scripts[i].Name);
 		}
-	}
-
-	TEST(RuntimeManifestSchema, Deserialize_Fails_When_RootIsNotObject)
-	{
-		// Arrange.
-		DomDocument document;
-		DomTokenStreamWriter writer(document);
-		writer.Emit(Token::Int { 1 });
-		DomTokenStreamReader reader(document);
-
-		// Act.
-		const auto result = RuntimeManifestSchema::Deserialize(reader);
-
-		// Assert.
-		ASSERT_FALSE(result.HasValue());
 	}
 
 	TEST(RuntimeManifestSchema, Deserialize_Fails_When_VersionMissing)
@@ -353,8 +177,8 @@ namespace Ludus::EngineTests::Serialization::Schemas
 		DomDocument document;
 		DomTokenStreamWriter writer(document);
 		writer.Emit(Token::StartObject { });
-		writer.Emit(Token::Key { "EntrySceneHandle" });
-		writer.Emit(Token::Int { 1 });
+		writer.Emit(Token::Key { "EntrySceneId" });
+		writer.Emit(Token::Uint { 1 });
 		writer.Emit(Token::Key { "Scenes" });
 		writer.Emit(Token::StartArray { });
 		writer.Emit(Token::EndArray { });
@@ -371,105 +195,28 @@ namespace Ludus::EngineTests::Serialization::Schemas
 		ASSERT_FALSE(result.HasValue());
 	}
 
-	TEST(RuntimeManifestSchema, Deserialize_Fails_When_ScenesIsNotArray)
+	TEST(RuntimeManifestSchema, Deserialize_Fails_When_EntrySceneIdDoesNotMatchSceneReference)
 	{
 		// Arrange.
 		DomDocument document;
 		DomTokenStreamWriter writer(document);
 		writer.Emit(Token::StartObject { });
-		WriteVersion(writer, 0, 2, 0);
-		writer.Emit(Token::Key { "EntrySceneHandle" });
-		writer.Emit(Token::Int { 1 });
-		writer.Emit(Token::Key { "Scenes" });
-		writer.Emit(Token::StartObject { });
-		writer.Emit(Token::EndObject { });
-		writer.Emit(Token::Key { "Scripts" });
-		writer.Emit(Token::StartArray { });
-		writer.Emit(Token::EndArray { });
-		writer.Emit(Token::EndObject { });
-		DomTokenStreamReader reader(document);
-
-		// Act.
-		const auto result = RuntimeManifestSchema::Deserialize(reader);
-
-		// Assert.
-		ASSERT_FALSE(result.HasValue());
-	}
-
-	TEST(RuntimeManifestSchema, Deserialize_Fails_When_SceneEntryIsIncomplete)
-	{
-		// Arrange.
-		DomDocument document;
-		DomTokenStreamWriter writer(document);
-		writer.Emit(Token::StartObject { });
-		WriteVersion(writer, 0, 2, 0);
-		writer.Emit(Token::Key { "EntrySceneHandle" });
-		writer.Emit(Token::Int { 1 });
+		WriteVersion(writer, RuntimeManifest::CurrentVersion.Major, RuntimeManifest::CurrentVersion.Minor, RuntimeManifest::CurrentVersion.Patch);
+		writer.Emit(Token::Key { "EntrySceneId" });
+		writer.Emit(Token::Uint { 99 });
 		writer.Emit(Token::Key { "Scenes" });
 		writer.Emit(Token::StartArray { });
 		writer.Emit(Token::StartObject { });
-		writer.Emit(Token::Key { "Handle" });
-		writer.Emit(Token::Int { 1 });
+		writer.Emit(Token::Key { "Id" });
+		writer.Emit(Token::Uint { 1 });
 		writer.Emit(Token::Key { "Name" });
-		writer.Emit(Token::String { "Scene1" });
+		writer.Emit(Token::String { "Scene" });
+		writer.Emit(Token::Key { "Path" });
+		writer.Emit(Token::String { "Scenes/Scene.ludus.scene" });
 		writer.Emit(Token::EndObject { });
 		writer.Emit(Token::EndArray { });
 		writer.Emit(Token::Key { "Scripts" });
 		writer.Emit(Token::StartArray { });
-		writer.Emit(Token::EndArray { });
-		writer.Emit(Token::EndObject { });
-		DomTokenStreamReader reader(document);
-
-		// Act.
-		const auto result = RuntimeManifestSchema::Deserialize(reader);
-
-		// Assert.
-		ASSERT_FALSE(result.HasValue());
-	}
-
-	TEST(RuntimeManifestSchema, Deserialize_Fails_When_ScriptsIsNotArray)
-	{
-		// Arrange.
-		DomDocument document;
-		DomTokenStreamWriter writer(document);
-		writer.Emit(Token::StartObject { });
-		WriteVersion(writer, 0, 2, 0);
-		writer.Emit(Token::Key { "EntrySceneHandle" });
-		writer.Emit(Token::Int { 1 });
-		writer.Emit(Token::Key { "Scenes" });
-		writer.Emit(Token::StartArray { });
-		writer.Emit(Token::EndArray { });
-		writer.Emit(Token::Key { "Scripts" });
-		writer.Emit(Token::StartObject { });
-		writer.Emit(Token::EndObject { });
-		writer.Emit(Token::EndObject { });
-		DomTokenStreamReader reader(document);
-
-		// Act.
-		const auto result = RuntimeManifestSchema::Deserialize(reader);
-
-		// Assert.
-		ASSERT_FALSE(result.HasValue());
-	}
-
-	TEST(RuntimeManifestSchema, Deserialize_Fails_When_ScriptEntryIsIncomplete)
-	{
-		// Arrange.
-		DomDocument document;
-		DomTokenStreamWriter writer(document);
-		writer.Emit(Token::StartObject { });
-		WriteVersion(writer, 0, 2, 0);
-		writer.Emit(Token::Key { "EntrySceneHandle" });
-		writer.Emit(Token::Int { 1 });
-		writer.Emit(Token::Key { "Scenes" });
-		writer.Emit(Token::StartArray { });
-		writer.Emit(Token::EndArray { });
-		writer.Emit(Token::Key { "Scripts" });
-		writer.Emit(Token::StartArray { });
-		writer.Emit(Token::StartObject { });
-		writer.Emit(Token::Key { "Handle" });
-		writer.Emit(Token::Int { 100 });
-		writer.Emit(Token::EndObject { });
 		writer.Emit(Token::EndArray { });
 		writer.Emit(Token::EndObject { });
 		DomTokenStreamReader reader(document);

--- a/EngineTests/Ludus/EngineTests/Serialization/Schemas/SceneSchemaTests.cpp
+++ b/EngineTests/Ludus/EngineTests/Serialization/Schemas/SceneSchemaTests.cpp
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <string_view>
 
+#include <Ludus/Engine/Core/Id.h>
 #include <Ludus/Engine/Core/Scene.h>
 #include <Ludus/Engine/Serialization/Core/DomDocument.h>
 #include <Ludus/Engine/Serialization/Core/DomNode.h>
@@ -18,6 +19,9 @@ namespace Ludus::EngineTests::Serialization::Schemas
 	using DomTokenStreamReader = Ludus::Engine::Serialization::Core::DomTokenStreamReader;
 	using Scene = Ludus::Engine::Core::Scene;
 	using SceneSchema = Ludus::Engine::Serialization::Schemas::SceneSchema;
+	using EntityId = Ludus::Engine::Core::EntityId;
+	using SceneId = Ludus::Engine::Core::SceneId;
+	using ScriptId = Ludus::Engine::Core::ScriptId;
 	using Token = Ludus::Engine::Serialization::Core::Token;
 
 	using Ludus::Engine::Serialization::Core::AsObject;
@@ -26,10 +30,10 @@ namespace Ludus::EngineTests::Serialization::Schemas
 	using Ludus::Engine::Serialization::Core::DomNode;
 	using Ludus::Engine::Serialization::Core::DomObject;
 
-	static const Ludus::Engine::Core::SceneHandle GetId()
+	static SceneId GetId()
 	{
 		Ludus::Engine::Core::Random random;
-		return random.NextId();
+		return { random.NextId() };
 	}
 
 	static const DomNode* FindMember(const DomObject& object, std::string_view key)
@@ -49,20 +53,11 @@ namespace Ludus::EngineTests::Serialization::Schemas
 	{
 		const auto& entityObject = AsObject(entity);
 
-		const auto* handleNode = FindMember(entityObject, "Handle");
-		ASSERT_NE(handleNode, nullptr);
-
-		const auto entityHandle = std::get<uint64_t>(AsValue(*handleNode));
-
 		const auto* componentNode = FindMember(entityObject, component);
 		ASSERT_NE(componentNode, nullptr);
 
 		const auto& componentObject = AsObject(*componentNode);
-		const auto* ownerNode = FindMember(componentObject, "OwnerHandle");
-		ASSERT_NE(ownerNode, nullptr);
-
-		const auto componentHandle = std::get<uint64_t>(AsValue(*ownerNode));
-		ASSERT_EQ(entityHandle, componentHandle);
+		ASSERT_EQ(componentObject.empty(), false);
 	}
 
 	TEST(SceneSchema, Serialize_WritesSceneWithEntitiesArray_When_SceneHasEntities)
@@ -144,7 +139,7 @@ namespace Ludus::EngineTests::Serialization::Schemas
 		}
 	}
 
-	TEST(SceneSchema, Deserialize_CreatesEntitiesWithSameHandles_When_ArchiveIsValid)
+	TEST(SceneSchema, Deserialize_CreatesEntitiesWithSameIds_When_ArchiveIsValid)
 	{
 		// Arrange.
 		DomDocument document;
@@ -184,29 +179,29 @@ namespace Ludus::EngineTests::Serialization::Schemas
 		DomTokenStreamWriter writer(document);
 		Scene scene(GetId());
 
-		const auto handle1 = scene.EntityComponentSystem.AddEntity();
-		scene.EntityComponentSystem.AttachCamera(handle1);
+		const auto entityId1 = scene.EntityComponentSystem.AddEntity();
+		scene.EntityComponentSystem.AttachCamera(entityId1);
 
-		const auto handle2 = scene.EntityComponentSystem.AddEntity();
-		scene.EntityComponentSystem.AttachCollider(handle2);
+		const auto entityId2 = scene.EntityComponentSystem.AddEntity();
+		scene.EntityComponentSystem.AttachCollider(entityId2);
 
-		const auto handle3 = scene.EntityComponentSystem.AddEntity();
-		scene.EntityComponentSystem.AttachDisplayName(handle3);
+		const auto entityId3 = scene.EntityComponentSystem.AddEntity();
+		scene.EntityComponentSystem.AttachDisplayName(entityId3);
 
-		const auto handle4 = scene.EntityComponentSystem.AddEntity();
-		scene.EntityComponentSystem.AttachRigidBody(handle4);
+		const auto entityId4 = scene.EntityComponentSystem.AddEntity();
+		scene.EntityComponentSystem.AttachRigidBody(entityId4);
 
-		const auto handle5 = scene.EntityComponentSystem.AddEntity();
-		scene.EntityComponentSystem.AttachSprite(handle5);
+		const auto entityId5 = scene.EntityComponentSystem.AddEntity();
+		scene.EntityComponentSystem.AttachSprite(entityId5);
 
-		const auto handle6 = scene.EntityComponentSystem.AddEntity();
-		scene.EntityComponentSystem.AttachText(handle6);
+		const auto entityId6 = scene.EntityComponentSystem.AddEntity();
+		scene.EntityComponentSystem.AttachText(entityId6);
 
-		const auto handle7 = scene.EntityComponentSystem.AddEntity();
-		scene.EntityComponentSystem.AttachScript(handle7);
+		const auto entityId7 = scene.EntityComponentSystem.AddEntity();
+		scene.EntityComponentSystem.AttachScript(entityId7, ScriptId { 1 });
 
-		const auto handle8 = scene.EntityComponentSystem.AddEntity();
-		scene.EntityComponentSystem.AttachTransform(handle8);
+		const auto entityId8 = scene.EntityComponentSystem.AddEntity();
+		scene.EntityComponentSystem.AttachTransform(entityId8);
 
 		SceneSchema::Serialize(writer, scene);
 		DomTokenStreamReader reader(document);
@@ -218,14 +213,16 @@ namespace Ludus::EngineTests::Serialization::Schemas
 		ASSERT_TRUE(result.HasValue());
 
 		const auto& loadedEcs = result.GetValue().EntityComponentSystem;
-		ASSERT_TRUE(loadedEcs.Cameras.ContainsOwner(handle1));
-		ASSERT_TRUE(loadedEcs.Colliders.ContainsOwner(handle2));
-		ASSERT_TRUE(loadedEcs.DisplayNames.ContainsOwner(handle3));
-		ASSERT_TRUE(loadedEcs.RigidBodies.ContainsOwner(handle4));
-		ASSERT_TRUE(loadedEcs.Sprites.ContainsOwner(handle5));
-		ASSERT_TRUE(loadedEcs.Texts.ContainsOwner(handle6));
-		ASSERT_TRUE(loadedEcs.Scripts.ContainsOwner(handle7));
-		ASSERT_TRUE(loadedEcs.Transforms.ContainsOwner(handle8));
+		const auto loadedEntities = loadedEcs.View();
+		ASSERT_EQ(loadedEntities.size(), 8u);
+		ASSERT_TRUE(loadedEcs.Cameras.ContainsOwner(loadedEntities[0].Id));
+		ASSERT_TRUE(loadedEcs.Colliders.ContainsOwner(loadedEntities[1].Id));
+		ASSERT_TRUE(loadedEcs.DisplayNames.ContainsOwner(loadedEntities[2].Id));
+		ASSERT_TRUE(loadedEcs.RigidBodies.ContainsOwner(loadedEntities[3].Id));
+		ASSERT_TRUE(loadedEcs.Sprites.ContainsOwner(loadedEntities[4].Id));
+		ASSERT_TRUE(loadedEcs.Texts.ContainsOwner(loadedEntities[5].Id));
+		ASSERT_TRUE(loadedEcs.Scripts.ContainsOwner(loadedEntities[6].Id));
+		ASSERT_TRUE(loadedEcs.Transforms.ContainsOwner(loadedEntities[7].Id));
 	}
 
 	TEST(SceneSchema, RoundTrip_PreservesEntitiesAndComponents_When_SavedAndLoaded)
@@ -275,8 +272,6 @@ namespace Ludus::EngineTests::Serialization::Schemas
 		DomDocument document;
 		DomTokenStreamWriter writer(document);
 		writer.Emit(Token::StartObject { });
-		writer.Emit(Token::Key { "Handle" });
-		writer.Emit(Token::Int { 1 });
 		writer.Emit(Token::Key { "Entities" });
 		writer.Emit(Token::StartObject { });
 		writer.Emit(Token::EndObject { });
@@ -290,13 +285,13 @@ namespace Ludus::EngineTests::Serialization::Schemas
 		ASSERT_FALSE(result.HasValue());
 	}
 
-	TEST(SceneSchema, Deserialize_SkipsEntity_When_EntityHandleIsMissing)
+	TEST(SceneSchema, Deserialize_SkipsEntity_When_EntityIdIsMissing)
 	{
 		// Arrange.
 		DomDocument document;
 		DomTokenStreamWriter writer(document);
 		writer.Emit(Token::StartObject { });
-		writer.Emit(Token::Key { "Handle" });
+		writer.Emit(Token::Key { "Id" });
 		writer.Emit(Token::Int { 1 });
 		writer.Emit(Token::Key { "Entities" });
 		writer.Emit(Token::StartArray { });
@@ -314,18 +309,18 @@ namespace Ludus::EngineTests::Serialization::Schemas
 		ASSERT_EQ(result.GetValue().EntityComponentSystem.GetEntityCount(), 0u);
 	}
 
-	TEST(SceneSchema, Deserialize_SkipsEntity_When_ComponentIsInvalid)
+	TEST(SceneSchema, Deserialize_DefaultsComponent_When_ComponentPayloadIsEmptyObject)
 	{
 		// Arrange.
 		DomDocument document;
 		DomTokenStreamWriter writer(document);
 		writer.Emit(Token::StartObject { });
-		writer.Emit(Token::Key { "Handle" });
+		writer.Emit(Token::Key { "Id" });
 		writer.Emit(Token::Int { 1 });
 		writer.Emit(Token::Key { "Entities" });
 		writer.Emit(Token::StartArray { });
 		writer.Emit(Token::StartObject { });
-		writer.Emit(Token::Key { "Handle" });
+		writer.Emit(Token::Key { "Id" });
 		writer.Emit(Token::Int { 1 });
 		writer.Emit(Token::Key { "Transform2D" });
 		writer.Emit(Token::StartObject { });
@@ -340,6 +335,7 @@ namespace Ludus::EngineTests::Serialization::Schemas
 
 		// Assert.
 		ASSERT_TRUE(result.HasValue());
-		ASSERT_EQ(result.GetValue().EntityComponentSystem.GetEntityCount(), 0u);
+		ASSERT_EQ(result.GetValue().EntityComponentSystem.GetEntityCount(), 1u);
+		EXPECT_TRUE(result.GetValue().EntityComponentSystem.Transforms.ContainsOwner(EntityId { 1 }));
 	}
 }

--- a/EngineTests/Ludus/EngineTests/Serialization/Schemas/ScriptComponentSchemaTests.cpp
+++ b/EngineTests/Ludus/EngineTests/Serialization/Schemas/ScriptComponentSchemaTests.cpp
@@ -1,9 +1,8 @@
 #include "pch.h"
 
 #include <cstdint>
-#include <string>
-
 #include <Ludus/Engine/Components/ScriptComponent.h>
+#include <Ludus/Engine/Core/Id.h>
 #include <Ludus/Engine/Serialization/Core/DomDocument.h>
 #include <Ludus/Engine/Serialization/Core/DomNode.h>
 #include <Ludus/Engine/Serialization/Core/DomTokenStreamReader.h>
@@ -18,6 +17,8 @@ namespace Ludus::EngineTests::Serialization::Schemas
 	using DomTokenStreamReader = Ludus::Engine::Serialization::Core::DomTokenStreamReader;
 	using ScriptComponentSchema = Ludus::Engine::Serialization::Schemas::ScriptComponentSchema;
 	using Token = Ludus::Engine::Serialization::Core::Token;
+	using EntityId = Ludus::Engine::Core::EntityId;
+	using ScriptId = Ludus::Engine::Core::ScriptId;
 
 	using Ludus::Engine::Serialization::Core::AsObject;
 	using Ludus::Engine::Serialization::Core::AsValue;
@@ -40,7 +41,7 @@ namespace Ludus::EngineTests::Serialization::Schemas
 	TEST(ScriptComponentSchema, Serialize_WritesExpectedComponentValues)
 	{
 		// Arrange.
-		Ludus::Engine::Components::ScriptComponent script(1, "PlayerScript", 999);
+		Ludus::Engine::Components::ScriptComponent script(EntityId { 1 }, ScriptId { 999 });
 		DomDocument document;
 		DomTokenStreamWriter writer(document);
 
@@ -52,73 +53,33 @@ namespace Ludus::EngineTests::Serialization::Schemas
 		ASSERT_NE(root, nullptr);
 
 		const auto& scriptObject = AsObject(*root);
-		const auto* ownerNode = FindMember(scriptObject, "OwnerHandle");
-		const auto* handleNode = FindMember(scriptObject, "Handle");
+		const auto* idNode = FindMember(scriptObject, "Id");
 		const auto* nameNode = FindMember(scriptObject, "Name");
 
-		ASSERT_NE(ownerNode, nullptr);
-		ASSERT_NE(handleNode, nullptr);
-		ASSERT_NE(nameNode, nullptr);
-
-		const auto ownerHandle = std::get<uint64_t>(AsValue(*ownerNode));
-		const auto handle = std::get<uint64_t>(AsValue(*handleNode));
-		const auto name = std::get<std::string>(AsValue(*nameNode));
-
-		ASSERT_EQ(ownerHandle, 1u);
-		ASSERT_EQ(handle, 999u);
-		ASSERT_EQ(name, "PlayerScript");
+		ASSERT_NE(idNode, nullptr);
+		ASSERT_EQ(nameNode, nullptr);
 	}
 
-	TEST(ScriptComponentSchema, Deserialize_ReadsFields_When_ComponentHasValues)
+	TEST(ScriptComponentSchema, Deserialize_ReadsId_When_ComponentIsValid)
 	{
 		// Arrange.
 		DomDocument document;
 		DomTokenStreamWriter writer(document);
 		writer.Emit(Token::StartObject { });
-		writer.Emit(Token::Key { "OwnerHandle" });
-		writer.Emit(Token::Int { 1 });
-		writer.Emit(Token::Key { "Handle" });
-		writer.Emit(Token::Int { 999 });
-		writer.Emit(Token::Key { "Name" });
-		writer.Emit(Token::String { "PlayerScript" });
+		writer.Emit(Token::Key { "Id" });
+		writer.Emit(Token::Uint { 7 });
 		writer.Emit(Token::EndObject { });
 		DomTokenStreamReader reader(document);
 
 		// Act.
-		const auto result = ScriptComponentSchema::Deserialize(reader);
+		const auto result = ScriptComponentSchema::Deserialize(reader, EntityId { 1 });
 
 		// Assert.
 		ASSERT_TRUE(result.HasValue());
 
 		const auto& scriptResult = result.GetValue();
-		ASSERT_EQ(scriptResult.OwnerHandle, 1u);
-		ASSERT_EQ(scriptResult.Handle, 999u);
-		ASSERT_EQ(scriptResult.Name, "PlayerScript");
-	}
-
-	TEST(ScriptComponentSchema, Deserialize_DefaultsOptionalFields_When_Missing)
-	{
-		// Arrange.
-		DomDocument document;
-		DomTokenStreamWriter writer(document);
-		writer.Emit(Token::StartObject { });
-		writer.Emit(Token::Key { "OwnerHandle" });
-		writer.Emit(Token::Int { 1 });
-		writer.Emit(Token::Key { "Handle" });
-		writer.Emit(Token::Int { 999 });
-		writer.Emit(Token::EndObject { });
-		DomTokenStreamReader reader(document);
-
-		// Act.
-		const auto result = ScriptComponentSchema::Deserialize(reader);
-
-		// Assert.
-		ASSERT_TRUE(result.HasValue());
-
-		const auto& scriptResult = result.GetValue();
-		ASSERT_EQ(scriptResult.OwnerHandle, 1u);
-		ASSERT_EQ(scriptResult.Handle, 999u);
-		ASSERT_EQ(scriptResult.Name, "");
+		ASSERT_EQ(scriptResult.OwnerId.Value, 1u);
+		ASSERT_EQ(scriptResult.Id, ScriptId { 7 });
 	}
 
 	TEST(ScriptComponentSchema, Deserialize_Fails_When_RequiredFieldsAreMissing)
@@ -131,7 +92,7 @@ namespace Ludus::EngineTests::Serialization::Schemas
 		DomTokenStreamReader reader(document);
 
 		// Act.
-		const auto result = ScriptComponentSchema::Deserialize(reader);
+		const auto result = ScriptComponentSchema::Deserialize(reader, EntityId { 1 });
 
 		// Assert.
 		ASSERT_FALSE(result.HasValue());
@@ -146,7 +107,7 @@ namespace Ludus::EngineTests::Serialization::Schemas
 		DomTokenStreamReader reader(document);
 
 		// Act.
-		const auto result = ScriptComponentSchema::Deserialize(reader);
+		const auto result = ScriptComponentSchema::Deserialize(reader, EntityId { 1 });
 
 		// Assert.
 		ASSERT_FALSE(result.HasValue());

--- a/EngineTests/Ludus/EngineTests/Serialization/Schemas/Sprite2DComponentSchemaTests.cpp
+++ b/EngineTests/Ludus/EngineTests/Serialization/Schemas/Sprite2DComponentSchemaTests.cpp
@@ -4,6 +4,7 @@
 #include <string>
 
 #include <Ludus/Engine/Components/Sprite2DComponent.h>
+#include <Ludus/Engine/Core/Id.h>
 #include <Ludus/Engine/Graphics/Shape.h>
 #include <Ludus/Engine/Serialization/Core/DomDocument.h>
 #include <Ludus/Engine/Serialization/Core/DomNode.h>
@@ -20,6 +21,7 @@ namespace Ludus::EngineTests::Serialization::Schemas
 	using Sprite2DComponentSchema = Ludus::Engine::Serialization::Schemas::Sprite2DComponentSchema;
 	using Token = Ludus::Engine::Serialization::Core::Token;
 	using Shape = Ludus::Engine::Graphics::Shape;
+	using EntityId = Ludus::Engine::Core::EntityId;
 
 	using Ludus::Engine::Serialization::Core::AsObject;
 	using Ludus::Engine::Serialization::Core::AsValue;
@@ -42,7 +44,7 @@ namespace Ludus::EngineTests::Serialization::Schemas
 	TEST(Sprite2DComponentSchema, Serialize_WritesExpectedComponentValues)
 	{
 		// Arrange.
-		Ludus::Engine::Components::Sprite2DComponent sprite(1);
+		Ludus::Engine::Components::Sprite2DComponent sprite(EntityId { 1 });
 		sprite.Shape = Shape::Circle;
 		sprite.Color = { 0.2f, 0.4f, 0.6f, 0.8f };
 		sprite.Fill = false;
@@ -59,17 +61,14 @@ namespace Ludus::EngineTests::Serialization::Schemas
 
 		const auto& spriteObject = AsObject(*root);
 
-		const auto* ownerNode = FindMember(spriteObject, "OwnerHandle");
 		const auto* shapeNode = FindMember(spriteObject, "Shape");
 		const auto* colorNode = FindMember(spriteObject, "Color");
 		const auto* fillNode = FindMember(spriteObject, "Fill");
 
-		ASSERT_NE(ownerNode, nullptr);
 		ASSERT_NE(shapeNode, nullptr);
 		ASSERT_NE(colorNode, nullptr);
 		ASSERT_NE(fillNode, nullptr);
 
-		const auto ownerHandle = std::get<uint64_t>(AsValue(*ownerNode));
 		const auto shapeValue = std::get<std::string>(AsValue(*shapeNode));
 		const auto fillValue = std::get<bool>(AsValue(*fillNode));
 
@@ -79,7 +78,6 @@ namespace Ludus::EngineTests::Serialization::Schemas
 		const auto colorB = std::get<double>(AsValue(*FindMember(colorObject, "B")));
 		const auto colorA = std::get<double>(AsValue(*FindMember(colorObject, "A")));
 
-		ASSERT_EQ(ownerHandle, 1u);
 		ASSERT_EQ(shapeValue, "Circle");
 		ASSERT_EQ(fillValue, false);
 		ASSERT_EQ(colorR, 0.2f);
@@ -91,11 +89,10 @@ namespace Ludus::EngineTests::Serialization::Schemas
 	TEST(Sprite2DComponentSchema, Deserialize_ReadsFields_When_ComponentHasValues)
 	{
 		// Arrange.
+		const EntityId ownerId { 1 };
 		DomDocument document;
 		DomTokenStreamWriter writer(document);
 		writer.Emit(Token::StartObject { });
-		writer.Emit(Token::Key { "OwnerHandle" });
-		writer.Emit(Token::Int { 1 });
 		writer.Emit(Token::Key { "Shape" });
 		writer.Emit(Token::String { "Circle" });
 		writer.Emit(Token::Key { "Color" });
@@ -115,13 +112,13 @@ namespace Ludus::EngineTests::Serialization::Schemas
 		DomTokenStreamReader reader(document);
 
 		// Act.
-		const auto result = Sprite2DComponentSchema::Deserialize(reader);
+		const auto result = Sprite2DComponentSchema::Deserialize(reader, ownerId);
 
 		// Assert.
 		ASSERT_TRUE(result.HasValue());
 
 		const auto& spriteResult = result.GetValue();
-		ASSERT_EQ(spriteResult.OwnerHandle, 1u);
+		ASSERT_EQ(spriteResult.OwnerId, ownerId);
 		ASSERT_EQ(spriteResult.Shape, Shape::Circle);
 		ASSERT_EQ(spriteResult.Color.R, 0.2f);
 		ASSERT_EQ(spriteResult.Color.G, 0.4f);
@@ -133,22 +130,21 @@ namespace Ludus::EngineTests::Serialization::Schemas
 	TEST(Sprite2DComponentSchema, Deserialize_DefaultsOptionalFields_When_Missing)
 	{
 		// Arrange.
+		const EntityId ownerId { 1 };
 		DomDocument document;
 		DomTokenStreamWriter writer(document);
 		writer.Emit(Token::StartObject { });
-		writer.Emit(Token::Key { "OwnerHandle" });
-		writer.Emit(Token::Int { 1 });
 		writer.Emit(Token::EndObject { });
 		DomTokenStreamReader reader(document);
 
 		// Act.
-		const auto result = Sprite2DComponentSchema::Deserialize(reader);
+		const auto result = Sprite2DComponentSchema::Deserialize(reader, ownerId);
 
 		// Assert.
 		ASSERT_TRUE(result.HasValue());
 
 		const auto& spriteResult = result.GetValue();
-		ASSERT_EQ(spriteResult.OwnerHandle, 1u);
+		ASSERT_EQ(spriteResult.OwnerId, ownerId);
 		ASSERT_EQ(spriteResult.Color.R, 1.0f);
 		ASSERT_EQ(spriteResult.Color.G, 1.0f);
 		ASSERT_EQ(spriteResult.Color.B, 1.0f);
@@ -156,9 +152,10 @@ namespace Ludus::EngineTests::Serialization::Schemas
 		ASSERT_EQ(spriteResult.Fill, true);
 	}
 
-	TEST(Sprite2DComponentSchema, Deserialize_Fails_When_RequiredFieldsAreMissing)
+	TEST(Sprite2DComponentSchema, Deserialize_DefaultsFields_When_AllPayloadFieldsAreMissing)
 	{
 		// Arrange.
+		const EntityId ownerId { 1 };
 		DomDocument document;
 		DomTokenStreamWriter writer(document);
 		writer.Emit(Token::StartObject { });
@@ -166,22 +163,29 @@ namespace Ludus::EngineTests::Serialization::Schemas
 		DomTokenStreamReader reader(document);
 
 		// Act.
-		const auto result = Sprite2DComponentSchema::Deserialize(reader);
+		const auto result = Sprite2DComponentSchema::Deserialize(reader, ownerId);
 
 		// Assert.
-		ASSERT_FALSE(result.HasValue());
+		ASSERT_TRUE(result.HasValue());
+		ASSERT_EQ(result.GetValue().OwnerId, ownerId);
+		ASSERT_EQ(result.GetValue().Color.R, 1.0f);
+		ASSERT_EQ(result.GetValue().Color.G, 1.0f);
+		ASSERT_EQ(result.GetValue().Color.B, 1.0f);
+		ASSERT_EQ(result.GetValue().Color.A, 1.0f);
+		ASSERT_EQ(result.GetValue().Fill, true);
 	}
 
 	TEST(Sprite2DComponentSchema, Deserialize_Fails_When_ComponentHeaderIsMissing)
 	{
 		// Arrange.
+		const EntityId ownerId { 1 };
 		DomDocument document;
 		DomTokenStreamWriter writer(document);
 		writer.Emit(Token::Int { 1 });
 		DomTokenStreamReader reader(document);
 
 		// Act.
-		const auto result = Sprite2DComponentSchema::Deserialize(reader);
+		const auto result = Sprite2DComponentSchema::Deserialize(reader, ownerId);
 
 		// Assert.
 		ASSERT_FALSE(result.HasValue());

--- a/EngineTests/Ludus/EngineTests/Serialization/Schemas/Text2DComponentSchemaTests.cpp
+++ b/EngineTests/Ludus/EngineTests/Serialization/Schemas/Text2DComponentSchemaTests.cpp
@@ -4,6 +4,7 @@
 #include <string>
 
 #include <Ludus/Engine/Components/Text2DComponent.h>
+#include <Ludus/Engine/Core/Id.h>
 #include <Ludus/Engine/Graphics/HorizontalTextAlignment.h>
 #include <Ludus/Engine/Serialization/Core/DomDocument.h>
 #include <Ludus/Engine/Serialization/Core/DomNode.h>
@@ -20,6 +21,7 @@ namespace Ludus::EngineTests::Serialization::Schemas
 	using Text2DComponentSchema = Ludus::Engine::Serialization::Schemas::Text2DComponentSchema;
 	using Token = Ludus::Engine::Serialization::Core::Token;
 	using HorizontalTextAlignment = Ludus::Engine::Graphics::HorizontalTextAlignment;
+	using EntityId = Ludus::Engine::Core::EntityId;
 
 	using Ludus::Engine::Serialization::Core::AsObject;
 	using Ludus::Engine::Serialization::Core::AsValue;
@@ -42,7 +44,7 @@ namespace Ludus::EngineTests::Serialization::Schemas
 	TEST(Text2DComponentSchema, Serialize_WritesExpectedComponentValues)
 	{
 		// Arrange.
-		Ludus::Engine::Components::Text2DComponent text(1);
+		Ludus::Engine::Components::Text2DComponent text(EntityId { 1 });
 		text.Text = "Hello";
 		text.Color = { 0.1f, 0.2f, 0.3f, 0.4f };
 		text.HorizontalTextAlignment = HorizontalTextAlignment::Center;
@@ -59,17 +61,14 @@ namespace Ludus::EngineTests::Serialization::Schemas
 
 		const auto& textObject = AsObject(*root);
 
-		const auto* ownerNode = FindMember(textObject, "OwnerHandle");
 		const auto* textNode = FindMember(textObject, "Text");
 		const auto* colorNode = FindMember(textObject, "Color");
 		const auto* alignNode = FindMember(textObject, "HorizontalTextAlignment");
 
-		ASSERT_NE(ownerNode, nullptr);
 		ASSERT_NE(textNode, nullptr);
 		ASSERT_NE(colorNode, nullptr);
 		ASSERT_NE(alignNode, nullptr);
 
-		const auto ownerHandle = std::get<uint64_t>(AsValue(*ownerNode));
 		const auto textValue = std::get<std::string>(AsValue(*textNode));
 		const auto alignment = std::get<std::string>(AsValue(*alignNode));
 
@@ -79,7 +78,6 @@ namespace Ludus::EngineTests::Serialization::Schemas
 		const auto colorB = std::get<double>(AsValue(*FindMember(colorObject, "B")));
 		const auto colorA = std::get<double>(AsValue(*FindMember(colorObject, "A")));
 
-		ASSERT_EQ(ownerHandle, 1u);
 		ASSERT_EQ(textValue, "Hello");
 		ASSERT_EQ(alignment, "Center");
 		ASSERT_EQ(colorR, 0.1f);
@@ -91,11 +89,10 @@ namespace Ludus::EngineTests::Serialization::Schemas
 	TEST(Text2DComponentSchema, Deserialize_ReadsFields_When_ComponentHasValues)
 	{
 		// Arrange.
+		const EntityId ownerId { 1 };
 		DomDocument document;
 		DomTokenStreamWriter writer(document);
 		writer.Emit(Token::StartObject { });
-		writer.Emit(Token::Key { "OwnerHandle" });
-		writer.Emit(Token::Int { 1 });
 		writer.Emit(Token::Key { "Text" });
 		writer.Emit(Token::String { "Hello" });
 		writer.Emit(Token::Key { "Color" });
@@ -115,13 +112,13 @@ namespace Ludus::EngineTests::Serialization::Schemas
 		DomTokenStreamReader reader(document);
 
 		// Act.
-		const auto result = Text2DComponentSchema::Deserialize(reader);
+		const auto result = Text2DComponentSchema::Deserialize(reader, ownerId);
 
 		// Assert.
 		ASSERT_TRUE(result.HasValue());
 
 		const auto& textResult = result.GetValue();
-		ASSERT_EQ(textResult.OwnerHandle, 1u);
+		ASSERT_EQ(textResult.OwnerId, ownerId);
 		ASSERT_EQ(textResult.Text, "Hello");
 		ASSERT_EQ(textResult.Color.R, 0.1f);
 		ASSERT_EQ(textResult.Color.G, 0.2f);
@@ -133,22 +130,21 @@ namespace Ludus::EngineTests::Serialization::Schemas
 	TEST(Text2DComponentSchema, Deserialize_DefaultsOptionalFields_When_Missing)
 	{
 		// Arrange.
+		const EntityId ownerId { 1 };
 		DomDocument document;
 		DomTokenStreamWriter writer(document);
 		writer.Emit(Token::StartObject { });
-		writer.Emit(Token::Key { "OwnerHandle" });
-		writer.Emit(Token::Int { 1 });
 		writer.Emit(Token::EndObject { });
 		DomTokenStreamReader reader(document);
 
 		// Act.
-		const auto result = Text2DComponentSchema::Deserialize(reader);
+		const auto result = Text2DComponentSchema::Deserialize(reader, ownerId);
 
 		// Assert.
 		ASSERT_TRUE(result.HasValue());
 
 		const auto& textResult = result.GetValue();
-		ASSERT_EQ(textResult.OwnerHandle, 1u);
+		ASSERT_EQ(textResult.OwnerId, ownerId);
 		ASSERT_EQ(textResult.Text, "");
 		ASSERT_EQ(textResult.Color.R, 1.0f);
 		ASSERT_EQ(textResult.Color.G, 1.0f);
@@ -156,9 +152,10 @@ namespace Ludus::EngineTests::Serialization::Schemas
 		ASSERT_EQ(textResult.Color.A, 1.0f);
 	}
 
-	TEST(Text2DComponentSchema, Deserialize_Fails_When_RequiredFieldsAreMissing)
+	TEST(Text2DComponentSchema, Deserialize_DefaultsFields_When_AllPayloadFieldsAreMissing)
 	{
 		// Arrange.
+		const EntityId ownerId { 1 };
 		DomDocument document;
 		DomTokenStreamWriter writer(document);
 		writer.Emit(Token::StartObject { });
@@ -166,22 +163,29 @@ namespace Ludus::EngineTests::Serialization::Schemas
 		DomTokenStreamReader reader(document);
 
 		// Act.
-		const auto result = Text2DComponentSchema::Deserialize(reader);
+		const auto result = Text2DComponentSchema::Deserialize(reader, ownerId);
 
 		// Assert.
-		ASSERT_FALSE(result.HasValue());
+		ASSERT_TRUE(result.HasValue());
+		ASSERT_EQ(result.GetValue().OwnerId, ownerId);
+		ASSERT_EQ(result.GetValue().Text, "");
+		ASSERT_EQ(result.GetValue().Color.R, 1.0f);
+		ASSERT_EQ(result.GetValue().Color.G, 1.0f);
+		ASSERT_EQ(result.GetValue().Color.B, 1.0f);
+		ASSERT_EQ(result.GetValue().Color.A, 1.0f);
 	}
 
 	TEST(Text2DComponentSchema, Deserialize_Fails_When_ComponentHeaderIsMissing)
 	{
 		// Arrange.
+		const EntityId ownerId { 1 };
 		DomDocument document;
 		DomTokenStreamWriter writer(document);
 		writer.Emit(Token::Int { 1 });
 		DomTokenStreamReader reader(document);
 
 		// Act.
-		const auto result = Text2DComponentSchema::Deserialize(reader);
+		const auto result = Text2DComponentSchema::Deserialize(reader, ownerId);
 
 		// Assert.
 		ASSERT_FALSE(result.HasValue());

--- a/EngineTests/Ludus/EngineTests/Serialization/Schemas/Transform2DComponentSchemaTests.cpp
+++ b/EngineTests/Ludus/EngineTests/Serialization/Schemas/Transform2DComponentSchemaTests.cpp
@@ -3,6 +3,7 @@
 #include <cstdint>
 
 #include <Ludus/Engine/Components/Transform2DComponent.h>
+#include <Ludus/Engine/Core/Id.h>
 #include <Ludus/Engine/Serialization/Core/DomDocument.h>
 #include <Ludus/Engine/Serialization/Core/DomNode.h>
 #include <Ludus/Engine/Serialization/Core/DomTokenStreamReader.h>
@@ -17,6 +18,7 @@ namespace Ludus::EngineTests::Serialization::Schemas
 	using DomTokenStreamReader = Ludus::Engine::Serialization::Core::DomTokenStreamReader;
 	using Transform2DComponentSchema = Ludus::Engine::Serialization::Schemas::Transform2DComponentSchema;
 	using Token = Ludus::Engine::Serialization::Core::Token;
+	using EntityId = Ludus::Engine::Core::EntityId;
 
 	using Ludus::Engine::Serialization::Core::AsObject;
 	using Ludus::Engine::Serialization::Core::AsValue;
@@ -39,7 +41,7 @@ namespace Ludus::EngineTests::Serialization::Schemas
 	TEST(Transform2DComponentSchema, Serialize_WritesExpectedComponentValues)
 	{
 		// Arrange.
-		Ludus::Engine::Components::Transform2DComponent transform(1, { 5, 10 }, { 2, 4 }, 45);
+		Ludus::Engine::Components::Transform2DComponent transform(EntityId { 1 }, { 5, 10 }, { 2, 4 }, 45);
 		DomDocument document;
 		DomTokenStreamWriter writer(document);
 
@@ -52,17 +54,13 @@ namespace Ludus::EngineTests::Serialization::Schemas
 
 		const auto& transformObject = AsObject(*root);
 
-		const auto* ownerNode = FindMember(transformObject, "OwnerHandle");
 		const auto* positionNode = FindMember(transformObject, "Position");
 		const auto* scaleNode = FindMember(transformObject, "Scale");
 		const auto* rotationNode = FindMember(transformObject, "Rotation");
 
-		ASSERT_NE(ownerNode, nullptr);
 		ASSERT_NE(positionNode, nullptr);
 		ASSERT_NE(scaleNode, nullptr);
 		ASSERT_NE(rotationNode, nullptr);
-
-		const auto ownerHandle = std::get<uint64_t>(AsValue(*ownerNode));
 
 		const auto& positionObject = AsObject(*positionNode);
 		const auto positionX = std::get<double>(AsValue(*FindMember(positionObject, "X")));
@@ -74,7 +72,6 @@ namespace Ludus::EngineTests::Serialization::Schemas
 
 		const auto rotation = std::get<double>(AsValue(*rotationNode));
 
-		ASSERT_EQ(ownerHandle, 1u);
 		ASSERT_EQ(positionX, 5.0f);
 		ASSERT_EQ(positionY, 10.0f);
 		ASSERT_EQ(scaleX, 2.0f);
@@ -85,11 +82,10 @@ namespace Ludus::EngineTests::Serialization::Schemas
 	TEST(Transform2DComponentSchema, Deserialize_ReadsFields_When_ComponentHasValues)
 	{
 		// Arrange.
+		const EntityId ownerId { 1 };
 		DomDocument document;
 		DomTokenStreamWriter writer(document);
 		writer.Emit(Token::StartObject { });
-		writer.Emit(Token::Key { "OwnerHandle" });
-		writer.Emit(Token::Int { 1 });
 		writer.Emit(Token::Key { "Position" });
 		writer.Emit(Token::StartObject { });
 		writer.Emit(Token::Key { "X" });
@@ -110,13 +106,13 @@ namespace Ludus::EngineTests::Serialization::Schemas
 		DomTokenStreamReader reader(document);
 
 		// Act.
-		const auto result = Transform2DComponentSchema::Deserialize(reader);
+		const auto result = Transform2DComponentSchema::Deserialize(reader, ownerId);
 
 		// Assert.
 		ASSERT_TRUE(result.HasValue());
 
 		const auto& transformResult = result.GetValue();
-		ASSERT_EQ(transformResult.OwnerHandle, 1u);
+		ASSERT_EQ(transformResult.OwnerId, ownerId);
 		ASSERT_EQ(transformResult.Position.X, 5.0f);
 		ASSERT_EQ(transformResult.Position.Y, 10.0f);
 		ASSERT_EQ(transformResult.Scale.X, 2.0f);
@@ -127,22 +123,21 @@ namespace Ludus::EngineTests::Serialization::Schemas
 	TEST(Transform2DComponentSchema, Deserialize_DefaultsOptionalFields_When_Missing)
 	{
 		// Arrange.
+		const EntityId ownerId { 1 };
 		DomDocument document;
 		DomTokenStreamWriter writer(document);
 		writer.Emit(Token::StartObject { });
-		writer.Emit(Token::Key { "OwnerHandle" });
-		writer.Emit(Token::Int { 1 });
 		writer.Emit(Token::EndObject { });
 		DomTokenStreamReader reader(document);
 
 		// Act.
-		const auto result = Transform2DComponentSchema::Deserialize(reader);
+		const auto result = Transform2DComponentSchema::Deserialize(reader, ownerId);
 
 		// Assert.
 		ASSERT_TRUE(result.HasValue());
 
 		const auto& transformResult = result.GetValue();
-		ASSERT_EQ(transformResult.OwnerHandle, 1u);
+		ASSERT_EQ(transformResult.OwnerId, ownerId);
 		ASSERT_EQ(transformResult.Position.X, 0.0f);
 		ASSERT_EQ(transformResult.Position.Y, 0.0f);
 		ASSERT_EQ(transformResult.Scale.X, 1.0f);
@@ -150,9 +145,10 @@ namespace Ludus::EngineTests::Serialization::Schemas
 		ASSERT_EQ(transformResult.Rotation, 0.0f);
 	}
 
-	TEST(Transform2DComponentSchema, Deserialize_Fails_When_RequiredFieldsAreMissing)
+	TEST(Transform2DComponentSchema, Deserialize_DefaultsFields_When_AllPayloadFieldsAreMissing)
 	{
 		// Arrange.
+		const EntityId ownerId { 1 };
 		DomDocument document;
 		DomTokenStreamWriter writer(document);
 		writer.Emit(Token::StartObject { });
@@ -160,22 +156,29 @@ namespace Ludus::EngineTests::Serialization::Schemas
 		DomTokenStreamReader reader(document);
 
 		// Act.
-		const auto result = Transform2DComponentSchema::Deserialize(reader);
+		const auto result = Transform2DComponentSchema::Deserialize(reader, ownerId);
 
 		// Assert.
-		ASSERT_FALSE(result.HasValue());
+		ASSERT_TRUE(result.HasValue());
+		ASSERT_EQ(result.GetValue().OwnerId, ownerId);
+		ASSERT_EQ(result.GetValue().Position.X, 0.0f);
+		ASSERT_EQ(result.GetValue().Position.Y, 0.0f);
+		ASSERT_EQ(result.GetValue().Scale.X, 1.0f);
+		ASSERT_EQ(result.GetValue().Scale.Y, 1.0f);
+		ASSERT_EQ(result.GetValue().Rotation, 0.0f);
 	}
 
 	TEST(Transform2DComponentSchema, Deserialize_Fails_When_ComponentHeaderIsMissing)
 	{
 		// Arrange.
+		const EntityId ownerId { 1 };
 		DomDocument document;
 		DomTokenStreamWriter writer(document);
 		writer.Emit(Token::Int { 1 });
 		DomTokenStreamReader reader(document);
 
 		// Act.
-		const auto result = Transform2DComponentSchema::Deserialize(reader);
+		const auto result = Transform2DComponentSchema::Deserialize(reader, ownerId);
 
 		// Assert.
 		ASSERT_FALSE(result.HasValue());

--- a/EngineTests/Ludus/EngineTests/SmokeTests.cpp
+++ b/EngineTests/Ludus/EngineTests/SmokeTests.cpp
@@ -4,6 +4,7 @@ namespace Ludus::EngineTests
 {
 	TEST(SmokeTests, Compiles)
 	{
+		// Arrange & Act & Assert.
 		SUCCEED();
 	}
 }


### PR DESCRIPTION
# Summary
This PR includes the following:
- added `Guid` struct for Windows. Used by script and runtime host template projects.
- replacing separate runtime _ID_ implementations with a shared tagged _Id_ type
- renaming remaining _Handle_ usage to _Id_ where appropriate
- keeping strong type safety between `EntityId`, `SceneId`, and `ScriptId`
- making invalid/unassigned IDs explicit through `Invalid()`
- simplifying component persistence so components no longer persist `OwnerId`
- simplifying script component persistence and runtime usage so script components store only `ScriptId`

# Linked
- Closes #311 
- Story: #338  

