### PR TITLE
Feature: Added deferred editor actions and unsaved changes prompts

### DIFF
--- a/Editor/Editor.vcxproj
+++ b/Editor/Editor.vcxproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
@@ -23,14 +23,20 @@
     <ClCompile Include="Source\Ludus\Editor\Build\MSBuild\MSBuildRuntimeHostPipeline.cpp" />
     <ClCompile Include="Source\Ludus\Editor\Build\MSBuild\MSBuildPipeline.cpp" />
     <ClCompile Include="Source\Ludus\Editor\Build\RuntimePackage\RuntimeHostPackagePipeline.cpp" />
+    <ClCompile Include="Source\Ludus\Editor\Commands\Requests\BuildActions.cpp" />
     <ClCompile Include="Source\Ludus\Editor\Commands\Requests\Builds.cpp" />
+    <ClCompile Include="Source\Ludus\Editor\Commands\Requests\DeferredAction.cpp" />
     <ClCompile Include="Source\Ludus\Editor\Commands\Requests\EditorState.cpp" />
+    <ClCompile Include="Source\Ludus\Editor\Commands\Requests\EditorStateActions.cpp" />
+    <ClCompile Include="Source\Ludus\Editor\Commands\Requests\ProjectActions.cpp" />
+    <ClCompile Include="Source\Ludus\Editor\Commands\Requests\SceneActions.cpp" />
     <ClCompile Include="Source\Ludus\Editor\Commands\Requests\Scripts.cpp" />
     <ClCompile Include="Source\Ludus\Editor\Core\EditorSession.cpp" />
     <ClCompile Include="Source\Ludus\Editor\Core\ProjectSessionEditorState.cpp" />
     <ClCompile Include="Source\Ludus\Editor\Core\ProjectSessionPersistence.cpp" />
     <ClCompile Include="Source\Ludus\Editor\Core\ProjectSessionRuntimeState.cpp" />
     <ClCompile Include="Source\Ludus\Editor\Dialogs\RenameSceneDialog.cpp" />
+    <ClCompile Include="Source\Ludus\Editor\Dialogs\UnsavedChangesDialog.cpp" />
     <ClCompile Include="Source\Ludus\Editor\Persistence\ProjectSessionLoader.cpp" />
     <ClCompile Include="Source\Ludus\Editor\Serialization\ProjectManifestSchema.cpp" />
     <ClCompile Include="Source\Ludus\Editor\Persistence\LmlProjectManifestPersistence.cpp" />
@@ -84,8 +90,12 @@
     <ClInclude Include="Include\Ludus\Editor\Build\MSBuild\RuntimeHostBuildSettings.h" />
     <ClInclude Include="Include\Ludus\Editor\Build\RuntimePackage\RuntimeHostPackagePipeline.h" />
     <ClInclude Include="Include\Ludus\Editor\Commands\ProjectSessionCommandContext.h" />
+    <ClInclude Include="Include\Ludus\Editor\Commands\Requests\BuildActions.h" />
     <ClInclude Include="Include\Ludus\Editor\Commands\Requests\Builds.h" />
     <ClInclude Include="Include\Ludus\Editor\Commands\Requests\EditorState.h" />
+    <ClInclude Include="Include\Ludus\Editor\Commands\Requests\EditorStateActions.h" />
+    <ClInclude Include="Include\Ludus\Editor\Commands\Requests\ProjectActions.h" />
+    <ClInclude Include="Include\Ludus\Editor\Commands\Requests\SceneActions.h" />
     <ClInclude Include="Include\Ludus\Editor\Commands\Requests\Scripts.h" />
     <ClInclude Include="Include\Ludus\Editor\Commands\StartupCommandContext.h" />
     <ClInclude Include="Include\Ludus\Editor\Core\EditorSession.h" />
@@ -127,6 +137,7 @@
     <ClInclude Include="Include\Ludus\Editor\Core\EditorConfiguration.h" />
     <ClInclude Include="Include\Ludus\Editor\Core\EditorExecutionFlags.h" />
     <ClInclude Include="Include\Ludus\Editor\Core\ExecutionManager.h" />
+    <ClInclude Include="Include\Ludus\Editor\Core\SceneQueries.h" />
     <ClInclude Include="Include\Ludus\Editor\Core\SelectionManager.h" />
     <ClInclude Include="Include\Ludus\Editor\Core\EditorState.h" />
     <ClInclude Include="Include\Ludus\Editor\Core\EditorSystem.h" />
@@ -144,6 +155,10 @@
     <ClInclude Include="Include\Ludus\Editor\Dialogs\DialogManager.h" />
     <ClInclude Include="Include\Ludus\Editor\Dialogs\DialogOutcome.h" />
     <ClInclude Include="Include\Ludus\Editor\Dialogs\RenameSceneDialog.h" />
+    <ClInclude Include="Include\Ludus\Editor\Commands\Requests\DeferredAction.h" />
+    <ClInclude Include="Include\Ludus\Editor\Commands\Requests\ProjectTransitionContext.h" />
+    <ClInclude Include="Include\Ludus\Editor\Dialogs\UnsavedChangesDialog.h" />
+    <ClInclude Include="Include\Ludus\Editor\Dialogs\UnsavedChangesResult.h" />
     <ClInclude Include="Include\Ludus\Editor\Panels\PanelRegistry.h" />
     <ClInclude Include="Include\Ludus\Editor\Core\Constants.h" />
     <ClInclude Include="Include\Ludus\Editor\Panels\DockPanel.h" />

--- a/Editor/Include/Ludus/Editor/Commands/RequestCommand.h
+++ b/Editor/Include/Ludus/Editor/Commands/RequestCommand.h
@@ -10,8 +10,10 @@
 #include <Ludus/Editor/Build/BuildConfiguration.h>
 #include <Ludus/Editor/Build/BuildTarget.h>
 #include <Ludus/Editor/Commands/EntityReference.h>
+#include <Ludus/Editor/Commands/Requests/DeferredAction.h>
 #include <Ludus/Editor/Core/EditorExecutionFlags.h>
 #include <Ludus/Editor/Core/ExecutionMode.h>
+#include <Ludus/Editor/Dialogs/UnsavedChangesResult.h>
 #include <Ludus/Editor/Panels/PanelKind.h>
 #include <Ludus/Engine/Core/Id.h>
 #include <Ludus/UI/Theme/ThemeId.h>
@@ -29,16 +31,17 @@ namespace Ludus::Editor::Commands
 		struct UnsetExecutionFlag { Ludus::Editor::Core::EditorExecutionFlags Flag; };
 		struct SetPanelVisibility { Ludus::Editor::Panels::PanelKind PanelKind; bool IsVisible; };
 		struct SetTheme { Ludus::UI::Theme::ThemeId ThemeId; };
+		struct CloseApplication { };
 
 		struct CreateScene { };
 		struct CreateSceneAs { std::filesystem::path Path; };
-		struct OpenScene { std::filesystem::path Path; bool Additive = false; };
+		struct OpenScene { std::filesystem::path Path; };
 		struct SaveScene { Ludus::Engine::Core::SceneId SceneId; };
 		struct SaveSceneAs { Ludus::Engine::Core::SceneId SceneId; std::filesystem::path Path; };
 		struct RenameScene { Ludus::Engine::Core::SceneId SceneId; std::filesystem::path Path; };
 
 		struct CreateProject { std::string Name; };
-		struct CreateProjectAs { std::string Name; std::filesystem::path ProjectRoot; };
+		struct CreateProjectAs { std::string Name; std::filesystem::path Path; };
 		struct OpenProject { std::filesystem::path Path; };
 		struct SaveProject { };
 		struct CloseProject { };
@@ -54,13 +57,15 @@ namespace Ludus::Editor::Commands
 		struct BuildRuntime { Ludus::Editor::Build::BuildConfiguration BuildConfiguration; };
 		struct CleanRuntime { };
 
+		struct ResolveUnsavedChanges { Ludus::Editor::Commands::Requests::DeferredAction DeferredAction; Ludus::Editor::Dialogs::UnsavedChangesResult Result; };
 
 		using Variant = std::variant<
-			AddViewport, SetExecutionMode, SetExecutionFlag, UnsetExecutionFlag, SetPanelVisibility, SetTheme,
+			AddViewport, SetExecutionMode, SetExecutionFlag, UnsetExecutionFlag, SetPanelVisibility, SetTheme, CloseApplication,
 			CreateScene, CreateSceneAs, OpenScene, SaveScene, SaveSceneAs, RenameScene,
 			CreateProject, CreateProjectAs, OpenProject, SaveProject, CloseProject,
 			CreateScript,
-			RunTargetBuildCommand, BuildRuntime, CleanRuntime
+			RunTargetBuildCommand, BuildRuntime, CleanRuntime,
+			ResolveUnsavedChanges
 		>;
 
 		Variant Data;

--- a/Editor/Include/Ludus/Editor/Commands/Requests/BuildActions.h
+++ b/Editor/Include/Ludus/Editor/Commands/Requests/BuildActions.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <Ludus/Editor/Build/BuildCommand.h>
+#include <Ludus/Editor/Build/BuildConfiguration.h>
+#include <Ludus/Editor/Build/BuildTarget.h>
+#include <Ludus/Editor/Commands/ProjectSessionCommandContext.h>
+
+namespace Ludus::Editor::Commands::Requests::Builds
+{
+	void BuildRuntimeAction(
+		Ludus::Editor::Build::BuildConfiguration buildConfiguration,
+		ProjectSessionCommandContext& context
+	);
+
+	void CleanRuntimeAction(ProjectSessionCommandContext& context);
+
+	void RunTargetBuildCommandAction(
+		Ludus::Editor::Build::BuildTarget buildTarget,
+		Ludus::Editor::Build::BuildCommand buildCommand,
+		Ludus::Editor::Build::BuildConfiguration buildConfiguration,
+		ProjectSessionCommandContext& context
+	);
+}

--- a/Editor/Include/Ludus/Editor/Commands/Requests/DeferredAction.h
+++ b/Editor/Include/Ludus/Editor/Commands/Requests/DeferredAction.h
@@ -1,0 +1,98 @@
+#pragma once
+
+#include <filesystem>
+#include <string>
+#include <utility>
+#include <variant>
+
+#include <Ludus/Editor/Build/BuildConfiguration.h>
+
+namespace Ludus::Editor::Commands
+{
+	struct ProjectSessionCommandContext;
+}
+
+namespace Ludus::Editor::Commands::Requests
+{
+	struct DeferredAction
+	{
+		struct BuildRuntimeDeferredAction { Ludus::Editor::Build::BuildConfiguration BuildConfiguration; };
+		struct CloseApplicationDeferredAction { };
+		struct CloseProjectDeferredAction { };
+		struct CreateProjectDeferredAction { std::string Name; };
+		struct CreateProjectAsDeferredAction { std::string Name; std::filesystem::path Path; };
+		struct CreateSceneDeferredAction { };
+		struct CreateSceneAsDeferredAction { std::filesystem::path Path; };
+		struct OpenProjectDeferredAction { std::filesystem::path Path; };
+		struct OpenSceneDeferredAction { std::filesystem::path Path; };
+
+		using Variant = std::variant<
+			BuildRuntimeDeferredAction,
+			CloseApplicationDeferredAction,
+			CloseProjectDeferredAction,
+			CreateProjectDeferredAction,
+			CreateProjectAsDeferredAction,
+			CreateSceneDeferredAction,
+			CreateSceneAsDeferredAction,
+			OpenProjectDeferredAction,
+			OpenSceneDeferredAction
+		>;
+
+		Variant Data;
+
+		static DeferredAction BuildRuntime(Ludus::Editor::Build::BuildConfiguration buildConfiguration)
+		{
+			return { DeferredAction::BuildRuntimeDeferredAction { buildConfiguration } };
+		}
+
+		static DeferredAction CloseProject()
+		{
+			return { DeferredAction::CloseProjectDeferredAction { } };
+		}
+
+		static DeferredAction CloseApplication()
+		{
+			return { DeferredAction::CloseApplicationDeferredAction { } };
+		}
+
+		static DeferredAction CreateProject(std::string name)
+		{
+			return { DeferredAction::CreateProjectDeferredAction { std::move(name) } };
+		}
+
+		static DeferredAction CreateProjectAs(std::string name, std::filesystem::path path)
+		{
+			return { DeferredAction::CreateProjectAsDeferredAction { std::move(name), std::move(path) } };
+		}
+
+		static DeferredAction CreateScene()
+		{
+			return { DeferredAction::CreateSceneDeferredAction { } };
+		}
+
+		static DeferredAction CreateSceneAs(std::filesystem::path path)
+		{
+			return { DeferredAction::CreateSceneAsDeferredAction { std::move(path) } };
+		}
+
+		static DeferredAction OpenProject(std::filesystem::path path)
+		{
+			return { DeferredAction::OpenProjectDeferredAction { std::move(path) } };
+		}
+
+		static DeferredAction OpenScene(std::filesystem::path path)
+		{
+			return { DeferredAction::OpenSceneDeferredAction { std::move(path) } };
+		}
+	};
+
+	void ExecuteDeferredAction(
+		const DeferredAction& deferredAction,
+		ProjectSessionCommandContext& context
+	);
+
+	bool TryOpenUnsavedChangesDialog(
+		const DeferredAction& action,
+		ProjectSessionCommandContext& context
+	);
+}

--- a/Editor/Include/Ludus/Editor/Commands/Requests/EditorState.h
+++ b/Editor/Include/Ludus/Editor/Commands/Requests/EditorState.h
@@ -10,11 +10,14 @@ namespace Ludus::Editor::Commands
 
 namespace Ludus::Editor::Commands::Requests::EditorState
 {
+	void CloseApplication(ProjectSessionCommandContext& context);
+	void ResolveUnsavedChanges(const RequestCommand::ResolveUnsavedChanges& command, ProjectSessionCommandContext& context);
 	void SetExecutionMode(const RequestCommand::SetExecutionMode& command, ProjectSessionCommandContext& context);
 	void SetExecutionFlag(const RequestCommand::SetExecutionFlag& command, ProjectSessionCommandContext& context);
-	void UnsetExecutionFlag(const RequestCommand::UnsetExecutionFlag& command, ProjectSessionCommandContext& context);
 	void SetTheme(const RequestCommand::SetTheme& command, ProjectSessionCommandContext& context);
+	void UnsetExecutionFlag(const RequestCommand::UnsetExecutionFlag& command, ProjectSessionCommandContext& context);
 
+	void CloseApplication(StartupCommandContext& context);
 	void SetExecutionFlag(const RequestCommand::SetExecutionFlag& command, StartupCommandContext& context);
 	void UnsetExecutionFlag(const RequestCommand::UnsetExecutionFlag& command, StartupCommandContext& context);
 }

--- a/Editor/Include/Ludus/Editor/Commands/Requests/EditorStateActions.h
+++ b/Editor/Include/Ludus/Editor/Commands/Requests/EditorStateActions.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <Ludus/Editor/Core/EditorExecutionFlags.h>
+#include <Ludus/Editor/Core/ExecutionMode.h>
+#include <Ludus/UI/Theme/ThemeId.h>
+
+namespace Ludus::Editor::Commands
+{
+	struct ProjectSessionCommandContext;
+	struct StartupCommandContext;
+}
+
+namespace Ludus::Editor::Commands::Requests::EditorState
+{
+	void CloseApplicationAction(ProjectSessionCommandContext& context);
+	void SetExecutionModeAction(Ludus::Editor::Core::ExecutionMode mode, ProjectSessionCommandContext& context);
+	void SetExecutionFlagAction(Ludus::Editor::Core::EditorExecutionFlags flag, ProjectSessionCommandContext& context);
+	void SetThemeAction(Ludus::UI::Theme::ThemeId themeId, ProjectSessionCommandContext& context);
+	void UnsetExecutionFlagAction(Ludus::Editor::Core::EditorExecutionFlags flag, ProjectSessionCommandContext& context);
+
+	void CloseApplicationAction(StartupCommandContext& context);
+	void SetExecutionFlagAction(Ludus::Editor::Core::EditorExecutionFlags flag, StartupCommandContext& context);
+	void UnsetExecutionFlagAction(Ludus::Editor::Core::EditorExecutionFlags flag, StartupCommandContext& context);
+}

--- a/Editor/Include/Ludus/Editor/Commands/Requests/ProjectActions.h
+++ b/Editor/Include/Ludus/Editor/Commands/Requests/ProjectActions.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <filesystem>
+#include <string>
+
+#include <Ludus/Editor/Commands/ProjectSessionCommandContext.h>
+#include <Ludus/Editor/Commands/Requests/ProjectTransitionContext.h>
+#include <Ludus/Editor/Commands/StartupCommandContext.h>
+
+namespace Ludus::Editor::Commands::Requests::Projects
+{
+	void CreateProjectAction(const std::string& name, ProjectTransitionContext context);
+	void CreateProjectAsAction(const std::filesystem::path& path, const std::string& name, ProjectTransitionContext context);
+	void OpenProjectAction(const std::filesystem::path& path, ProjectTransitionContext context);
+	void CloseProjectAction(ProjectSessionCommandContext& context);
+	void SaveProjectAction(ProjectSessionCommandContext& context);
+}

--- a/Editor/Include/Ludus/Editor/Commands/Requests/ProjectTransitionContext.h
+++ b/Editor/Include/Ludus/Editor/Commands/Requests/ProjectTransitionContext.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <Ludus/Editor/Core/EditorShell.h>
+#include <Ludus/Editor/Panels/PanelRegistry.h>
+#include <Ludus/Editor/Persistence/IProjectManifestPersistence.h>
+#include <Ludus/Engine/Persistence/IRuntimeLaunchSettingsPersistence.h>
+#include <Ludus/Engine/Persistence/IRuntimeManifestPersistence.h>
+#include <Ludus/Engine/Persistence/IScenePersistence.h>
+
+namespace Ludus::Editor::Commands
+{
+	struct ProjectSessionCommandContext;
+	struct StartupCommandContext;
+}
+
+namespace Ludus::Editor::Commands::Requests::Projects
+{
+	struct ProjectTransitionContext
+	{
+		Ludus::Editor::Core::EditorShell& Shell;
+		Ludus::Engine::Persistence::IScenePersistence& ScenePersistence;
+		Ludus::Engine::Persistence::IRuntimeManifestPersistence& RuntimeManifestPersistence;
+		Ludus::Engine::Persistence::IRuntimeLaunchSettingsPersistence& RuntimeLaunchSettingsPersistence;
+		Ludus::Editor::Persistence::IProjectManifestPersistence& ProjectManifestPersistence;
+		Ludus::Editor::Panels::PanelRegistry& PanelRegistry;
+	};
+}

--- a/Editor/Include/Ludus/Editor/Commands/Requests/SceneActions.h
+++ b/Editor/Include/Ludus/Editor/Commands/Requests/SceneActions.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <filesystem>
+
+#include <Ludus/Editor/Commands/ProjectSessionCommandContext.h>
+#include <Ludus/Engine/Core/Id.h>
+
+namespace Ludus::Editor::Commands::Requests::Scenes
+{
+	void CreateSceneAction(ProjectSessionCommandContext& context);
+	void CreateSceneAsAction(const std::filesystem::path& path, ProjectSessionCommandContext& context);
+	void OpenSceneAction(const std::filesystem::path& path, ProjectSessionCommandContext& context);
+	void SaveSceneAction(Ludus::Engine::Core::SceneId sceneId, ProjectSessionCommandContext& context);
+	void SaveSceneAsAction(
+		Ludus::Engine::Core::SceneId sceneId,
+		const std::filesystem::path& path,
+		ProjectSessionCommandContext& context
+	);
+	void RenameSceneAction(
+		Ludus::Engine::Core::SceneId sceneId,
+		const std::filesystem::path& path,
+		ProjectSessionCommandContext& context
+	);
+}

--- a/Editor/Include/Ludus/Editor/Commands/UI/Dialogs.h
+++ b/Editor/Include/Ludus/Editor/Commands/UI/Dialogs.h
@@ -13,6 +13,7 @@ namespace Ludus::Editor::Commands::UI::Dialogs
 	void OpenAddScriptDialog(const UICommand::OpenAddScriptDialog& command, ProjectSessionCommandContext& context);
 	void OpenCreateProjectDialog(ProjectSessionCommandContext& context);
 	void OpenRenameSceneDialog(const UICommand::OpenRenameSceneDialog& command, ProjectSessionCommandContext& context);
+	void OpenUnsavedChangesDialog(const UICommand::OpenUnsavedChangesDialog& command, ProjectSessionCommandContext& context);
 
 	void OpenCreateProjectDialog(StartupCommandContext& context);
 }

--- a/Editor/Include/Ludus/Editor/Commands/UICommand.h
+++ b/Editor/Include/Ludus/Editor/Commands/UICommand.h
@@ -3,6 +3,7 @@
 #include <utility>
 #include <variant>
 
+#include <Ludus/Editor/Commands/Requests/DeferredAction.h>
 #include <Ludus/Engine/Core/Id.h>
 
 namespace Ludus::Editor::Commands
@@ -15,8 +16,9 @@ namespace Ludus::Editor::Commands
 		struct OpenAddScriptDialog { Ludus::Engine::Core::SceneId SceneId; Ludus::Engine::Core::EntityId EntityId; };
 		struct OpenCreateProjectDialog { };
 		struct OpenRenameSceneDialog { Ludus::Engine::Core::SceneId SceneId; };
+		struct OpenUnsavedChangesDialog { Ludus::Editor::Commands::Requests::DeferredAction DeferredAction; };
 
-		using Variant = std::variant<OpenAddScriptDialog, OpenCreateProjectDialog, OpenRenameSceneDialog>;
+		using Variant = std::variant<OpenAddScriptDialog, OpenCreateProjectDialog, OpenRenameSceneDialog, OpenUnsavedChangesDialog>;
 
 		Variant Data;
 

--- a/Editor/Include/Ludus/Editor/Core/EditorSystem.h
+++ b/Editor/Include/Ludus/Editor/Core/EditorSystem.h
@@ -13,16 +13,16 @@
 #include <Ludus/Editor/Panels/PanelRegistry.h>
 #include <Ludus/Editor/Persistence/LmlProjectManifestPersistence.h>
 #include <Ludus/Editor/Persistence/ProjectSessionLoader.h>
+#include <Ludus/Engine/Events/EventHandler.h>
 #include <Ludus/Engine/Persistence/LmlRuntimeLaunchSettingsPersistence.h>
 #include <Ludus/Engine/Persistence/LmlRuntimeManifestPersistence.h>
 #include <Ludus/Engine/Persistence/LmlScenePersistence.h>
 #include <Ludus/Engine/Runtime/IHostContext.h>
 #include <Ludus/Engine/Runtime/ISystem.h>
-#include <Ludus/Engine/Runtime/RuntimeEnvironment.h>
 
 namespace Ludus::Editor::Core
 {
-	class EditorSystem final : public Ludus::Engine::Runtime::ISystem
+	class EditorSystem final : public Ludus::Engine::Runtime::ISystem, public Ludus::Engine::Events::EventHandler
 	{
 	private:
 		EditorShell m_Shell;
@@ -70,5 +70,7 @@ namespace Ludus::Editor::Core
 		virtual void OnDetachImpl() override;
 
 		virtual void UpdateImpl(float deltaTime) override;
+
+		virtual bool ProcessEvent(const Ludus::Engine::Events::Event& event) override;
 	};
 }

--- a/Editor/Include/Ludus/Editor/Core/ProjectTemplates.h
+++ b/Editor/Include/Ludus/Editor/Core/ProjectTemplates.h
@@ -1,16 +1,18 @@
 #pragma once
 
+#include <string_view>
+
 #include <Ludus/Engine/Core/Random.h>
 #include <Ludus/Engine/Core/Scene.h>
 
 namespace Ludus::Editor::Core::ProjectTemplates
 {
-	inline Ludus::Engine::Core::Scene CreateDefaultScene()
+	inline Ludus::Engine::Core::Scene CreateDefaultScene(std::string_view name = "Sample Scene")
 	{
 		auto random = Ludus::Engine::Core::Random();
 		Ludus::Engine::Core::Scene scene(
 			{ random.NextId() },
-			"Sample Scene"
+			name
 		);
 
 		const auto entityId = scene.EntityComponentSystem.AddEntity();

--- a/Editor/Include/Ludus/Editor/Core/SceneQueries.h
+++ b/Editor/Include/Ludus/Editor/Core/SceneQueries.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <Ludus/Engine/Core/Scene.h>
+#include <Ludus/Engine/Runtime/RuntimeManifest.h>
+
+namespace Ludus::Editor::Core::SceneQueries
+{
+	inline bool ContainsUnresolvedScriptReferences(
+		const Ludus::Engine::Core::Scene& scene,
+		const Ludus::Engine::Runtime::RuntimeManifest& runtimeManifest
+	)
+	{
+		for (const auto& script : scene.EntityComponentSystem.Scripts.View())
+		{
+			if (!runtimeManifest.TryGetScriptReference(script.Id))
+			{
+				return true;
+			}
+		}
+
+		return false;
+	}
+}

--- a/Editor/Include/Ludus/Editor/Dialogs/AddScriptDialog.h
+++ b/Editor/Include/Ludus/Editor/Dialogs/AddScriptDialog.h
@@ -17,17 +17,17 @@ namespace Ludus::Editor::Dialogs
 	private:
 		enum class AddScriptTab { Create, Select };
 
-		bool IsOpen = true;
-		bool JustOpened = true;
-		std::string Error;
-		std::string CreateName;
-		std::string SelectName;
-		AddScriptTab ActiveTab = AddScriptTab::Create;
+		bool m_IsOpen = true;
+		bool m_JustOpened = true;
+		std::string m_Error;
+		std::string m_CreateName;
+		std::string m_SelectName;
+		AddScriptTab m_ActiveTab = AddScriptTab::Create;
 
-		Ludus::Engine::Core::SceneId SceneId;
-		Ludus::Engine::Core::EntityId EntityId;
-		std::vector<std::string> ScriptNames;
-		std::vector<Ludus::Engine::Runtime::ScriptReference> ScriptReferences;
+		Ludus::Engine::Core::SceneId m_SceneId;
+		Ludus::Engine::Core::EntityId m_EntityId;
+		std::vector<std::string> m_ScriptNames;
+		std::vector<Ludus::Engine::Runtime::ScriptReference> m_ScriptReferences;
 
 		using Outcome = DialogOutcome<std::string>;
 

--- a/Editor/Include/Ludus/Editor/Dialogs/DialogManager.h
+++ b/Editor/Include/Ludus/Editor/Dialogs/DialogManager.h
@@ -9,10 +9,11 @@
 #include <Ludus/Editor/Dialogs/AddScriptDialog.h>
 #include <Ludus/Editor/Dialogs/CreateProjectDialog.h>
 #include <Ludus/Editor/Dialogs/RenameSceneDialog.h>
+#include <Ludus/Editor/Dialogs/UnsavedChangesDialog.h>
 
 namespace Ludus::Editor::Dialogs
 {
-	using ActiveDialog = std::variant<std::monostate, AddScriptDialog, CreateProjectDialog, RenameSceneDialog>;
+	using ActiveDialog = std::variant<std::monostate, AddScriptDialog, CreateProjectDialog, RenameSceneDialog, UnsavedChangesDialog>;
 
 	struct DialogManager
 	{

--- a/Editor/Include/Ludus/Editor/Dialogs/RenameSceneDialog.h
+++ b/Editor/Include/Ludus/Editor/Dialogs/RenameSceneDialog.h
@@ -18,15 +18,15 @@ namespace Ludus::Editor::Dialogs
 			std::filesystem::path Path;
 		};
 
-		bool IsOpen = true;
-		bool JustOpened = true;
-		std::string Error;
+		bool m_IsOpen = true;
+		bool m_JustOpened = true;
+		std::string m_Error;
 
-		std::string Name;
-		std::filesystem::path NewPath;
+		std::string m_Name;
+		std::filesystem::path m_NewPath;
 
-		Ludus::Engine::Core::SceneId SceneId;
-		std::filesystem::path CurrentPath;
+		Ludus::Engine::Core::SceneId m_SceneId;
+		std::filesystem::path m_CurrentPath;
 
 		using Outcome = DialogOutcome<RenameOutcome>;
 

--- a/Editor/Include/Ludus/Editor/Dialogs/UnsavedChangesDialog.h
+++ b/Editor/Include/Ludus/Editor/Dialogs/UnsavedChangesDialog.h
@@ -1,24 +1,24 @@
 #pragma once
 
-#include <string>
-
 #include <Ludus/Editor/Commands/CommandSet.h>
+#include <Ludus/Editor/Commands/Requests/DeferredAction.h>
 #include <Ludus/Editor/Dialogs/DialogOutcome.h>
+#include <Ludus/Editor/Dialogs/UnsavedChangesResult.h>
 
 namespace Ludus::Editor::Dialogs
 {
-	struct CreateProjectDialog
+	struct UnsavedChangesDialog
 	{
 	private:
 		bool m_IsOpen = true;
 		bool m_JustOpened = true;
-		std::string m_Error;
+		Ludus::Editor::Commands::Requests::DeferredAction m_DeferredAction;
 
-		std::string m_Name;
-
-		using Outcome = DialogOutcome<std::string>;
+		using Outcome = DialogOutcome<UnsavedChangesResult>;
 
 	public:
+		UnsavedChangesDialog(Ludus::Editor::Commands::Requests::DeferredAction deferredAction);
+
 		Outcome Draw();
 		void Resolve(const Outcome& outcome, Ludus::Editor::Commands::CommandSet& out);
 		bool ShouldClose(const Outcome&) const;

--- a/Editor/Include/Ludus/Editor/Dialogs/UnsavedChangesResult.h
+++ b/Editor/Include/Ludus/Editor/Dialogs/UnsavedChangesResult.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <cstdint>
+
+namespace Ludus::Editor::Dialogs
+{
+	enum class UnsavedChangesResult : uint8_t
+	{
+		Save,
+		DontSave,
+		Cancel
+	};
+}

--- a/Editor/Source/Ludus/Editor/Commands/RequestCommand.cpp
+++ b/Editor/Source/Ludus/Editor/Commands/RequestCommand.cpp
@@ -42,6 +42,8 @@ namespace Ludus::Editor::Commands
 			void operator()(const RequestCommand::UnsetExecutionFlag& command) const { Requests::EditorState::UnsetExecutionFlag(command, Context); }
 			void operator()(const RequestCommand::SetPanelVisibility& command) const { Requests::Panels::SetPanelVisibility(command, Context); }
 			void operator()(const RequestCommand::SetTheme& command) const { Requests::EditorState::SetTheme(command, Context); }
+			void operator()(const RequestCommand::CloseApplication&) const { Requests::EditorState::CloseApplication(Context); }
+			void operator()(const RequestCommand::ResolveUnsavedChanges& command) const { Requests::EditorState::ResolveUnsavedChanges(command, Context); }
 
 			template<typename T>
 			void operator()(T&& unhandled) const
@@ -75,6 +77,8 @@ namespace Ludus::Editor::Commands
 			void operator()(const RequestCommand::UnsetExecutionFlag& command) const { Requests::EditorState::UnsetExecutionFlag(command, Context); }
 			void operator()(const RequestCommand::SetPanelVisibility&) const { LUDUS_ASSERT(false, "SetPanelVisibility is unavailable during startup."); }
 			void operator()(const RequestCommand::SetTheme&) const { LUDUS_ASSERT(false, "SetTheme is unavailable during startup."); }
+			void operator()(const RequestCommand::CloseApplication&) const { Requests::EditorState::CloseApplication(Context); }
+			void operator()(const RequestCommand::ResolveUnsavedChanges&) const { LUDUS_ASSERT(false, "ResolveUnsavedChanges is unavailable during startup."); }
 
 			template<typename T>
 			void operator()(T&& unhandled) const

--- a/Editor/Source/Ludus/Editor/Commands/Requests/BuildActions.cpp
+++ b/Editor/Source/Ludus/Editor/Commands/Requests/BuildActions.cpp
@@ -1,0 +1,63 @@
+#include "pch.h"
+
+#include <Ludus/Editor/Build/BuildCommand.h>
+#include <Ludus/Editor/Build/BuildConfiguration.h>
+#include <Ludus/Editor/Build/BuildTarget.h>
+#include <Ludus/Editor/Commands/ProjectSessionCommandContext.h>
+#include <Ludus/Editor/Commands/RequestCommand.h>
+#include <Ludus/Editor/Commands/Requests/BuildActions.h>
+#include <Ludus/Editor/Panels/PanelHelpers.h>
+#include <Ludus/Engine/Debug/Debug.h>
+
+namespace Ludus::Editor::Commands::Requests::Builds
+{
+	void BuildRuntimeAction(
+		Ludus::Editor::Build::BuildConfiguration buildConfiguration,
+		ProjectSessionCommandContext& context
+	)
+	{
+		LUDUS_ASSERT(
+			!context.ProjectSession.RuntimeState.IsSimulationActive(),
+			"Build command cannot be executed while the simulation session is active."
+		);
+
+		const auto projectRoot = context.ProjectSession.Persistence.GetProjectRoot();
+		auto& build = context.Shell.Build;
+		build.BuildRuntime(projectRoot, buildConfiguration);
+
+		Ludus::Editor::Panels::RefreshContentPanel(projectRoot, context.PanelRegistry);
+	}
+
+	void CleanRuntimeAction(ProjectSessionCommandContext& context)
+	{
+		LUDUS_ASSERT(
+			!context.ProjectSession.RuntimeState.IsSimulationActive(),
+			"Build command cannot be executed while the simulation session is active."
+		);
+
+		const auto projectRoot = context.ProjectSession.Persistence.GetProjectRoot();
+		auto& build = context.Shell.Build;
+		build.CleanRuntime(projectRoot);
+
+		Ludus::Editor::Panels::RefreshContentPanel(projectRoot, context.PanelRegistry);
+	}
+
+	void RunTargetBuildCommandAction(
+		Ludus::Editor::Build::BuildTarget buildTarget,
+		Ludus::Editor::Build::BuildCommand buildCommand,
+		Ludus::Editor::Build::BuildConfiguration buildConfiguration,
+		ProjectSessionCommandContext& context
+	)
+	{
+		LUDUS_ASSERT(
+			!context.ProjectSession.RuntimeState.IsSimulationActive(),
+			"Build command cannot be executed while the simulation session is active."
+		);
+
+		const auto projectRoot = context.ProjectSession.Persistence.GetProjectRoot();
+		auto& build = context.Shell.Build;
+		build.RunTargetBuildCommand(projectRoot, buildTarget, buildCommand, buildConfiguration);
+
+		Ludus::Editor::Panels::RefreshContentPanel(projectRoot, context.PanelRegistry);
+	}
+}

--- a/Editor/Source/Ludus/Editor/Commands/Requests/Builds.cpp
+++ b/Editor/Source/Ludus/Editor/Commands/Requests/Builds.cpp
@@ -1,60 +1,35 @@
 #include "pch.h"
 
-#include <stdexcept>
-
 #include <Ludus/Editor/Commands/ProjectSessionCommandContext.h>
 #include <Ludus/Editor/Commands/RequestCommand.h>
-#include <Ludus/Editor/Commands/Requests/Projects.h>
-#include <Ludus/Editor/Panels/PanelHelpers.h>
-#include <Ludus/Engine/Debug/Debug.h>
+#include <Ludus/Editor/Commands/Requests/BuildActions.h>
+#include <Ludus/Editor/Commands/Requests/DeferredAction.h>
 
 namespace Ludus::Editor::Commands::Requests::Builds
 {
-	void RunTargetBuildCommand(const RequestCommand::RunTargetBuildCommand& command, ProjectSessionCommandContext& context)
-	{
-		LUDUS_ASSERT(
-			!context.ProjectSession.RuntimeState.IsSimulationActive(),
-			"Build command cannot be executed while the simulation session is active."
-		);
-
-		const auto projectRoot = context.ProjectSession.Persistence.GetProjectRoot();
-		auto& build = context.Shell.Build;
-		build.RunTargetBuildCommand(projectRoot, command.BuildTarget, command.BuildCommand, command.BuildConfiguration);
-
-		Ludus::Editor::Panels::RefreshContentPanel(projectRoot, context.PanelRegistry);
-	}
-
 	void BuildRuntime(const RequestCommand::BuildRuntime& command, ProjectSessionCommandContext& context)
 	{
-		LUDUS_ASSERT(
-			!context.ProjectSession.RuntimeState.IsSimulationActive(),
-			"Build command cannot be executed while the simulation session is active."
-		);
-
-		if (context.ProjectSession.EditorState.HasUnsavedChanges())
+		auto action = DeferredAction::BuildRuntime(command.BuildConfiguration);
+		if (TryOpenUnsavedChangesDialog(action, context))
 		{
-			LUDUS_LOG_WARN("Build command cannot be executed when the project has unsaved changes.");
 			return;
 		}
 
-		const auto projectRoot = context.ProjectSession.Persistence.GetProjectRoot();
-		auto& build = context.Shell.Build;
-		build.BuildRuntime(projectRoot, command.BuildConfiguration);
-
-		Ludus::Editor::Panels::RefreshContentPanel(projectRoot, context.PanelRegistry);
+		ExecuteDeferredAction(action, context);
 	}
 
 	void CleanRuntime(ProjectSessionCommandContext& context)
 	{
-		LUDUS_ASSERT(
-			!context.ProjectSession.RuntimeState.IsSimulationActive(),
-			"Build command cannot be executed while the simulation session is active."
+		Ludus::Editor::Commands::Requests::Builds::CleanRuntimeAction(context);
+	}
+
+	void RunTargetBuildCommand(const RequestCommand::RunTargetBuildCommand& command, ProjectSessionCommandContext& context)
+	{
+		Ludus::Editor::Commands::Requests::Builds::RunTargetBuildCommandAction(
+			command.BuildTarget,
+			command.BuildCommand,
+			command.BuildConfiguration,
+			context
 		);
-
-		const auto projectRoot = context.ProjectSession.Persistence.GetProjectRoot();
-		auto& build = context.Shell.Build;
-		build.CleanRuntime(projectRoot);
-
-		Ludus::Editor::Panels::RefreshContentPanel(projectRoot, context.PanelRegistry);
 	}
 }

--- a/Editor/Source/Ludus/Editor/Commands/Requests/DeferredAction.cpp
+++ b/Editor/Source/Ludus/Editor/Commands/Requests/DeferredAction.cpp
@@ -1,0 +1,101 @@
+#include "pch.h"
+
+#include <variant>
+
+#include <Ludus/Editor/Commands/ProjectSessionCommandContext.h>
+#include <Ludus/Editor/Commands/Requests/BuildActions.h>
+#include <Ludus/Editor/Commands/Requests/DeferredAction.h>
+#include <Ludus/Editor/Commands/Requests/EditorStateActions.h>
+#include <Ludus/Editor/Commands/Requests/ProjectActions.h>
+#include <Ludus/Editor/Commands/Requests/ProjectTransitionContext.h>
+#include <Ludus/Editor/Commands/Requests/SceneActions.h>
+#include <Ludus/Editor/Commands/UICommand.h>
+
+namespace Ludus::Editor::Commands::Requests
+{
+	namespace
+	{
+		Projects::ProjectTransitionContext MakeProjectTransitionContext(ProjectSessionCommandContext& context)
+		{
+			return {
+				.Shell = context.Shell,
+				.ScenePersistence = context.ScenePersistence,
+				.RuntimeManifestPersistence = context.RuntimeManifestPersistence,
+				.RuntimeLaunchSettingsPersistence = context.RuntimeLaunchSettingsPersistence,
+				.ProjectManifestPersistence = context.ProjectManifestPersistence,
+				.PanelRegistry = context.PanelRegistry
+			};
+		}
+	}
+
+	void ExecuteDeferredAction(
+		const DeferredAction& deferredAction,
+		ProjectSessionCommandContext& context
+	)
+	{
+		using DeferredAction = DeferredAction;
+
+		std::visit([&](auto&& value)
+		{
+			using Alt = std::decay_t<decltype(value)>;
+
+			if constexpr (std::is_same_v<Alt, DeferredAction::BuildRuntimeDeferredAction>)
+			{
+				Builds::BuildRuntimeAction(value.BuildConfiguration, context);
+			}
+			else if constexpr (std::is_same_v<Alt, DeferredAction::CloseApplicationDeferredAction>)
+			{
+				EditorState::CloseApplicationAction(context);
+			}
+			else if constexpr (std::is_same_v<Alt, DeferredAction::CloseProjectDeferredAction>)
+			{
+				Projects::CloseProjectAction(context);
+			}
+			else if constexpr (std::is_same_v<Alt, DeferredAction::CreateProjectDeferredAction>)
+			{
+				Projects::CreateProjectAction(value.Name, MakeProjectTransitionContext(context));
+			}
+			else if constexpr (std::is_same_v<Alt, DeferredAction::CreateProjectAsDeferredAction>)
+			{
+				Projects::CreateProjectAsAction(value.Path, value.Name, MakeProjectTransitionContext(context));
+			}
+			else if constexpr (std::is_same_v<Alt, DeferredAction::CreateSceneDeferredAction>)
+			{
+				Scenes::CreateSceneAction(context);
+			}
+			else if constexpr (std::is_same_v<Alt, DeferredAction::CreateSceneAsDeferredAction>)
+			{
+				Scenes::CreateSceneAsAction(value.Path, context);
+			}
+			else if constexpr (std::is_same_v<Alt, DeferredAction::OpenProjectDeferredAction>)
+			{
+				Projects::OpenProjectAction(value.Path, MakeProjectTransitionContext(context));
+			}
+			else if constexpr (std::is_same_v<Alt, DeferredAction::OpenSceneDeferredAction>)
+			{
+				Scenes::OpenSceneAction(value.Path, context);
+			}
+			else
+			{
+				throw std::runtime_error("Unsupported unsaved changes deferred action.");
+			}
+		}, deferredAction.Data);
+	}
+
+	bool TryOpenUnsavedChangesDialog(
+		const DeferredAction& action,
+		ProjectSessionCommandContext& context
+	)
+	{
+		if (context.ProjectSession.EditorState.HasUnsavedChanges())
+		{
+			context.Shell.State.Commands.AddUICommand(
+				UICommand::OpenUnsavedChangesDialog { .DeferredAction = action }
+			);
+
+			return true;
+		}
+
+		return false;
+	}
+}

--- a/Editor/Source/Ludus/Editor/Commands/Requests/EditorState.cpp
+++ b/Editor/Source/Ludus/Editor/Commands/Requests/EditorState.cpp
@@ -1,54 +1,87 @@
 #include "pch.h"
 
 #include <Ludus/Editor/Commands/ProjectSessionCommandContext.h>
+#include <Ludus/Editor/Commands/RequestCommand.h>
+#include <Ludus/Editor/Commands/Requests/DeferredAction.h>
 #include <Ludus/Editor/Commands/Requests/EditorState.h>
+#include <Ludus/Editor/Commands/Requests/EditorStateActions.h>
+#include <Ludus/Editor/Commands/Requests/Projects.h>
 #include <Ludus/Editor/Commands/StartupCommandContext.h>
-#include <Ludus/UI/Context/ThemeContext.h>
+#include <Ludus/Editor/Dialogs/UnsavedChangesResult.h>
 
 namespace Ludus::Editor::Commands::Requests::EditorState
 {
-	void SetExecutionFlag(const RequestCommand::SetExecutionFlag& command, ProjectSessionCommandContext& context)
+	void CloseApplication(ProjectSessionCommandContext& context)
 	{
-		context.Shell.State.Execution.SetFlag(context.HostContext.GetExecutionFlags(), command.Flag);
+		auto action = DeferredAction::CloseApplication();
+		if (TryOpenUnsavedChangesDialog(action, context))
+		{
+			return;
+		}
+
+		ExecuteDeferredAction(action, context);
 	}
 
-	void UnsetExecutionFlag(const RequestCommand::UnsetExecutionFlag& command, ProjectSessionCommandContext& context)
+	void ResolveUnsavedChanges(const RequestCommand::ResolveUnsavedChanges& command, ProjectSessionCommandContext& context)
 	{
-		context.Shell.State.Execution.UnsetFlag(context.HostContext.GetExecutionFlags(), command.Flag);
+		if (command.Result == Ludus::Editor::Dialogs::UnsavedChangesResult::DontSave)
+		{
+			ExecuteDeferredAction(command.DeferredAction, context);
+			return;
+		}
+
+		if (command.Result == Ludus::Editor::Dialogs::UnsavedChangesResult::Save)
+		{
+			Ludus::Editor::Commands::Requests::Projects::SaveProject(context);
+
+			if (context.ProjectSession.EditorState.HasUnsavedChanges())
+			{
+				LUDUS_LOG_WARN("Deferred action was not resumed because saving did not clear all unsaved changes.");
+				return;
+			}
+
+			ExecuteDeferredAction(command.DeferredAction, context);
+			return;
+		}
+
+		if (command.Result == Ludus::Editor::Dialogs::UnsavedChangesResult::Cancel)
+		{
+			return;
+		}
+	}
+
+	void SetExecutionFlag(const RequestCommand::SetExecutionFlag& command, ProjectSessionCommandContext& context)
+	{
+		SetExecutionFlagAction(command.Flag, context);
 	}
 
 	void SetExecutionMode(const RequestCommand::SetExecutionMode& command, ProjectSessionCommandContext& context)
 	{
-		switch (command.Mode)
-		{
-			case Ludus::Editor::Core::ExecutionMode::Start:
-				context.ProjectSession.StartSimulation(context.HostContext);
-				break;
-			case Ludus::Editor::Core::ExecutionMode::Stop:
-				context.ProjectSession.StopSimulation(context.HostContext);
-				break;
-			case Ludus::Editor::Core::ExecutionMode::Pause:
-				context.ProjectSession.PauseSimulation(context.HostContext);
-				break;
-		}
-
-		context.Shell.State.Execution.ExecutionMode = command.Mode;
-		context.Shell.State.Execution.Apply(context.HostContext.GetExecutionFlags(), command.Mode);
+		SetExecutionModeAction(command.Mode, context);
 	}
 
 	void SetTheme(const RequestCommand::SetTheme& command, ProjectSessionCommandContext& context)
 	{
-		Ludus::UI::Context::ThemeContext::SetActiveTheme(command.ThemeId);
-		context.Shell.State.Theme.ActiveThemeId = command.ThemeId;
+		SetThemeAction(command.ThemeId, context);
+	}
+
+	void UnsetExecutionFlag(const RequestCommand::UnsetExecutionFlag& command, ProjectSessionCommandContext& context)
+	{
+		UnsetExecutionFlagAction(command.Flag, context);
+	}
+
+	void CloseApplication(StartupCommandContext& context)
+	{
+		CloseApplicationAction(context);
 	}
 
 	void SetExecutionFlag(const RequestCommand::SetExecutionFlag& command, StartupCommandContext& context)
 	{
-		context.Shell.State.Execution.SetFlag(context.HostContext.GetExecutionFlags(), command.Flag);
+		SetExecutionFlagAction(command.Flag, context);
 	}
 
 	void UnsetExecutionFlag(const RequestCommand::UnsetExecutionFlag& command, StartupCommandContext& context)
 	{
-		context.Shell.State.Execution.UnsetFlag(context.HostContext.GetExecutionFlags(), command.Flag);
+		UnsetExecutionFlagAction(command.Flag, context);
 	}
 }

--- a/Editor/Source/Ludus/Editor/Commands/Requests/EditorStateActions.cpp
+++ b/Editor/Source/Ludus/Editor/Commands/Requests/EditorStateActions.cpp
@@ -1,0 +1,64 @@
+#include "pch.h"
+
+#include <Ludus/Editor/Commands/ProjectSessionCommandContext.h>
+#include <Ludus/Editor/Commands/Requests/EditorStateActions.h>
+#include <Ludus/Editor/Commands/StartupCommandContext.h>
+#include <Ludus/UI/Context/ThemeContext.h>
+
+namespace Ludus::Editor::Commands::Requests::EditorState
+{
+	void CloseApplicationAction(ProjectSessionCommandContext& context)
+	{
+		context.HostContext.SetWindowShouldClose();
+	}
+
+	void SetExecutionModeAction(Ludus::Editor::Core::ExecutionMode mode, ProjectSessionCommandContext& context)
+	{
+		switch (mode)
+		{
+			case Ludus::Editor::Core::ExecutionMode::Start:
+				context.ProjectSession.StartSimulation(context.HostContext);
+				break;
+			case Ludus::Editor::Core::ExecutionMode::Stop:
+				context.ProjectSession.StopSimulation(context.HostContext);
+				break;
+			case Ludus::Editor::Core::ExecutionMode::Pause:
+				context.ProjectSession.PauseSimulation(context.HostContext);
+				break;
+		}
+
+		context.Shell.State.Execution.ExecutionMode = mode;
+		context.Shell.State.Execution.Apply(context.HostContext.GetExecutionFlags(), mode);
+	}
+
+	void SetExecutionFlagAction(Ludus::Editor::Core::EditorExecutionFlags flag, ProjectSessionCommandContext& context)
+	{
+		context.Shell.State.Execution.SetFlag(context.HostContext.GetExecutionFlags(), flag);
+	}
+
+	void SetThemeAction(Ludus::UI::Theme::ThemeId themeId, ProjectSessionCommandContext& context)
+	{
+		Ludus::UI::Context::ThemeContext::SetActiveTheme(themeId);
+		context.Shell.State.Theme.ActiveThemeId = themeId;
+	}
+
+	void UnsetExecutionFlagAction(Ludus::Editor::Core::EditorExecutionFlags flag, ProjectSessionCommandContext& context)
+	{
+		context.Shell.State.Execution.UnsetFlag(context.HostContext.GetExecutionFlags(), flag);
+	}
+
+	void CloseApplicationAction(StartupCommandContext& context)
+	{
+		context.HostContext.SetWindowShouldClose();
+	}
+
+	void SetExecutionFlagAction(Ludus::Editor::Core::EditorExecutionFlags flag, StartupCommandContext& context)
+	{
+		context.Shell.State.Execution.SetFlag(context.HostContext.GetExecutionFlags(), flag);
+	}
+
+	void UnsetExecutionFlagAction(Ludus::Editor::Core::EditorExecutionFlags flag, StartupCommandContext& context)
+	{
+		context.Shell.State.Execution.UnsetFlag(context.HostContext.GetExecutionFlags(), flag);
+	}
+}

--- a/Editor/Source/Ludus/Editor/Commands/Requests/ProjectActions.cpp
+++ b/Editor/Source/Ludus/Editor/Commands/Requests/ProjectActions.cpp
@@ -1,0 +1,199 @@
+#include "pch.h"
+
+#include <filesystem>
+#include <string>
+#include <string_view>
+
+#include <Ludus/Editor/Commands/ProjectSessionCommandContext.h>
+#include <Ludus/Editor/Commands/Requests/ProjectTransitionContext.h>
+#include <Ludus/Editor/Core/ProjectTemplates.h>
+#include <Ludus/Editor/Core/SceneQueries.h>
+#include <Ludus/Editor/Panels/PanelHelpers.h>
+#include <Ludus/Editor/Persistence/ProjectPaths.h>
+
+namespace Ludus::Editor::Commands::Requests::Projects
+{
+	namespace
+	{
+		void CreateProject(
+			const std::filesystem::path& projectRoot,
+			std::string_view projectName,
+			Ludus::Editor::Core::PendingProjectTransition& pendingProjectTransition,
+			Ludus::Engine::Persistence::IScenePersistence& scenePersistence,
+			Ludus::Engine::Persistence::IRuntimeManifestPersistence& runtimeManifestPersistence,
+			Ludus::Engine::Persistence::IRuntimeLaunchSettingsPersistence& runtimeLaunchSettingsPersistence,
+			Ludus::Editor::Persistence::IProjectManifestPersistence& projectManifestPersistence
+		)
+		{
+			Ludus::Editor::Persistence::ProjectPaths::EnsureProjectLayoutExists(projectRoot);
+
+			// Create default scene.
+			const auto scene = Ludus::Editor::Core::ProjectTemplates::CreateDefaultScene();
+			const auto scenePath = Ludus::Editor::Persistence::ProjectPaths::SceneFile(projectRoot, scene.Name);
+			scenePersistence.Save(
+				scene,
+				scenePath
+			);
+
+			// Create runtime manifest.
+			const auto runtimeManifest = Ludus::Engine::Runtime::RuntimeManifest::Create(
+				scene.Id,
+				{ { scene.Id, scene.Name, scenePath } },
+				{ }
+			);
+			const auto runtimeManifestPath = Ludus::Engine::Persistence::Paths::RuntimeManifestFile(projectRoot, projectName);
+			runtimeManifestPersistence.Save(
+				runtimeManifest,
+				runtimeManifestPath
+			);
+
+			// Create runtime settings.
+			const auto runtimeLaunchSettings = Ludus::Engine::Runtime::RuntimeLaunchSettings();
+			const auto runtimeLaunchSettingsPath = Ludus::Engine::Persistence::Paths::RuntimeLaunchSettingsFile(projectRoot, projectName);
+			runtimeLaunchSettingsPersistence.Save(
+				runtimeLaunchSettings,
+				runtimeLaunchSettingsPath
+			);
+
+			// Create project manifest.
+			const auto projectManifest = Ludus::Editor::Core::ProjectManifest::Create(
+				projectRoot,
+				runtimeManifestPath
+			);
+			projectManifestPersistence.Save(
+				projectManifest,
+				Ludus::Editor::Persistence::ProjectPaths::ProjectManifestFile(projectRoot, projectName)
+			);
+
+			// Set pending project.
+			pendingProjectTransition = Ludus::Editor::Core::PendingProjectTransition::OpenProject({ projectManifest });
+		}
+
+		void RefreshContentPanel(
+			const std::filesystem::path& projectRoot,
+			ProjectTransitionContext context
+		)
+		{
+			Ludus::Editor::Panels::RefreshContentPanel(projectRoot, context.PanelRegistry);
+		}
+	}
+
+	void CreateProjectAction(const std::string& name, ProjectTransitionContext context)
+	{
+		Ludus::Editor::Persistence::ProjectPaths::EnsureProjectsRootExists();
+
+		const auto projectRoot = Ludus::Editor::Persistence::ProjectPaths::ProjectRoot(name);
+		CreateProject(
+			projectRoot,
+			name,
+			context.Shell.State.PendingProjectTransition,
+			context.ScenePersistence,
+			context.RuntimeManifestPersistence,
+			context.RuntimeLaunchSettingsPersistence,
+			context.ProjectManifestPersistence
+		);
+
+		RefreshContentPanel(projectRoot, context);
+	}
+
+	void CreateProjectAsAction(const std::filesystem::path& path, const std::string& name, ProjectTransitionContext context)
+	{
+		Ludus::Editor::Persistence::ProjectPaths::EnsureProjectsRootExists();
+
+		CreateProject(
+			path,
+			name,
+			context.Shell.State.PendingProjectTransition,
+			context.ScenePersistence,
+			context.RuntimeManifestPersistence,
+			context.RuntimeLaunchSettingsPersistence,
+			context.ProjectManifestPersistence
+		);
+
+		RefreshContentPanel(path, context);
+	}
+
+	void OpenProjectAction(const std::filesystem::path& path, ProjectTransitionContext context)
+	{
+		auto projectManifest = context.ProjectManifestPersistence.Load(path);
+		const auto projectRoot = projectManifest.ProjectRoot;
+		context.Shell.State.PendingProjectTransition = Ludus::Editor::Core::PendingProjectTransition::OpenProject({ std::move(projectManifest) });
+
+		RefreshContentPanel(projectRoot, context);
+	}
+
+	void CloseProjectAction(ProjectSessionCommandContext& context)
+	{
+		context.Shell.State.PendingProjectTransition = Ludus::Editor::Core::PendingProjectTransition::CloseProject();
+
+		Ludus::Editor::Panels::ClearConsolePanel(context.PanelRegistry);
+	}
+
+	void SaveProjectAction(ProjectSessionCommandContext& context)
+	{
+		auto& editorState = context.ProjectSession.EditorState;
+		if (!editorState.HasUnsavedChanges())
+		{
+			return;
+		}
+
+		if (editorState.IsSceneDirty())
+		{
+			if (!editorState.ActiveSceneHasSavePath())
+			{
+				LUDUS_LOG_WARN("The project cannot be saved with the active scene missing a save path.");
+				return;
+			}
+
+			const auto& scene = context.ProjectSession.RuntimeState.GetEditorScene(editorState.GetActiveSceneId());
+			if (Ludus::Editor::Core::SceneQueries::ContainsUnresolvedScriptReferences(
+				scene,
+				context.ProjectSession.Persistence.GetRuntimeManifest()
+			))
+			{
+				LUDUS_LOG_WARN("The project cannot be saved while the active editor scene contains unresolved script references.");
+				return;
+			}
+
+			const auto activeSceneId = editorState.GetActiveSceneId();
+			context.ScenePersistence.Save(
+				context.ProjectSession.RuntimeState.GetEditorScene(activeSceneId),
+				editorState.GetActiveSceneSavePath()
+			);
+
+			editorState.SetSceneDirty(false);
+		}
+
+		auto& persistence = context.ProjectSession.Persistence;
+
+		if (editorState.IsProjectManifestDirty())
+		{
+			context.ProjectManifestPersistence.Save(
+				persistence.GetProjectManifest(),
+				persistence.GetProjectManifestPath()
+			);
+
+			editorState.SetProjectManifestDirty(false);
+		}
+
+		if (editorState.IsRuntimeManifestDirty())
+		{
+			context.RuntimeManifestPersistence.Save(
+				persistence.GetRuntimeManifest(),
+				persistence.GetRuntimeManifestPath()
+			);
+
+			editorState.SetRuntimeManifestDirty(false);
+		}
+
+		if (editorState.IsRuntimeLaunchSettingsDirty())
+		{
+			context.RuntimeLaunchSettingsPersistence.Save(
+				persistence.GetRuntimeLaunchSettings(),
+				persistence.GetRuntimeLaunchSettingsPath()
+			);
+
+			editorState.SetRuntimeLaunchSettingsDirty(false);
+		}
+	}
+}

--- a/Editor/Source/Ludus/Editor/Commands/Requests/Projects.cpp
+++ b/Editor/Source/Ludus/Editor/Commands/Requests/Projects.cpp
@@ -1,290 +1,91 @@
 #include "pch.h"
 
-#include <filesystem>
-
 #include <Ludus/Editor/Commands/ProjectSessionCommandContext.h>
 #include <Ludus/Editor/Commands/RequestCommand.h>
+#include <Ludus/Editor/Commands/Requests/DeferredAction.h>
+#include <Ludus/Editor/Commands/Requests/ProjectActions.h>
 #include <Ludus/Editor/Commands/Requests/Projects.h>
+#include <Ludus/Editor/Commands/Requests/ProjectTransitionContext.h>
 #include <Ludus/Editor/Commands/StartupCommandContext.h>
-#include <Ludus/Editor/Core/PendingProjectTransition.h>
-#include <Ludus/Editor/Core/ProjectTemplates.h>
-#include <Ludus/Editor/Panels/PanelHelpers.h>
-#include <Ludus/Editor/Persistence/IProjectManifestPersistence.h>
-#include <Ludus/Editor/Persistence/ProjectPaths.h>
-#include <Ludus/Engine/Debug/Debug.h>
-#include <Ludus/Engine/Persistence/IRuntimeLaunchSettingsPersistence.h>
-#include <Ludus/Engine/Persistence/IRuntimeManifestPersistence.h>
-#include <Ludus/Engine/Persistence/IScenePersistence.h>
-#include <Ludus/Engine/Runtime/RuntimeLaunchSettings.h>
-#include <Ludus/Engine/Runtime/RuntimeManifest.h>
 
 namespace Ludus::Editor::Commands::Requests::Projects
 {
 	namespace
 	{
-		bool HasUnresolvedScriptReferences(
-			const Ludus::Engine::Core::Scene& scene,
-			const Ludus::Engine::Runtime::RuntimeManifest& runtimeManifest
-		)
+		ProjectTransitionContext MakeProjectTransitionContext(StartupCommandContext& context)
 		{
-			for (const auto& script : scene.EntityComponentSystem.Scripts.View())
-			{
-				if (!runtimeManifest.TryGetScriptReference(script.Id))
-				{
-					return true;
-				}
-			}
-
-			return false;
-		}
-
-		bool CanSaveActiveEditorScene(ProjectSessionCommandContext& context)
-		{
-			const auto activeSceneId = context.ProjectSession.EditorState.GetActiveSceneId();
-			const auto& editorScene = context.ProjectSession.RuntimeState.GetEditorScene(activeSceneId);
-			const auto& runtimeManifest = context.ProjectSession.Persistence.GetRuntimeManifest();
-			if (HasUnresolvedScriptReferences(editorScene, runtimeManifest))
-			{
-				LUDUS_LOG_WARN("The project cannot be saved while the active editor scene contains unresolved script references.");
-				return false;
-			}
-
-			return true;
-		}
-
-		bool CanTransitionProject(ProjectSessionCommandContext& context, std::string_view action)
-		{
-			if (!context.ProjectSession.EditorState.HasUnsavedChanges())
-			{
-				return true;
-			}
-
-			LUDUS_LOG_WARN(std::string(action) + " cannot be executed while the project has unsaved changes.");
-			return false;
-		}
-
-		void CreateProject(
-			const std::filesystem::path& projectRoot,
-			std::string_view projectName,
-			Ludus::Editor::Core::PendingProjectTransition& pendingProjectTransition,
-			Ludus::Engine::Persistence::IScenePersistence& scenePersistence,
-			Ludus::Engine::Persistence::IRuntimeManifestPersistence& runtimeManifestPersistence,
-			Ludus::Engine::Persistence::IRuntimeLaunchSettingsPersistence& runtimeLaunchSettingsPersistence,
-			Ludus::Editor::Persistence::IProjectManifestPersistence& projectManifestPersistence
-		)
-		{
-			Ludus::Editor::Persistence::ProjectPaths::EnsureProjectLayoutExists(projectRoot);
-
-			// Create default scene.
-			const auto scene = Ludus::Editor::Core::ProjectTemplates::CreateDefaultScene();
-			const auto scenePath = Ludus::Editor::Persistence::ProjectPaths::SceneFile(projectRoot, scene.Name);
-			scenePersistence.Save(
-				scene,
-				scenePath
-			);
-
-			// Create runtime manifest.
-			const auto runtimeManifest = Ludus::Engine::Runtime::RuntimeManifest::Create(
-				scene.Id,
-				{ { scene.Id, scene.Name, scenePath } },
-				{ }
-			);
-			const auto runtimeManifestPath = Ludus::Engine::Persistence::Paths::RuntimeManifestFile(projectRoot, projectName);
-			runtimeManifestPersistence.Save(
-				runtimeManifest,
-				runtimeManifestPath
-			);
-
-			// Create runtime settings.
-			const auto runtimeLaunchSettings = Ludus::Engine::Runtime::RuntimeLaunchSettings();
-			const auto runtimeLaunchSettingsPath = Ludus::Engine::Persistence::Paths::RuntimeLaunchSettingsFile(projectRoot, projectName);
-			runtimeLaunchSettingsPersistence.Save(
-				runtimeLaunchSettings,
-				runtimeLaunchSettingsPath
-			);
-
-			// Create project manifest.
-			const auto projectManifest = Ludus::Editor::Core::ProjectManifest::Create(
-				projectRoot,
-				runtimeManifestPath
-			);
-			projectManifestPersistence.Save(
-				projectManifest,
-				Ludus::Editor::Persistence::ProjectPaths::ProjectManifestFile(projectRoot, projectName)
-			);
-
-			// Set pending project.
-			pendingProjectTransition = Ludus::Editor::Core::PendingProjectTransition::OpenProject({ projectManifest });
+			return {
+				.Shell = context.Shell,
+				.ScenePersistence = context.ScenePersistence,
+				.RuntimeManifestPersistence = context.RuntimeManifestPersistence,
+				.RuntimeLaunchSettingsPersistence = context.RuntimeLaunchSettingsPersistence,
+				.ProjectManifestPersistence = context.ProjectManifestPersistence,
+				.PanelRegistry = context.PanelRegistry
+			};
 		}
 	}
 
 	void CreateProject(const RequestCommand::CreateProject& command, StartupCommandContext& context)
 	{
-		Ludus::Editor::Persistence::ProjectPaths::EnsureProjectsRootExists();
-		const auto projectRoot = Ludus::Editor::Persistence::ProjectPaths::ProjectRoot(command.Name);
-		CreateProject(
-			projectRoot,
-			command.Name,
-			context.Shell.State.PendingProjectTransition,
-			context.ScenePersistence,
-			context.RuntimeManifestPersistence,
-			context.RuntimeLaunchSettingsPersistence,
-			context.ProjectManifestPersistence
-		);
-
-		Ludus::Editor::Panels::RefreshContentPanel(projectRoot, context.PanelRegistry);
+		CreateProjectAction(command.Name, MakeProjectTransitionContext(context));
 	}
 
 	void CreateProjectAs(const RequestCommand::CreateProjectAs& command, StartupCommandContext& context)
 	{
-		CreateProject(
-			command.ProjectRoot,
-			command.Name,
-			context.Shell.State.PendingProjectTransition,
-			context.ScenePersistence,
-			context.RuntimeManifestPersistence,
-			context.RuntimeLaunchSettingsPersistence,
-			context.ProjectManifestPersistence
-		);
-
-		Ludus::Editor::Panels::RefreshContentPanel(command.ProjectRoot, context.PanelRegistry);
+		CreateProjectAsAction(command.Path, command.Name, MakeProjectTransitionContext(context));
 	}
 
 	void OpenProject(const RequestCommand::OpenProject& command, StartupCommandContext& context)
 	{
-		auto projectManifest = context.ProjectManifestPersistence.Load(command.Path);
-		context.Shell.State.PendingProjectTransition = Ludus::Editor::Core::PendingProjectTransition::OpenProject({ projectManifest });
-
-		Ludus::Editor::Panels::RefreshContentPanel(projectManifest.ProjectRoot, context.PanelRegistry);
+		OpenProjectAction(command.Path, MakeProjectTransitionContext(context));
 	}
 
 	void CreateProject(const RequestCommand::CreateProject& command, ProjectSessionCommandContext& context)
 	{
-		if (!CanTransitionProject(context, "Create project"))
+		auto action = DeferredAction::CreateProject(command.Name);
+		if (TryOpenUnsavedChangesDialog(action, context))
 		{
 			return;
 		}
 
-		Ludus::Editor::Persistence::ProjectPaths::EnsureProjectsRootExists();
-		const auto projectRoot = Ludus::Editor::Persistence::ProjectPaths::ProjectRoot(command.Name);
-		CreateProject(
-			projectRoot,
-			command.Name,
-			context.Shell.State.PendingProjectTransition,
-			context.ScenePersistence,
-			context.RuntimeManifestPersistence,
-			context.RuntimeLaunchSettingsPersistence,
-			context.ProjectManifestPersistence
-		);
-
-		Ludus::Editor::Panels::RefreshContentPanel(projectRoot, context.PanelRegistry);
+		ExecuteDeferredAction(action, context);
 	}
 
 	void CreateProjectAs(const RequestCommand::CreateProjectAs& command, ProjectSessionCommandContext& context)
 	{
-		if (!CanTransitionProject(context, "Create project"))
+		auto action = DeferredAction::CreateProjectAs(command.Name, command.Path);
+		if (TryOpenUnsavedChangesDialog(action, context))
 		{
 			return;
 		}
 
-		CreateProject(
-			command.ProjectRoot,
-			command.Name,
-			context.Shell.State.PendingProjectTransition,
-			context.ScenePersistence,
-			context.RuntimeManifestPersistence,
-			context.RuntimeLaunchSettingsPersistence,
-			context.ProjectManifestPersistence
-		);
-
-		Ludus::Editor::Panels::RefreshContentPanel(command.ProjectRoot, context.PanelRegistry);
+		ExecuteDeferredAction(action, context);
 	}
 
 	void OpenProject(const RequestCommand::OpenProject& command, ProjectSessionCommandContext& context)
 	{
-		if (!CanTransitionProject(context, "Open project"))
+		auto action = DeferredAction::OpenProject(command.Path);
+		if (TryOpenUnsavedChangesDialog(action, context))
 		{
 			return;
 		}
 
-		auto projectManifest = context.ProjectManifestPersistence.Load(command.Path);
-		context.Shell.State.PendingProjectTransition = Ludus::Editor::Core::PendingProjectTransition::OpenProject({ projectManifest });
-
-		Ludus::Editor::Panels::RefreshContentPanel(projectManifest.ProjectRoot, context.PanelRegistry);
+		ExecuteDeferredAction(action, context);
 	}
 
 	void SaveProject(ProjectSessionCommandContext& context)
 	{
-		auto& editorState = context.ProjectSession.EditorState;
-		if (!editorState.HasUnsavedChanges())
-		{
-			return;
-		}
-
-		if (editorState.IsSceneDirty())
-		{
-			if (!editorState.ActiveSceneHasSavePath())
-			{
-				LUDUS_LOG_WARN("The project cannot be saved with the active scene missing a save path.");
-				return;
-			}
-
-			if (!CanSaveActiveEditorScene(context))
-			{
-				return;
-			}
-
-			const auto activeSceneId = editorState.GetActiveSceneId();
-			context.ScenePersistence.Save(
-				context.ProjectSession.RuntimeState.GetEditorScene(activeSceneId),
-				editorState.GetActiveSceneSavePath()
-			);
-
-			editorState.SetSceneDirty(false);
-		}
-
-		auto& persistence = context.ProjectSession.Persistence;
-
-		if (editorState.IsProjectManifestDirty())
-		{
-			context.ProjectManifestPersistence.Save(
-				persistence.GetProjectManifest(),
-				persistence.GetProjectManifestPath()
-			);
-
-			editorState.SetProjectManifestDirty(false);
-		}
-
-		if (editorState.IsRuntimeManifestDirty())
-		{
-			context.RuntimeManifestPersistence.Save(
-				persistence.GetRuntimeManifest(),
-				persistence.GetRuntimeManifestPath()
-			);
-
-			editorState.SetRuntimeManifestDirty(false);
-		}
-
-		if (editorState.IsRuntimeLaunchSettingsDirty())
-		{
-			context.RuntimeLaunchSettingsPersistence.Save(
-				persistence.GetRuntimeLaunchSettings(),
-				persistence.GetRuntimeLaunchSettingsPath()
-			);
-
-			editorState.SetRuntimeLaunchSettingsDirty(false);
-		}
+		SaveProjectAction(context);
 	}
 
 	void CloseProject(ProjectSessionCommandContext& context)
 	{
-		if (!CanTransitionProject(context, "Close project"))
+		auto action = DeferredAction::CloseProject();
+		if (TryOpenUnsavedChangesDialog(action, context))
 		{
 			return;
 		}
 
-		context.Shell.State.PendingProjectTransition = Ludus::Editor::Core::PendingProjectTransition::CloseProject();
-
-		Ludus::Editor::Panels::ClearConsolePanel(context.PanelRegistry);
+		ExecuteDeferredAction(action, context);
 	}
 }

--- a/Editor/Source/Ludus/Editor/Commands/Requests/SceneActions.cpp
+++ b/Editor/Source/Ludus/Editor/Commands/Requests/SceneActions.cpp
@@ -1,0 +1,176 @@
+#include "pch.h"
+
+#include <filesystem>
+
+#include <Ludus/Editor/Commands/ProjectSessionCommandContext.h>
+#include <Ludus/Editor/Commands/Requests/SceneActions.h>
+#include <Ludus/Editor/Core/ProjectTemplates.h>
+#include <Ludus/Editor/Core/SceneQueries.h>
+#include <Ludus/Editor/Panels/PanelHelpers.h>
+#include <Ludus/Editor/Persistence/ProjectPaths.h>
+#include <Ludus/Engine/Core/Id.h>
+
+namespace Ludus::Editor::Commands::Requests::Scenes
+{
+	namespace
+	{
+		void RefreshContentPanel(ProjectSessionCommandContext& context)
+		{
+			Ludus::Editor::Panels::RefreshContentPanel(
+				context.ProjectSession.Persistence.GetProjectRoot(),
+				context.PanelRegistry
+			);
+		}
+
+		std::filesystem::path RequireScenePath(
+			Ludus::Engine::Core::SceneId id,
+			ProjectSessionCommandContext& context
+		)
+		{
+			const auto scenePath = context.ProjectSession.Persistence.TryGetScenePath(id);
+			if (!scenePath)
+			{
+				throw std::runtime_error("No valid path was found for scene.");
+			}
+
+			return *scenePath;
+		}
+
+		void SaveSceneToPath(
+			ProjectSessionCommandContext& context,
+			Ludus::Engine::Core::SceneId id,
+			const std::filesystem::path& path
+		)
+		{
+			context.ScenePersistence.Save(context.ProjectSession.RuntimeState.GetEditorScene(id), path);
+		}
+
+		void SaveRuntimeManifest(ProjectSessionCommandContext& context)
+		{
+			context.RuntimeManifestPersistence.Save(
+				context.ProjectSession.Persistence.GetRuntimeManifest(),
+				context.ProjectSession.Persistence.GetRuntimeManifestPath()
+			);
+		}
+
+		void CommitSceneSave(
+			ProjectSessionCommandContext& context,
+			const std::filesystem::path& path
+		)
+		{
+			context.ProjectSession.EditorState.SetActiveSceneSavePath(path);
+			context.ProjectSession.EditorState.SetSceneDirty(false);
+
+			RefreshContentPanel(context);
+		}
+
+		void CommitRuntimeManifestSave(ProjectSessionCommandContext& context)
+		{
+			context.ProjectSession.EditorState.SetRuntimeManifestDirty(false);
+		}
+	}
+
+	void CreateSceneAction(ProjectSessionCommandContext& context)
+	{
+		auto scene = Ludus::Editor::Core::ProjectTemplates::CreateDefaultScene();
+		context.ProjectSession.SetActiveScene(std::move(scene));
+		context.ProjectSession.MarkActiveSceneDirty();
+	}
+
+	void CreateSceneAsAction(const std::filesystem::path& path, ProjectSessionCommandContext& context)
+	{
+		// Remove ".scene.ludus" to get the scene name.
+		const auto name = path.filename().stem().stem().string();
+		auto scene = Ludus::Editor::Core::ProjectTemplates::CreateDefaultScene(name);
+		context.ProjectSession.SetActiveScene(std::move(scene), path);
+		context.ProjectSession.MarkActiveSceneDirty();
+	}
+
+	void OpenSceneAction(const std::filesystem::path& path, ProjectSessionCommandContext& context)
+	{
+		auto scene = context.ScenePersistence.Load(path);
+		context.ProjectSession.SetActiveScene(std::move(scene), path);
+	}
+
+	void SaveSceneAction(Ludus::Engine::Core::SceneId sceneId, ProjectSessionCommandContext& context)
+	{
+		const auto& scene = context.ProjectSession.RuntimeState.GetEditorScene(sceneId);
+		if (Ludus::Editor::Core::SceneQueries::ContainsUnresolvedScriptReferences(
+			scene,
+			context.ProjectSession.Persistence.GetRuntimeManifest()
+		))
+		{
+			LUDUS_LOG_WARN("Scene cannot be saved while it contains unresolved script references.");
+			return;
+		}
+
+		const auto scenePath = RequireScenePath(sceneId, context);
+		SaveSceneToPath(context, sceneId, scenePath);
+		CommitSceneSave(context, scenePath);
+	}
+
+	void SaveSceneAsAction(
+		Ludus::Engine::Core::SceneId sceneId,
+		const std::filesystem::path& path,
+		ProjectSessionCommandContext& context
+	)
+	{
+		const auto& scene = context.ProjectSession.RuntimeState.GetEditorScene(sceneId);
+		if (Ludus::Editor::Core::SceneQueries::ContainsUnresolvedScriptReferences(
+			scene,
+			context.ProjectSession.Persistence.GetRuntimeManifest()
+		))
+		{
+			LUDUS_LOG_WARN("Scene cannot be saved while it contains unresolved script references.");
+			return;
+		}
+
+		context.ProjectSession.AddOrUpdateSceneReference(scene.Id, scene.Name, path);
+
+		// SaveSceneAs also persists the runtime manifest because the scene reference path has changed.
+		SaveSceneToPath(context, sceneId, path);
+		SaveRuntimeManifest(context);
+
+		CommitSceneSave(context, path);
+		CommitRuntimeManifestSave(context);
+	}
+
+	void RenameSceneAction(
+		Ludus::Engine::Core::SceneId sceneId,
+		const std::filesystem::path& path,
+		ProjectSessionCommandContext& context
+	)
+	{
+		auto& scene = context.ProjectSession.RuntimeState.GetEditorScene(sceneId);
+		if (Ludus::Editor::Core::SceneQueries::ContainsUnresolvedScriptReferences(
+			scene,
+			context.ProjectSession.Persistence.GetRuntimeManifest()
+		))
+		{
+			LUDUS_LOG_WARN("Scene cannot be saved while it contains unresolved script references.");
+			return;
+		}
+
+		const auto newName = Ludus::Editor::Persistence::ProjectPaths::SceneName(path);
+		const auto previousPath = context.ProjectSession.Persistence.TryGetScenePath(sceneId);
+
+		context.ProjectSession.AddOrUpdateSceneReference(scene.Id, newName, path);
+		scene.Name = newName;
+
+		// RenameScene also persists the runtime manifest because the scene reference path has changed.
+		SaveSceneToPath(context, sceneId, path);
+		SaveRuntimeManifest(context);
+
+		if (previousPath && *previousPath != path)
+		{
+			std::error_code errorCode;
+			if (!std::filesystem::remove(*previousPath, errorCode))
+			{
+				LUDUS_LOG_WARN("Failed to remove previous scene: " + errorCode.message());
+			}
+		}
+
+		CommitSceneSave(context, path);
+		CommitRuntimeManifestSave(context);
+	}
+}

--- a/Editor/Source/Ludus/Editor/Commands/Requests/Scenes.cpp
+++ b/Editor/Source/Ludus/Editor/Commands/Requests/Scenes.cpp
@@ -1,201 +1,58 @@
 #include "pch.h"
 
-#include <filesystem>
-#include <stdexcept>
-
 #include <Ludus/Editor/Commands/ProjectSessionCommandContext.h>
 #include <Ludus/Editor/Commands/RequestCommand.h>
+#include <Ludus/Editor/Commands/Requests/DeferredAction.h>
+#include <Ludus/Editor/Commands/Requests/SceneActions.h>
 #include <Ludus/Editor/Commands/Requests/Scenes.h>
-#include <Ludus/Editor/Core/ProjectTemplates.h>
-#include <Ludus/Editor/Panels/PanelHelpers.h>
-#include <Ludus/Editor/Persistence/ProjectPaths.h>
-#include <Ludus/Engine/Core/Id.h>
 
 namespace Ludus::Editor::Commands::Requests::Scenes
 {
-	namespace
-	{
-		bool CanOpenScene(ProjectSessionCommandContext& context)
-		{
-			if (!context.ProjectSession.EditorState.HasUnsavedChanges())
-			{
-				return true;
-			}
-
-			LUDUS_LOG_WARN("Open scene cannot be executed while the project has unsaved changes.");
-			return false;
-		}
-
-		bool HasUnresolvedScriptReferences(
-			const Ludus::Engine::Core::Scene& scene,
-			const Ludus::Engine::Runtime::RuntimeManifest& runtimeManifest
-		)
-		{
-			for (const auto& script : scene.EntityComponentSystem.Scripts.View())
-			{
-				if (!runtimeManifest.TryGetScriptReference(script.Id))
-				{
-					return true;
-				}
-			}
-
-			return false;
-		}
-
-		bool CanSaveScene(
-			ProjectSessionCommandContext& context,
-			Ludus::Engine::Core::SceneId id
-		)
-		{
-			const auto& scene = context.ProjectSession.RuntimeState.GetEditorScene(id);
-			const auto& runtimeManifest = context.ProjectSession.Persistence.GetRuntimeManifest();
-			if (HasUnresolvedScriptReferences(scene, runtimeManifest))
-			{
-				LUDUS_LOG_WARN("Scene cannot be saved while it contains unresolved script references.");
-				return false;
-			}
-
-			return true;
-		}
-
-		void RefreshContentPanel(ProjectSessionCommandContext& context)
-		{
-			Ludus::Editor::Panels::RefreshContentPanel(
-				context.ProjectSession.Persistence.GetProjectRoot(),
-				context.PanelRegistry
-			);
-		}
-
-		std::filesystem::path RequireScenePath(
-			Ludus::Engine::Core::SceneId id,
-			ProjectSessionCommandContext& context
-		)
-		{
-			const auto scenePath = context.ProjectSession.Persistence.TryGetScenePath(id);
-			if (!scenePath)
-			{
-				throw std::runtime_error("No valid path was found for scene.");
-			}
-
-			return *scenePath;
-		}
-
-		void SaveSceneToPath(
-			ProjectSessionCommandContext& context,
-			Ludus::Engine::Core::SceneId id,
-			const std::filesystem::path& path
-		)
-		{
-			context.ScenePersistence.Save(context.ProjectSession.RuntimeState.GetEditorScene(id), path);
-		}
-
-		void SaveRuntimeManifest(ProjectSessionCommandContext& context)
-		{
-			context.RuntimeManifestPersistence.Save(
-				context.ProjectSession.Persistence.GetRuntimeManifest(),
-				context.ProjectSession.Persistence.GetRuntimeManifestPath()
-			);
-		}
-
-		void CommitSceneSave(
-			ProjectSessionCommandContext& context,
-			const std::filesystem::path& path
-		)
-		{
-			context.ProjectSession.EditorState.SetActiveSceneSavePath(path);
-			context.ProjectSession.EditorState.SetSceneDirty(false);
-
-			RefreshContentPanel(context);
-		}
-
-		void CommitRuntimeManifestSave(ProjectSessionCommandContext& context)
-		{
-			context.ProjectSession.EditorState.SetRuntimeManifestDirty(false);
-		}
-	}
-
 	void CreateScene(ProjectSessionCommandContext& context)
 	{
-		auto scene = Ludus::Editor::Core::ProjectTemplates::CreateDefaultScene();
-		context.ProjectSession.SetActiveScene(std::move(scene));
-		context.ProjectSession.MarkActiveSceneDirty();
+		auto action = DeferredAction::CreateScene();
+		if (TryOpenUnsavedChangesDialog(action, context))
+		{
+			return;
+		}
+
+		ExecuteDeferredAction(action, context);
 	}
 
 	void CreateSceneAs(const RequestCommand::CreateSceneAs& command, ProjectSessionCommandContext& context)
 	{
-		auto scene = Ludus::Editor::Core::ProjectTemplates::CreateDefaultScene();
-		context.ProjectSession.SetActiveScene(std::move(scene), command.Path);
-		context.ProjectSession.MarkActiveSceneDirty();
+		auto action = DeferredAction::CreateSceneAs(command.Path);
+		if (TryOpenUnsavedChangesDialog(action, context))
+		{
+			return;
+		}
+
+		ExecuteDeferredAction(action, context);
 	}
 
 	void OpenScene(const RequestCommand::OpenScene& command, ProjectSessionCommandContext& context)
 	{
-		if (!CanOpenScene(context))
+		auto action = DeferredAction::OpenScene(command.Path);
+		if (TryOpenUnsavedChangesDialog(action, context))
 		{
 			return;
 		}
 
-		auto scene = context.ScenePersistence.Load(command.Path);
-		context.ProjectSession.SetActiveScene(std::move(scene), command.Path);
+		ExecuteDeferredAction(action, context);
 	}
 
 	void SaveScene(const RequestCommand::SaveScene& command, ProjectSessionCommandContext& context)
 	{
-		if (!CanSaveScene(context, command.SceneId))
-		{
-			return;
-		}
-
-		const auto scenePath = RequireScenePath(command.SceneId, context);
-		SaveSceneToPath(context, command.SceneId, scenePath);
-		CommitSceneSave(context, scenePath);
+		SaveSceneAction(command.SceneId, context);
 	}
 
 	void SaveSceneAs(const RequestCommand::SaveSceneAs& command, ProjectSessionCommandContext& context)
 	{
-		if (!CanSaveScene(context, command.SceneId))
-		{
-			return;
-		}
-
-		const auto& scene = context.ProjectSession.RuntimeState.GetEditorScene(command.SceneId);
-		context.ProjectSession.AddOrUpdateSceneReference(scene.Id, scene.Name, command.Path);
-
-		SaveSceneToPath(context, command.SceneId, command.Path);
-		// SaveSceneAs also persists the runtime manifest because the scene reference path changed.
-		SaveRuntimeManifest(context);
-		CommitSceneSave(context, command.Path);
-		CommitRuntimeManifestSave(context);
+		SaveSceneAsAction(command.SceneId, command.Path, context);
 	}
 
 	void RenameScene(const RequestCommand::RenameScene& command, ProjectSessionCommandContext& context)
 	{
-		if (!CanSaveScene(context, command.SceneId))
-		{
-			return;
-		}
-
-		auto& scene = context.ProjectSession.RuntimeState.GetEditorScene(command.SceneId);
-		const auto newName = Ludus::Editor::Persistence::ProjectPaths::SceneName(command.Path);
-		const auto previousPath = context.ProjectSession.Persistence.TryGetScenePath(command.SceneId);
-
-		context.ProjectSession.AddOrUpdateSceneReference(scene.Id, newName, command.Path);
-		scene.Name = newName;
-
-		SaveSceneToPath(context, command.SceneId, command.Path);
-		// RenameScene also persists the runtime manifest so scene references stay aligned with the renamed file.
-		SaveRuntimeManifest(context);
-
-		if (previousPath && *previousPath != command.Path)
-		{
-			std::error_code errorCode;
-			if (!std::filesystem::remove(*previousPath, errorCode))
-			{
-				LUDUS_LOG_WARN("Failed to remove previous scene: " + errorCode.message());
-			}
-		}
-
-		CommitSceneSave(context, command.Path);
-		CommitRuntimeManifestSave(context);
+		RenameSceneAction(command.SceneId, command.Path, context);
 	}
 }

--- a/Editor/Source/Ludus/Editor/Commands/UI/Dialogs.cpp
+++ b/Editor/Source/Ludus/Editor/Commands/UI/Dialogs.cpp
@@ -11,9 +11,12 @@
 #include <Ludus/Editor/Dialogs/CreateProjectDialog.h>
 #include <Ludus/Editor/Dialogs/DialogManager.h>
 #include <Ludus/Editor/Dialogs/RenameSceneDialog.h>
+#include <Ludus/Editor/Dialogs/UnsavedChangesDialog.h>
 #include <Ludus/Engine/Components/ScriptComponent.h>
 #include <Ludus/Engine/Core/Id.h>
+#include <Ludus/Engine/Debug/Debug.h>
 #include <Ludus/Engine/Persistence/Paths.h>
+#include <Ludus/Engine/Platform/Modals.h>
 
 namespace Ludus::Editor::Commands::UI::Dialogs
 {
@@ -38,12 +41,34 @@ namespace Ludus::Editor::Commands::UI::Dialogs
 		const auto scenePath = context.ProjectSession.Persistence.TryGetScenePath(command.SceneId);
 		if (!scenePath)
 		{
-			throw std::runtime_error("Scene does not have a path.");
+			// Unsaved scenes need a first-time Save As path before they can be renamed.
+			std::filesystem::path path;
+			if (Ludus::Engine::Platform::Modals::SaveFileDialog(
+				path,
+				"scene.ludus",
+				Ludus::Engine::Persistence::Paths::ScenesDirectory(context.ProjectSession.Persistence.GetProjectRoot()),
+				"Untitled"
+			))
+			{
+				context.Shell.State.Commands.AddRequestCommand(
+					Ludus::Editor::Commands::RequestCommand::SaveSceneAs { .SceneId = command.SceneId, .Path = path }
+				);
+			}
+
+			return;
 		}
 
 		Ludus::Editor::Dialogs::RenameSceneDialog dialog(
 			command.SceneId,
 			*scenePath
+		);
+		context.Shell.State.Dialogs.Open(dialog);
+	}
+
+	void OpenUnsavedChangesDialog(const UICommand::OpenUnsavedChangesDialog& command, ProjectSessionCommandContext& context)
+	{
+		Ludus::Editor::Dialogs::UnsavedChangesDialog dialog(
+			command.DeferredAction
 		);
 		context.Shell.State.Dialogs.Open(dialog);
 	}

--- a/Editor/Source/Ludus/Editor/Commands/UICommand.cpp
+++ b/Editor/Source/Ludus/Editor/Commands/UICommand.cpp
@@ -18,6 +18,7 @@ namespace Ludus::Editor::Commands
 			void operator()(const UICommand::OpenAddScriptDialog& command) const { UI::Dialogs::OpenAddScriptDialog(command, Context); }
 			void operator()(const UICommand::OpenCreateProjectDialog&) const { UI::Dialogs::OpenCreateProjectDialog(Context); }
 			void operator()(const UICommand::OpenRenameSceneDialog& command) const { UI::Dialogs::OpenRenameSceneDialog(command, Context); }
+			void operator()(const UICommand::OpenUnsavedChangesDialog& command) const { UI::Dialogs::OpenUnsavedChangesDialog(command, Context); }
 
 			template<typename T>
 			void operator()(T&& unhandled) const
@@ -33,6 +34,7 @@ namespace Ludus::Editor::Commands
 			void operator()(const UICommand::OpenAddScriptDialog&) const { LUDUS_ASSERT(false, "OpenAddScriptDialog is unavailable during startup."); }
 			void operator()(const UICommand::OpenCreateProjectDialog& command) const { UI::Dialogs::OpenCreateProjectDialog(Context); }
 			void operator()(const UICommand::OpenRenameSceneDialog&) const { LUDUS_ASSERT(false, "OpenRenameSceneDialog is unavailable during startup."); }
+			void operator()(const UICommand::OpenUnsavedChangesDialog&) const { LUDUS_ASSERT(false, "OpenUnsavedChangesDialog is unavailable during startup."); }
 
 			template<typename T>
 			void operator()(T&& unhandled) const

--- a/Editor/Source/Ludus/Editor/Core/EditorSession.cpp
+++ b/Editor/Source/Ludus/Editor/Core/EditorSession.cpp
@@ -27,12 +27,20 @@ namespace Ludus::Editor::Core
 	{
 		void ShutdownProjectSession(
 			Ludus::Engine::Runtime::IHostContext& hostContext,
+			Ludus::Editor::Core::ExecutionManager& execution,
 			std::optional<Ludus::Editor::Core::ProjectSession>& projectSession
 		)
 		{
 			if (!projectSession)
 			{
 				return;
+			}
+
+			// Ensure that any running simulation is stopped.
+			if (execution.ExecutionMode != Ludus::Editor::Core::ExecutionMode::Stop)
+			{
+				execution.ExecutionMode = Ludus::Editor::Core::ExecutionMode::Stop;
+				execution.Apply(hostContext.GetExecutionFlags(), Ludus::Editor::Core::ExecutionMode::Stop);
 			}
 
 			hostContext.DetachRuntime();
@@ -136,14 +144,14 @@ namespace Ludus::Editor::Core
 			}
 			else if constexpr (std::is_same_v<Alt, typename Ludus::Editor::Core::PendingProjectTransition::Close>)
 			{
-				ShutdownProjectSession(m_HostContext, out);
+				ShutdownProjectSession(m_HostContext, m_Shell.State.Execution, out);
 				m_Shell.State.Mode = Ludus::Editor::Core::EditorMode::Startup;
 				pendingTransition = Ludus::Editor::Core::PendingProjectTransition::NoneState();
 				m_HostContext.SetWindowTitle("Ludus Editor");
 			}
 			else if constexpr (std::is_same_v<Alt, typename Ludus::Editor::Core::PendingProjectTransition::Open>)
 			{
-				ShutdownProjectSession(m_HostContext, out);
+				ShutdownProjectSession(m_HostContext, m_Shell.State.Execution, out);
 				out = LoadProjectSession(value.ProjectManifest);
 				out->RuntimeState.AttachEditorRuntime(m_HostContext);
 

--- a/Editor/Source/Ludus/Editor/Core/EditorSystem.cpp
+++ b/Editor/Source/Ludus/Editor/Core/EditorSystem.cpp
@@ -1,7 +1,8 @@
 #include "pch.h"
 
-#include <memory>
+#include <stdexcept>
 #include <utility>
+#include <vector>
 
 #include <Ludus/Editor/Commands/EditCommand.h>
 #include <Ludus/Editor/Commands/ProjectSessionCommandContext.h>
@@ -10,11 +11,9 @@
 #include <Ludus/Editor/Commands/UICommand.h>
 #include <Ludus/Editor/Core/EditorExecutionFlags.h>
 #include <Ludus/Editor/Core/EditorSystem.h>
-#include <Ludus/Editor/Core/WelcomeWindow.h>
 #include <Ludus/Engine/Debug/Debug.h>
-#include <Ludus/Engine/Persistence/Paths.h>
-#include <Ludus/Engine/Runtime/IHostContext.h>
-#include <Ludus/Engine/Runtime/RuntimeInstanceBuilder.h>
+#include <Ludus/Engine/Events/Event.h>
+#include <Ludus/Engine/Events/EventType.h>
 
 namespace Ludus::Editor::Core
 {
@@ -145,7 +144,7 @@ namespace Ludus::Editor::Core
 
 		LUDUS_ASSERT(
 			m_Shell.State.Commands.PendingCommands.EditCommands.empty(),
-			"Edit commands cannot execute without an open project."
+			"Edit commands are only valid while a project session is active."
 		);
 	}
 
@@ -260,13 +259,29 @@ namespace Ludus::Editor::Core
 
 	void Ludus::Editor::Core::EditorSystem::OnAttachImpl()
 	{
+		m_HostContext.SubscribeWindowCloseEvent(*this);
 		ApplyStartupOptions();
 		RegisterPanels();
 	}
 
 	void Ludus::Editor::Core::EditorSystem::OnDetachImpl()
 	{
+		m_HostContext.UnsubscribeWindowCloseEvent(*this);
 		m_PanelRegistry.Clear();
+	}
+
+	bool EditorSystem::ProcessEvent(const Ludus::Engine::Events::Event& event)
+	{
+		if (event.Type != Ludus::Engine::Events::EventType::WindowCloseEvent)
+		{
+			return false;
+		}
+
+		m_Shell.State.Commands.AddRequestCommand(
+			Ludus::Editor::Commands::RequestCommand::CloseApplication { }
+		);
+
+		return true;
 	}
 
 	void EditorSystem::UpdateStartup()

--- a/Editor/Source/Ludus/Editor/Core/WelcomeWindow.cpp
+++ b/Editor/Source/Ludus/Editor/Core/WelcomeWindow.cpp
@@ -5,8 +5,10 @@
 #include <Ludus/Editor/Commands/RequestCommand.h>
 #include <Ludus/Editor/Commands/UICommand.h>
 #include <Ludus/Editor/Core/Constants.h>
+#include <Ludus/Editor/Core/ProjectManifest.h>
 #include <Ludus/Editor/Core/WelcomeWindow.h>
 #include <Ludus/Editor/Persistence/ProjectPaths.h>
+#include <Ludus/Engine/Core/Version.h>
 #include <Ludus/Engine/Math/Vector2D.h>
 #include <Ludus/Engine/Platform/Modals.h>
 #include <Ludus/UI/Context/LayoutContext.h>
@@ -79,7 +81,9 @@ namespace Ludus::Editor::Core
 
 		const std::string title = "LUDUS";
 		const std::string subtitle = "Create or open a project";
-		const std::string version = "v0.2.0";
+		const std::string version = Ludus::Engine::Core::Version::ToString(
+			Ludus::Editor::Core::ProjectManifest::CurrentVersion
+		);
 		const auto buttonSize = Ludus::Editor::Core::Constants::WelcomeActionButtonSize;
 
 		const auto centerTextAtY = [&](const std::string& text, float y)

--- a/Editor/Source/Ludus/Editor/Dialogs/AddScriptDialog.cpp
+++ b/Editor/Source/Ludus/Editor/Dialogs/AddScriptDialog.cpp
@@ -33,57 +33,57 @@ namespace Ludus::Editor::Dialogs
 		std::vector<std::string> scriptNames,
 		std::vector<Ludus::Engine::Runtime::ScriptReference> scriptReferences
 	) :
-		SceneId(sceneId),
-		EntityId(entityId),
-		ScriptNames(std::move(scriptNames)),
-		ScriptReferences(std::move(scriptReferences))
+		m_SceneId(sceneId),
+		m_EntityId(entityId),
+		m_ScriptNames(std::move(scriptNames)),
+		m_ScriptReferences(std::move(scriptReferences))
 	{ }
 
 	AddScriptDialog::Outcome AddScriptDialog::Draw()
 	{
 		const auto popupLabel = Ludus::UI::CreateLabel("Add Script", "Add Script");
 
-		if (JustOpened)
+		if (m_JustOpened)
 		{
-			if (ScriptNames.empty())
+			if (m_ScriptNames.empty())
 			{
-				SelectName = "None";
-				ScriptNames.push_back(SelectName);
+				m_SelectName = "None";
+				m_ScriptNames.push_back(m_SelectName);
 			}
 			else
 			{
-				SelectName = ScriptNames[0];
+				m_SelectName = m_ScriptNames[0];
 			}
 
 			Ludus::Editor::Dialogs::CenterNextDialogOnMousePosition();
 			Ludus::UI::Context::PopupContext::OpenPopup(popupLabel.c_str(), Ludus::UI::Flags::Popup::None);
-			JustOpened = false;
+			m_JustOpened = false;
 		}
 
-		if (Ludus::UI::Scope::PopupModalScope dialogScope(popupLabel.c_str(), &IsOpen, Ludus::UI::Flags::Window::AlwaysAutoResize); dialogScope)
+		if (Ludus::UI::Scope::PopupModalScope dialogScope(popupLabel.c_str(), &m_IsOpen, Ludus::UI::Flags::Window::AlwaysAutoResize); dialogScope)
 		{
 			if (Ludus::UI::Scope::TabBarScope tabBarScope("##TabBar"); tabBarScope)
 			{
 				if (Ludus::UI::Scope::TabItemScope createTabItemScope("Create##Create_TabItem", nullptr); createTabItemScope)
 				{
-					ActiveTab = AddScriptTab::Create;
+					m_ActiveTab = AddScriptTab::Create;
 
 					Ludus::UI::Widgets::TextUnformatted("Create");
-					Ludus::UI::Widgets::InputText("##CreateName", CreateName);
+					Ludus::UI::Widgets::InputText("##CreateName", m_CreateName);
 
-					if (!Error.empty())
+					if (!m_Error.empty())
 					{
-						Ludus::UI::Widgets::TextUnformattedColor(Error.c_str(), Ludus::UI::Context::ThemeContext::Error());
+						Ludus::UI::Widgets::TextUnformattedColor(m_Error.c_str(), Ludus::UI::Context::ThemeContext::Error());
 					}
 				}
 
 				if (Ludus::UI::Scope::TabItemScope selectTabItemScope("Select##Select_TabItem", nullptr); selectTabItemScope)
 				{
-					ActiveTab = AddScriptTab::Select;
-					Error.clear();
+					m_ActiveTab = AddScriptTab::Select;
+					m_Error.clear();
 
 					auto currentIndex = -1;
-					auto names = Ludus::UI::Widgets::GetCStringItems(ScriptNames, [](const std::string& item)
+					auto names = Ludus::UI::Widgets::GetCStringItems(m_ScriptNames, [](const std::string& item)
 					{
 						return item.c_str();
 					});
@@ -93,7 +93,7 @@ namespace Ludus::Editor::Dialogs
 						for (auto i = 0; i < static_cast<int>(names.size()); i++)
 						{
 							const auto& name = names[static_cast<size_t>(i)];
-							if (std::string(name) == SelectName)
+							if (std::string(name) == m_SelectName)
 							{
 								currentIndex = i;
 								break;
@@ -108,10 +108,10 @@ namespace Ludus::Editor::Dialogs
 					}
 
 					Ludus::UI::Widgets::TextUnformatted("Select");
-					Ludus::UI::Scope::DisabledScope disabled(ActiveTab == AddScriptTab::Select && SelectName == "None");
+					Ludus::UI::Scope::DisabledScope disabled(m_ActiveTab == AddScriptTab::Select && m_SelectName == "None");
 					if (Ludus::UI::Widgets::Combo("##Select_Combo", &currentIndex, names))
 					{
-						SelectName = ScriptNames[currentIndex];
+						m_SelectName = m_ScriptNames[currentIndex];
 					}
 				}
 			}
@@ -120,35 +120,35 @@ namespace Ludus::Editor::Dialogs
 
 			{
 				Ludus::UI::Scope::DisabledScope disabled(
-					ActiveTab == AddScriptTab::Create && CreateName.empty() ||
-					ActiveTab == AddScriptTab::Select && SelectName == "None"
+					m_ActiveTab == AddScriptTab::Create && m_CreateName.empty() ||
+					m_ActiveTab == AddScriptTab::Select && m_SelectName == "None"
 				);
 
 				if (Ludus::UI::Widgets::Button("Create", Ludus::Editor::Core::Constants::ModalActionButtonSize))
 				{
-					if (ActiveTab == AddScriptTab::Create)
+					if (m_ActiveTab == AddScriptTab::Create)
 					{
-						Error = Ludus::Editor::Persistence::ProjectPaths::ValidateFileName(CreateName);
-						if (Error.empty())
+						m_Error = Ludus::Editor::Persistence::ProjectPaths::ValidateFileName(m_CreateName);
+						if (m_Error.empty())
 						{
-							for (const auto& scriptReference : ScriptReferences)
+							for (const auto& scriptReference : m_ScriptReferences)
 							{
-								if (scriptReference.Name == CreateName)
+								if (scriptReference.Name == m_CreateName)
 								{
-									Error = "Script already exists.";
+									m_Error = "Script already exists.";
 									break;
 								}
 							}
 						}
 
-						if (!Error.empty())
+						if (!m_Error.empty())
 						{
 							return Outcome::NoneState();
 						}
 					}
 
-					IsOpen = false;
-					return Outcome::Confirm(ActiveTab == AddScriptTab::Create ? CreateName : SelectName);
+					m_IsOpen = false;
+					return Outcome::Confirm(m_ActiveTab == AddScriptTab::Create ? m_CreateName : m_SelectName);
 				}
 			}
 
@@ -156,10 +156,10 @@ namespace Ludus::Editor::Dialogs
 
 			if (Ludus::UI::Widgets::Button("Cancel", Ludus::Editor::Core::Constants::ModalActionButtonSize))
 			{
-				CreateName.clear();
-				SelectName.clear();
-				ScriptNames.clear();
-				IsOpen = false;
+				m_CreateName.clear();
+				m_SelectName.clear();
+				m_ScriptNames.clear();
+				m_IsOpen = false;
 
 				return Outcome::Cancel();
 			}
@@ -186,15 +186,15 @@ namespace Ludus::Editor::Dialogs
 			}
 			else if constexpr (std::is_same_v<Alt, typename Outcome::Confirmed>)
 			{
-				if (ActiveTab == AddScriptTab::Create)
+				if (m_ActiveTab == AddScriptTab::Create)
 				{
 					out.RequestCommands.emplace_back(
-						Ludus::Editor::Commands::RequestCommand::CreateScript { SceneId, EntityId, value.Payload }
+						Ludus::Editor::Commands::RequestCommand::CreateScript { m_SceneId, m_EntityId, value.Payload }
 					);
 					return;
 				}
 
-				for (const auto& scriptReference : ScriptReferences)
+				for (const auto& scriptReference : m_ScriptReferences)
 				{
 					if (scriptReference.Name != value.Payload)
 					{
@@ -203,7 +203,7 @@ namespace Ludus::Editor::Dialogs
 
 					out.EditCommands.emplace_back(
 						Ludus::Editor::Commands::EditCommand::AddComponent<Ludus::Engine::Components::ScriptComponent> {
-						.SceneId = SceneId, .EntityReference = EntityId, .Init = Ludus::Engine::Components::ScriptComponent { scriptReference.Id }
+						.SceneId = m_SceneId, .EntityReference = m_EntityId, .Init = Ludus::Engine::Components::ScriptComponent { scriptReference.Id }
 					});
 					return;
 				}
@@ -213,6 +213,6 @@ namespace Ludus::Editor::Dialogs
 
 	bool AddScriptDialog::ShouldClose(const Outcome&) const
 	{
-		return !IsOpen;
+		return !m_IsOpen;
 	}
 }

--- a/Editor/Source/Ludus/Editor/Dialogs/RenameSceneDialog.cpp
+++ b/Editor/Source/Ludus/Editor/Dialogs/RenameSceneDialog.cpp
@@ -20,45 +20,45 @@
 namespace Ludus::Editor::Dialogs
 {
 	RenameSceneDialog::RenameSceneDialog(Ludus::Engine::Core::SceneId sceneId, std::filesystem::path currentPath)
-		: SceneId(sceneId), CurrentPath(currentPath)
+		: m_SceneId(sceneId), m_CurrentPath(currentPath)
 	{ }
 
 	RenameSceneDialog::Outcome RenameSceneDialog::Draw()
 	{
 		const auto popupLabel = Ludus::UI::CreateLabel("Rename Scene", "Rename Scene");
 
-		if (JustOpened)
+		if (m_JustOpened)
 		{
 			Ludus::Editor::Dialogs::CenterNextDialogOnMousePosition();
 			Ludus::UI::Context::PopupContext::OpenPopup(popupLabel.c_str(), Ludus::UI::Flags::Popup::None);
-			JustOpened = false;
+			m_JustOpened = false;
 		}
 
-		if (Ludus::UI::Scope::PopupModalScope dialogScope(popupLabel.c_str(), &IsOpen, Ludus::UI::Flags::Window::AlwaysAutoResize); dialogScope)
+		if (Ludus::UI::Scope::PopupModalScope dialogScope(popupLabel.c_str(), &m_IsOpen, Ludus::UI::Flags::Window::AlwaysAutoResize); dialogScope)
 		{
 			Ludus::UI::Widgets::TextUnformatted("Please write a new scene name:");
-			if (Ludus::UI::Widgets::InputText("##NewScene", Name))
+			if (Ludus::UI::Widgets::InputText("##NewScene", m_Name))
 			{
-				NewPath = Ludus::Editor::Persistence::ProjectPaths::SceneFileInDirectory(CurrentPath.parent_path(), Name);
+				m_NewPath = Ludus::Editor::Persistence::ProjectPaths::SceneFileInDirectory(m_CurrentPath.parent_path(), m_Name);
 			}
 
-			if (!Error.empty())
+			if (!m_Error.empty())
 			{
-				Ludus::UI::Widgets::TextUnformattedColor(Error.c_str(), Ludus::UI::Context::ThemeContext::Error());
+				Ludus::UI::Widgets::TextUnformattedColor(m_Error.c_str(), Ludus::UI::Context::ThemeContext::Error());
 			}
 
 			if (Ludus::UI::Widgets::Button("Rename", Ludus::Editor::Core::Constants::ModalActionButtonSize))
 			{
-				Error = Ludus::Editor::Persistence::ProjectPaths::ValidateFileName(Name);
-				if (Error.empty())
+				m_Error = Ludus::Editor::Persistence::ProjectPaths::ValidateFileName(m_Name);
+				if (m_Error.empty())
 				{
-					Error = Ludus::Editor::Persistence::ProjectPaths::ValidateAvailablePath(NewPath);
+					m_Error = Ludus::Editor::Persistence::ProjectPaths::ValidateAvailablePath(m_NewPath);
 				}
 
-				if (Error.empty())
+				if (m_Error.empty())
 				{
-					IsOpen = false;
-					return Outcome::Confirm({ .SceneId = SceneId, .Path = NewPath });
+					m_IsOpen = false;
+					return Outcome::Confirm({ .SceneId = m_SceneId, .Path = m_NewPath });
 				}
 			}
 
@@ -66,8 +66,8 @@ namespace Ludus::Editor::Dialogs
 
 			if (Ludus::UI::Widgets::Button("Cancel", Ludus::Editor::Core::Constants::ModalActionButtonSize))
 			{
-				Name.clear();
-				IsOpen = false;
+				m_Name.clear();
+				m_IsOpen = false;
 				return Outcome::Cancel();
 			}
 
@@ -102,6 +102,6 @@ namespace Ludus::Editor::Dialogs
 
 	bool RenameSceneDialog::ShouldClose(const Outcome&) const
 	{
-		return !IsOpen;
+		return !m_IsOpen;
 	}
 }

--- a/Editor/Source/Ludus/Editor/Dialogs/UnsavedChangesDialog.cpp
+++ b/Editor/Source/Ludus/Editor/Dialogs/UnsavedChangesDialog.cpp
@@ -1,25 +1,30 @@
 #include "pch.h"
 
 #include <type_traits>
+#include <utility>
 
+#include <Ludus/Editor/Commands/Requests/DeferredAction.h>
 #include <Ludus/Editor/Core/Constants.h>
-#include <Ludus/Editor/Dialogs/CreateProjectDialog.h>
 #include <Ludus/Editor/Dialogs/DialogHelpers.h>
-#include <Ludus/Editor/Persistence/ProjectPaths.h>
+#include <Ludus/Editor/Dialogs/UnsavedChangesDialog.h>
 #include <Ludus/UI/Context/LayoutContext.h>
 #include <Ludus/UI/Context/PopupContext.h>
-#include <Ludus/UI/Context/ThemeContext.h>
 #include <Ludus/UI/Labels.h>
 #include <Ludus/UI/Scope/ModalScope.h>
 #include <Ludus/UI/Widgets/Buttons.h>
-#include <Ludus/UI/Widgets/Input.h>
 #include <Ludus/UI/Widgets/Text.h>
 
 namespace Ludus::Editor::Dialogs
 {
-	CreateProjectDialog::Outcome CreateProjectDialog::Draw()
+	UnsavedChangesDialog::UnsavedChangesDialog(
+		Ludus::Editor::Commands::Requests::DeferredAction deferredAction
+	) :
+		m_DeferredAction(std::move(deferredAction))
+	{ }
+
+	UnsavedChangesDialog::Outcome UnsavedChangesDialog::Draw()
 	{
-		const auto popupLabel = Ludus::UI::CreateLabel("Create Project", "Create Project");
+		const auto popupLabel = Ludus::UI::CreateLabel("Unsaved Changes", "Unsaved Changes");
 
 		if (m_JustOpened)
 		{
@@ -30,38 +35,28 @@ namespace Ludus::Editor::Dialogs
 
 		if (Ludus::UI::Scope::PopupModalScope dialogScope(popupLabel.c_str(), &m_IsOpen, Ludus::UI::Flags::Window::AlwaysAutoResize); dialogScope)
 		{
-			const auto projectDirectory = Ludus::Editor::Persistence::ProjectPaths::ProjectRoot(m_Name);
+			Ludus::UI::Widgets::TextUnformatted("Save changes?");
 
-			Ludus::UI::Widgets::TextUnformatted("Please write a project name:");
-			Ludus::UI::Widgets::InputText("##NewProjectName", m_Name);
-
-			if (!m_Error.empty())
+			if (Ludus::UI::Widgets::Button("Save", Ludus::Editor::Core::Constants::ModalActionButtonSize))
 			{
-				Ludus::UI::Widgets::TextUnformattedColor(m_Error.c_str(), Ludus::UI::Context::ThemeContext::Error());
+				m_IsOpen = false;
+				return Outcome::Confirm(UnsavedChangesResult::Save);
 			}
 
-			if (Ludus::UI::Widgets::Button("Create", Ludus::Editor::Core::Constants::ModalActionButtonSize))
-			{
-				m_Error = Ludus::Editor::Persistence::ProjectPaths::ValidateFileName(m_Name);
-				if (m_Error.empty())
-				{
-					m_Error = Ludus::Editor::Persistence::ProjectPaths::ValidateAvailablePath(projectDirectory);
-				}
+			Ludus::UI::Context::LayoutContext::SameLine(0.0f, Ludus::Editor::Core::Constants::StandardInlineSpacing);
 
-				if (m_Error.empty())
-				{
-					m_IsOpen = false;
-					return Outcome::Confirm(m_Name);
-				}
+			if (Ludus::UI::Widgets::Button("Don't save", Ludus::Editor::Core::Constants::ModalActionButtonSize))
+			{
+				m_IsOpen = false;
+				return Outcome::Confirm(UnsavedChangesResult::DontSave);
 			}
 
 			Ludus::UI::Context::LayoutContext::SameLine(0.0f, Ludus::Editor::Core::Constants::StandardInlineSpacing);
 
 			if (Ludus::UI::Widgets::Button("Cancel", Ludus::Editor::Core::Constants::ModalActionButtonSize))
 			{
-				m_Name.clear();
 				m_IsOpen = false;
-				return Outcome::Cancel();
+				return Outcome::Confirm(UnsavedChangesResult::Cancel);
 			}
 
 			return Outcome::NoneState();
@@ -70,7 +65,7 @@ namespace Ludus::Editor::Dialogs
 		return Outcome::NoneState();
 	}
 
-	void CreateProjectDialog::Resolve(const Outcome& outcome, Ludus::Editor::Commands::CommandSet& out)
+	void UnsavedChangesDialog::Resolve(const Outcome& outcome, Ludus::Editor::Commands::CommandSet& out)
 	{
 		std::visit([&](auto&& value)
 		{
@@ -87,13 +82,13 @@ namespace Ludus::Editor::Dialogs
 			else if constexpr (std::is_same_v<Alt, typename Outcome::Confirmed>)
 			{
 				out.RequestCommands.emplace_back(
-					Ludus::Editor::Commands::RequestCommand::CreateProject { value.Payload }
+					Ludus::Editor::Commands::RequestCommand::ResolveUnsavedChanges { .DeferredAction = m_DeferredAction, .Result = value.Payload }
 				);
 			}
 		}, outcome.Data);
 	}
 
-	bool CreateProjectDialog::ShouldClose(const Outcome&) const
+	bool UnsavedChangesDialog::ShouldClose(const Outcome&) const
 	{
 		return !m_IsOpen;
 	}

--- a/Editor/Source/Ludus/Editor/Panels/DockPanel.cpp
+++ b/Editor/Source/Ludus/Editor/Panels/DockPanel.cpp
@@ -173,13 +173,6 @@ namespace Ludus::Editor::Panels
 
 				if (Ludus::UI::Widgets::MenuItem("Close Project"))
 				{
-					if (context.Shell.State.Execution.ExecutionMode != Ludus::Editor::Core::ExecutionMode::Stop)
-					{
-						context.Shell.State.Commands.AddRequestCommand(
-							Ludus::Editor::Commands::RequestCommand::SetExecutionMode { Ludus::Editor::Core::ExecutionMode::Stop }
-						);
-					}
-
 					context.Shell.State.Commands.AddRequestCommand(Ludus::Editor::Commands::RequestCommand::CloseProject { });
 				}
 			}

--- a/Engine/Include/Ludus/Engine/Core/Version.h
+++ b/Engine/Include/Ludus/Engine/Core/Version.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <cstdint>
+#include <format>
+#include <string>
 
 namespace Ludus::Engine::Core
 {
@@ -9,5 +11,10 @@ namespace Ludus::Engine::Core
 		uint32_t Major;
 		uint32_t Minor;
 		uint32_t Patch;
+
+		static std::string ToString(Version version)
+		{
+			return std::format("v.{}.{}.{}", version.Major, version.Minor, version.Patch);
+		}
 	};
 }

--- a/Engine/Include/Ludus/Engine/Runtime/ApplicationHost.h
+++ b/Engine/Include/Ludus/Engine/Runtime/ApplicationHost.h
@@ -82,7 +82,11 @@ namespace Ludus::Engine::Runtime
 
 		virtual Ludus::Engine::Core::FlagSet& GetExecutionFlags() override;
 
+		virtual void SetWindowShouldClose() override;
 		virtual void SetWindowTitle(std::string_view title) override;
+
+		virtual void SubscribeWindowCloseEvent(Ludus::Engine::Events::EventHandler& handler) override;
+		virtual void UnsubscribeWindowCloseEvent(Ludus::Engine::Events::EventHandler& handler) override;
 
 #pragma endregion
 

--- a/Engine/Include/Ludus/Engine/Runtime/IHostContext.h
+++ b/Engine/Include/Ludus/Engine/Runtime/IHostContext.h
@@ -14,6 +14,11 @@ namespace Ludus::Engine::Graphics
 	struct RenderTarget;
 }
 
+namespace Ludus::Engine::Events
+{
+	struct EventHandler;
+}
+
 namespace Ludus::Engine::Runtime
 {
 	class RuntimeInstance;
@@ -43,6 +48,9 @@ namespace Ludus::Engine::Runtime
 		virtual Ludus::Engine::Core::FlagSet& GetExecutionFlags() = 0;
 		virtual Ludus::Engine::Windowing::Input& GetInput() = 0;
 
+		virtual void SetWindowShouldClose() = 0;
 		virtual void SetWindowTitle(std::string_view title) = 0;
+		virtual void SubscribeWindowCloseEvent(Ludus::Engine::Events::EventHandler& handler) = 0;
+		virtual void UnsubscribeWindowCloseEvent(Ludus::Engine::Events::EventHandler& handler) = 0;
 	};
 }

--- a/Engine/Source/Ludus/Engine/Runtime/ApplicationHost.cpp
+++ b/Engine/Source/Ludus/Engine/Runtime/ApplicationHost.cpp
@@ -1,15 +1,8 @@
 #include "pch.h"
 
-#include <memory>
-#include <utility>
-
 #include <Ludus/Engine/Events/WindowEvents.h>
 #include <Ludus/Engine/Runtime/ApplicationHost.h>
 #include <Ludus/Engine/Runtime/RuntimeInstance.h>
-#include <Ludus/Engine/Runtime/RuntimeOptions.h>
-#include <Ludus/Engine/Runtime/SystemScheduler.h>
-#include <Ludus/Engine/Windowing/Window.h>
-#include <Ludus/Engine/Windowing/WindowOptions.h>
 
 namespace Ludus::Engine::Runtime
 {
@@ -39,9 +32,13 @@ namespace Ludus::Engine::Runtime
 		{
 			case EventType::WindowCloseEvent:
 			{
-				m_Window.SetWindowShouldClose();
+				if (m_EventBus.GetHandlerCount(EventType::WindowCloseEvent) == 1)
+				{
+					m_Window.SetWindowShouldClose();
+					return true;
+				}
 
-				return true;
+				return false;
 			}
 
 			case EventType::FramebufferSizeEvent:
@@ -229,9 +226,24 @@ namespace Ludus::Engine::Runtime
 		return m_ExecutionFlags;
 	}
 
+	void ApplicationHost::SetWindowShouldClose()
+	{
+		m_Window.SetWindowShouldClose();
+	}
+
 	void ApplicationHost::SetWindowTitle(std::string_view title)
 	{
 		m_Window.SetTitle(title);
+	}
+
+	void ApplicationHost::SubscribeWindowCloseEvent(Ludus::Engine::Events::EventHandler& handler)
+	{
+		m_EventBus.Subscribe(Ludus::Engine::Events::EventType::WindowCloseEvent, handler);
+	}
+
+	void ApplicationHost::UnsubscribeWindowCloseEvent(Ludus::Engine::Events::EventHandler& handler)
+	{
+		m_EventBus.Unsubscribe(Ludus::Engine::Events::EventType::WindowCloseEvent, handler);
 	}
 
 #pragma endregion


### PR DESCRIPTION
# Summary
- Introduced `DeferredAction`-based unsaved-changes orchestration.
- Split request handlers from raw execution into `BuildActions`, `ProjectActions`, `SceneActions`, and `EditorStateActions`.
- Added unsaved-changes dialog flow and `ResolveUnsavedChanges`.
- Routed application close through `WindowCloseEvent` into editor unsaved changes check before calling `SetWindowShouldClose()`.
- Moved unresolved-script-reference query into `SceneQueries`.

# Linked
- Closes #238 
- Story: #318 

