### PR TITLE
Feature: Added editor preferences persistence and recent project startup selection

### DIFF
--- a/Editor/Editor.vcxproj
+++ b/Editor/Editor.vcxproj
@@ -31,12 +31,14 @@
     <ClCompile Include="Source\Ludus\Editor\Commands\Requests\ProjectActions.cpp" />
     <ClCompile Include="Source\Ludus\Editor\Commands\Requests\SceneActions.cpp" />
     <ClCompile Include="Source\Ludus\Editor\Commands\Requests\Scripts.cpp" />
+    <ClCompile Include="Source\Ludus\Editor\Core\EditorLauncher.cpp" />
     <ClCompile Include="Source\Ludus\Editor\Core\EditorSession.cpp" />
     <ClCompile Include="Source\Ludus\Editor\Core\ProjectSessionEditorState.cpp" />
     <ClCompile Include="Source\Ludus\Editor\Core\ProjectSessionPersistence.cpp" />
     <ClCompile Include="Source\Ludus\Editor\Core\ProjectSessionRuntimeState.cpp" />
     <ClCompile Include="Source\Ludus\Editor\Dialogs\RenameSceneDialog.cpp" />
     <ClCompile Include="Source\Ludus\Editor\Dialogs\UnsavedChangesDialog.cpp" />
+    <ClCompile Include="Source\Ludus\Editor\Persistence\LmlEditorPreferencesPersistence.cpp" />
     <ClCompile Include="Source\Ludus\Editor\Persistence\ProjectSessionLoader.cpp" />
     <ClCompile Include="Source\Ludus\Editor\Serialization\ProjectManifestSchema.cpp" />
     <ClCompile Include="Source\Ludus\Editor\Persistence\LmlProjectManifestPersistence.cpp" />
@@ -66,6 +68,7 @@
     <ClCompile Include="Source\Ludus\Editor\Panels\ImGuiDemoPanel.cpp" />
     <ClCompile Include="Source\Ludus\Editor\Panels\InspectorPanel.cpp" />
     <ClCompile Include="Source\Ludus\Editor\Panels\ViewportPanel.cpp" />
+    <ClCompile Include="Source\Ludus\Editor\Widgets\Buttons.cpp" />
     <ClCompile Include="Source\Ludus\Editor\Widgets\Input.cpp" />
     <ClCompile Include="Source\Ludus\Editor\pch.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
@@ -98,6 +101,9 @@
     <ClInclude Include="Include\Ludus\Editor\Commands\Requests\SceneActions.h" />
     <ClInclude Include="Include\Ludus\Editor\Commands\Requests\Scripts.h" />
     <ClInclude Include="Include\Ludus\Editor\Commands\StartupCommandContext.h" />
+    <ClInclude Include="Include\Ludus\Editor\Core\EditorLauncher.h" />
+    <ClInclude Include="Include\Ludus\Editor\Core\EditorPersistenceContext.h" />
+    <ClInclude Include="Include\Ludus\Editor\Core\EditorPreferences.h" />
     <ClInclude Include="Include\Ludus\Editor\Core\EditorSession.h" />
     <ClInclude Include="Include\Ludus\Editor\Core\EditorShell.h" />
     <ClInclude Include="Include\Ludus\Editor\Core\ProjectSession.h" />
@@ -137,6 +143,7 @@
     <ClInclude Include="Include\Ludus\Editor\Core\EditorConfiguration.h" />
     <ClInclude Include="Include\Ludus\Editor\Core\EditorExecutionFlags.h" />
     <ClInclude Include="Include\Ludus\Editor\Core\ExecutionManager.h" />
+    <ClInclude Include="Include\Ludus\Editor\Core\RecentlyOpenedProject.h" />
     <ClInclude Include="Include\Ludus\Editor\Core\SceneQueries.h" />
     <ClInclude Include="Include\Ludus\Editor\Core\SelectionManager.h" />
     <ClInclude Include="Include\Ludus\Editor\Core\EditorState.h" />
@@ -171,6 +178,11 @@
     <ClInclude Include="Include\Ludus\Editor\Panels\ContentPanel.h" />
     <ClInclude Include="Include\Ludus\Editor\Panels\PanelKind.h" />
     <ClInclude Include="Include\Ludus\Editor\Panels\PanelHelpers.h" />
+    <ClInclude Include="Include\Ludus\Editor\Persistence\EditorPersistence.h" />
+    <ClInclude Include="Include\Ludus\Editor\Persistence\IEditorPreferencesPersistence.h" />
+    <ClInclude Include="Include\Ludus\Editor\Persistence\LmlEditorPreferencesPersistence.h" />
+    <ClInclude Include="Include\Ludus\Editor\Widgets\Buttons.h" />
+    <ClInclude Include="Include\Ludus\Editor\Widgets\Layout.h" />
     <ClInclude Include="Include\Ludus\Editor\Widgets\Input.h" />
     <ClInclude Include="Include\Ludus\Editor\Persistence\IProjectManifestPersistence.h" />
     <ClInclude Include="Include\Ludus\Editor\Persistence\LmlProjectManifestPersistence.h" />
@@ -182,6 +194,7 @@
     <ClInclude Include="Source\Ludus\Editor\pch.h" />
     <ClInclude Include="Include\Ludus\Editor\Core\WelcomeWindow.h" />
     <ClInclude Include="Include\Ludus\Editor\Persistence\ProjectSessionLoader.h" />
+    <ClInclude Include="Include\Ludus\Editor\Serialization\EditorPreferencesSchema.h" />
   </ItemGroup>
   <ItemGroup>
     <Image Include="Resources\LudusIcon.png" />

--- a/Editor/Include/Ludus/Editor/Build/BuildManager.h
+++ b/Editor/Include/Ludus/Editor/Build/BuildManager.h
@@ -7,8 +7,18 @@
 #include <Ludus/Editor/Build/BuildCommand.h>
 #include <Ludus/Editor/Build/BuildConfiguration.h>
 #include <Ludus/Editor/Build/BuildTarget.h>
-#include <Ludus/Editor/Build/IBuildPipeline.h>
-#include <Ludus/Editor/Build/IPackagePipeline.h>
+
+namespace Ludus::Editor::Build
+{
+	struct IBuildPipeline;
+	struct IPackagePipeline;
+}
+
+namespace Ludus::Engine::Persistence
+{
+	class IRuntimeLaunchSettingsPersistence;
+	class IRuntimeManifestPersistence;
+}
 
 namespace Ludus::Editor::Build
 {
@@ -18,12 +28,22 @@ namespace Ludus::Editor::Build
 		std::unique_ptr<IBuildPipeline> m_BuildPipeline;
 		std::unique_ptr<IPackagePipeline> m_PackagePipeline;
 
-	public:
-		explicit BuildManager(
+		BuildManager(
 			std::unique_ptr<IBuildPipeline> buildPipeline,
 			std::unique_ptr<IPackagePipeline> packagePipeline
 		);
-		BuildManager();
+
+	public:
+		static BuildManager Create(
+			const Ludus::Engine::Persistence::IRuntimeManifestPersistence& runtimeManifestPersistence,
+			const Ludus::Engine::Persistence::IRuntimeLaunchSettingsPersistence& runtimeLaunchSettingsPersistence
+		);
+		~BuildManager();
+
+		BuildManager(const BuildManager&) = delete;
+		BuildManager& operator=(const BuildManager&) = delete;
+		BuildManager(BuildManager&&) noexcept;
+		BuildManager& operator=(BuildManager&&) noexcept;
 
 		void Initialize();
 

--- a/Editor/Include/Ludus/Editor/Build/MSBuild/MSBuildPipeline.h
+++ b/Editor/Include/Ludus/Editor/Build/MSBuild/MSBuildPipeline.h
@@ -11,6 +11,11 @@
 #include <Ludus/Editor/Build/MSBuild/MSBuildRuntimeHostPipeline.h>
 #include <Ludus/Editor/Build/MSBuild/MSBuildScriptPipeline.h>
 
+namespace Ludus::Engine::Persistence
+{
+	class IRuntimeManifestPersistence;
+}
+
 namespace Ludus::Editor::Build::MSBuild
 {
 	struct MSBuildPipeline final : public IBuildPipeline
@@ -21,7 +26,7 @@ namespace Ludus::Editor::Build::MSBuild
 		MSBuildScriptPipeline m_ScriptPipeline;
 
 	public:
-		MSBuildPipeline();
+		explicit MSBuildPipeline(const Ludus::Engine::Persistence::IRuntimeManifestPersistence& runtimeManifestPersistence);
 
 		virtual void Initialize() override;
 

--- a/Editor/Include/Ludus/Editor/Build/MSBuild/MSBuildRuntimeHostPipeline.h
+++ b/Editor/Include/Ludus/Editor/Build/MSBuild/MSBuildRuntimeHostPipeline.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <filesystem>
-#include <optional>
 #include <string_view>
 
 #include <Ludus/Editor/Build/BuildCommand.h>
@@ -9,12 +8,18 @@
 #include <Ludus/Editor/Build/MSBuild/MSBuildContext.h>
 #include <Ludus/Editor/Build/MSBuild/RuntimeHostBuildSettings.h>
 
+namespace Ludus::Engine::Persistence
+{
+	class IRuntimeManifestPersistence;
+}
+
 namespace Ludus::Editor::Build::MSBuild
 {
 	struct MSBuildRuntimeHostPipeline
 	{
 	private:
 		MSBuildContext& m_Context;
+		const Ludus::Engine::Persistence::IRuntimeManifestPersistence& m_RuntimeManifestPersistence;
 
 		void CopyTemplateToDestinationIfMissing(
 			const std::filesystem::path& templateRoot,
@@ -38,7 +43,10 @@ namespace Ludus::Editor::Build::MSBuild
 		);
 
 	public:
-		MSBuildRuntimeHostPipeline(MSBuildContext& context);
+		MSBuildRuntimeHostPipeline(
+			MSBuildContext& context,
+			const Ludus::Engine::Persistence::IRuntimeManifestPersistence& runtimeManifestPersistence
+		);
 
 		void RunBuild(
 			const std::filesystem::path& projectRoot,

--- a/Editor/Include/Ludus/Editor/Build/RuntimePackage/RuntimeHostPackagePipeline.h
+++ b/Editor/Include/Ludus/Editor/Build/RuntimePackage/RuntimeHostPackagePipeline.h
@@ -4,11 +4,26 @@
 #include <Ludus/Editor/Build/BuildPlatform.h>
 #include <Ludus/Editor/Build/IPackagePipeline.h>
 
+namespace Ludus::Engine::Persistence
+{
+	class IRuntimeLaunchSettingsPersistence;
+	class IRuntimeManifestPersistence;
+}
+
 namespace Ludus::Editor::Build::RuntimePackage
 {
 	struct RuntimeHostPackagePipeline final : public IPackagePipeline
 	{
+	private:
+		const Ludus::Engine::Persistence::IRuntimeManifestPersistence& m_RuntimeManifestPersistence;
+		const Ludus::Engine::Persistence::IRuntimeLaunchSettingsPersistence& m_RuntimeLaunchSettingsPersistence;
+
 	public:
+		RuntimeHostPackagePipeline(
+			const Ludus::Engine::Persistence::IRuntimeManifestPersistence& runtimeManifestPersistence,
+			const Ludus::Engine::Persistence::IRuntimeLaunchSettingsPersistence& runtimeLaunchSettingsPersistence
+		);
+
 		virtual void Initialize() override;
 
 		virtual void BuildPackage(

--- a/Editor/Include/Ludus/Editor/Commands/ProjectSessionCommandContext.h
+++ b/Editor/Include/Ludus/Editor/Commands/ProjectSessionCommandContext.h
@@ -1,12 +1,10 @@
 #pragma once
 
+#include <Ludus/Editor/Core/EditorPersistenceContext.h>
+#include <Ludus/Editor/Core/EditorPreferences.h>
 #include <Ludus/Editor/Core/EditorShell.h>
 #include <Ludus/Editor/Core/ProjectSession.h>
 #include <Ludus/Editor/Panels/PanelRegistry.h>
-#include <Ludus/Editor/Persistence/IProjectManifestPersistence.h>
-#include <Ludus/Engine/Persistence/IRuntimeLaunchSettingsPersistence.h>
-#include <Ludus/Engine/Persistence/IRuntimeManifestPersistence.h>
-#include <Ludus/Engine/Persistence/IScenePersistence.h>
 #include <Ludus/Engine/Runtime/IHostContext.h>
 
 namespace Ludus::Editor::Commands
@@ -14,12 +12,10 @@ namespace Ludus::Editor::Commands
 	struct ProjectSessionCommandContext
 	{
 		Ludus::Editor::Core::EditorShell& Shell;
-		Ludus::Editor::Core::ProjectSession& ProjectSession;
 		Ludus::Engine::Runtime::IHostContext& HostContext;
-		Ludus::Engine::Persistence::IScenePersistence& ScenePersistence;
-		Ludus::Engine::Persistence::IRuntimeManifestPersistence& RuntimeManifestPersistence;
-		Ludus::Engine::Persistence::IRuntimeLaunchSettingsPersistence& RuntimeLaunchSettingsPersistence;
-		Ludus::Editor::Persistence::IProjectManifestPersistence& ProjectManifestPersistence;
+		Ludus::Editor::Core::ProjectSession& ProjectSession;
+		Ludus::Editor::Core::EditorPreferences& Preferences;
 		Ludus::Editor::Panels::PanelRegistry& PanelRegistry;
+		Ludus::Editor::Core::EditorPersistenceContext Persistence;
 	};
 }

--- a/Editor/Include/Ludus/Editor/Commands/Requests/EditorState.h
+++ b/Editor/Include/Ludus/Editor/Commands/Requests/EditorState.h
@@ -19,5 +19,6 @@ namespace Ludus::Editor::Commands::Requests::EditorState
 
 	void CloseApplication(StartupCommandContext& context);
 	void SetExecutionFlag(const RequestCommand::SetExecutionFlag& command, StartupCommandContext& context);
+	void SetTheme(const RequestCommand::SetTheme& command, StartupCommandContext& context);
 	void UnsetExecutionFlag(const RequestCommand::UnsetExecutionFlag& command, StartupCommandContext& context);
 }

--- a/Editor/Include/Ludus/Editor/Commands/Requests/EditorStateActions.h
+++ b/Editor/Include/Ludus/Editor/Commands/Requests/EditorStateActions.h
@@ -20,5 +20,6 @@ namespace Ludus::Editor::Commands::Requests::EditorState
 
 	void CloseApplicationAction(StartupCommandContext& context);
 	void SetExecutionFlagAction(Ludus::Editor::Core::EditorExecutionFlags flag, StartupCommandContext& context);
+	void SetThemeAction(Ludus::UI::Theme::ThemeId themeId, StartupCommandContext& context);
 	void UnsetExecutionFlagAction(Ludus::Editor::Core::EditorExecutionFlags flag, StartupCommandContext& context);
 }

--- a/Editor/Include/Ludus/Editor/Commands/Requests/ProjectTransitionContext.h
+++ b/Editor/Include/Ludus/Editor/Commands/Requests/ProjectTransitionContext.h
@@ -1,27 +1,17 @@
 #pragma once
 
+#include <Ludus/Editor/Core/EditorPersistenceContext.h>
+#include <Ludus/Editor/Core/EditorPreferences.h>
 #include <Ludus/Editor/Core/EditorShell.h>
 #include <Ludus/Editor/Panels/PanelRegistry.h>
-#include <Ludus/Editor/Persistence/IProjectManifestPersistence.h>
-#include <Ludus/Engine/Persistence/IRuntimeLaunchSettingsPersistence.h>
-#include <Ludus/Engine/Persistence/IRuntimeManifestPersistence.h>
-#include <Ludus/Engine/Persistence/IScenePersistence.h>
-
-namespace Ludus::Editor::Commands
-{
-	struct ProjectSessionCommandContext;
-	struct StartupCommandContext;
-}
 
 namespace Ludus::Editor::Commands::Requests::Projects
 {
 	struct ProjectTransitionContext
 	{
 		Ludus::Editor::Core::EditorShell& Shell;
-		Ludus::Engine::Persistence::IScenePersistence& ScenePersistence;
-		Ludus::Engine::Persistence::IRuntimeManifestPersistence& RuntimeManifestPersistence;
-		Ludus::Engine::Persistence::IRuntimeLaunchSettingsPersistence& RuntimeLaunchSettingsPersistence;
-		Ludus::Editor::Persistence::IProjectManifestPersistence& ProjectManifestPersistence;
+		Ludus::Editor::Core::EditorPreferences& Preferences;
 		Ludus::Editor::Panels::PanelRegistry& PanelRegistry;
+		Ludus::Editor::Core::EditorPersistenceContext& Persistence;
 	};
 }

--- a/Editor/Include/Ludus/Editor/Commands/StartupCommandContext.h
+++ b/Editor/Include/Ludus/Editor/Commands/StartupCommandContext.h
@@ -1,11 +1,9 @@
 #pragma once
 
+#include <Ludus/Editor/Core/EditorPersistenceContext.h>
+#include <Ludus/Editor/Core/EditorPreferences.h>
 #include <Ludus/Editor/Core/EditorShell.h>
 #include <Ludus/Editor/Panels/PanelRegistry.h>
-#include <Ludus/Editor/Persistence/IProjectManifestPersistence.h>
-#include <Ludus/Engine/Persistence/IRuntimeLaunchSettingsPersistence.h>
-#include <Ludus/Engine/Persistence/IRuntimeManifestPersistence.h>
-#include <Ludus/Engine/Persistence/IScenePersistence.h>
 #include <Ludus/Engine/Runtime/IHostContext.h>
 
 namespace Ludus::Editor::Commands
@@ -14,10 +12,8 @@ namespace Ludus::Editor::Commands
 	{
 		Ludus::Editor::Core::EditorShell& Shell;
 		Ludus::Engine::Runtime::IHostContext& HostContext;
-		Ludus::Engine::Persistence::IScenePersistence& ScenePersistence;
-		Ludus::Engine::Persistence::IRuntimeManifestPersistence& RuntimeManifestPersistence;
-		Ludus::Engine::Persistence::IRuntimeLaunchSettingsPersistence& RuntimeLaunchSettingsPersistence;
-		Ludus::Editor::Persistence::IProjectManifestPersistence& ProjectManifestPersistence;
+		Ludus::Editor::Core::EditorPreferences& Preferences;
 		Ludus::Editor::Panels::PanelRegistry& PanelRegistry;
+		Ludus::Editor::Core::EditorPersistenceContext Persistence;
 	};
 }

--- a/Editor/Include/Ludus/Editor/Core/Constants.h
+++ b/Editor/Include/Ludus/Editor/Core/Constants.h
@@ -5,30 +5,87 @@
 
 namespace Ludus::Editor::Core::Constants
 {
-	inline Ludus::UI::Flags::Window PanelFlags = Ludus::UI::Flags::Window::None;
-	inline float StandardInlineSpacing = 6.0f;
-	inline Ludus::Engine::Math::Vector2D ModalActionButtonSize = { 120.0f, 0.0f };
+	namespace Shared
+	{
+		inline constexpr float StandardInlineSpacing = 6.0f;
+		inline const Ludus::Engine::Math::Vector2D ModalActionButtonSize = { 120.0f, 0.0f };
+		inline constexpr float ToolbarButtonExtent = 30.0f;
+	}
 
-	inline Ludus::UI::Flags::Window DockPanelWindowFlags = Ludus::UI::Flags::Window::NoDocking
-		| Ludus::UI::Flags::Window::MenuBar
-		| Ludus::UI::Flags::Window::NoBringToFrontOnFocus
-		| Ludus::UI::Flags::Window::NoDecoration
-		| Ludus::UI::Flags::Window::NoMove
-		| Ludus::UI::Flags::Window::NoNav;
+	namespace Flags
+	{
+		inline constexpr Ludus::UI::Flags::Window Panel = Ludus::UI::Flags::Window::None;
 
-	inline Ludus::UI::Flags::Window WelcomeWindowFlags = Ludus::UI::Flags::Window::NoDocking
-		| Ludus::UI::Flags::Window::NoDecoration
-		| Ludus::UI::Flags::Window::NoMove
-		| Ludus::UI::Flags::Window::NoNav
-		| Ludus::UI::Flags::Window::NoNavFocus;
+		inline constexpr Ludus::UI::Flags::Window DockPanelWindow = Ludus::UI::Flags::Window::NoDocking
+			| Ludus::UI::Flags::Window::MenuBar
+			| Ludus::UI::Flags::Window::NoBringToFrontOnFocus
+			| Ludus::UI::Flags::Window::NoDecoration
+			| Ludus::UI::Flags::Window::NoMove
+			| Ludus::UI::Flags::Window::NoNav;
 
-	inline Ludus::UI::Flags::Window WelcomeBackgroundWindowFlags = WelcomeWindowFlags
-		| Ludus::UI::Flags::Window::NoBringToFrontOnFocus
-		| Ludus::UI::Flags::Window::NoMouseInputs
-		| Ludus::UI::Flags::Window::NoSavedSettings;
+		inline constexpr Ludus::UI::Flags::Window WelcomeWindow = Ludus::UI::Flags::Window::NoDocking
+			| Ludus::UI::Flags::Window::NoDecoration
+			| Ludus::UI::Flags::Window::NoMove
+			| Ludus::UI::Flags::Window::NoNav
+			| Ludus::UI::Flags::Window::NoNavFocus;
 
-	inline Ludus::Engine::Math::Vector2D WelcomeWindowSize = { 420.0f, 300.0f };
-	inline Ludus::Engine::Math::Vector2D WelcomeActionButtonSize = { 140.0f, 42.0f };
+		inline constexpr Ludus::UI::Flags::Window WelcomeBackgroundWindow = WelcomeWindow
+			| Ludus::UI::Flags::Window::NoBringToFrontOnFocus
+			| Ludus::UI::Flags::Window::NoMouseInputs
+			| Ludus::UI::Flags::Window::NoSavedSettings;
+	}
 
-	inline float ToolbarButtonExtent = 30.0f;
+	namespace Welcome
+	{
+		namespace Layout
+		{
+			inline const Ludus::Engine::Math::Vector2D WindowSize = { 680.0f, 520.0f };
+			inline const Ludus::Engine::Math::Vector2D ActionButtonSize = { 160.0f, 44.0f };
+
+			inline const float WindowBorderSize = 1.0f;
+			inline const float WindowRounding = 6.0f;
+			inline const float TitleFontSize = 42.0f;
+
+			inline const float TitleY = 28.0f;
+			inline const float SubtitleY = 84.0f;
+			inline const float ActionButtonsY = 138.0f;
+			inline const float RecentProjectsLabelY = 208.0f;
+			inline const float RecentListY = 248.0f;
+			inline const float ErrorBottomOffset = 56.0f;
+			inline const float FooterBottomOffset = 28.0f;
+
+			inline const float ActionButtonsSpacing = Shared::StandardInlineSpacing * 5.0f;
+		}
+
+		namespace RecentProjects
+		{
+			inline const int VisibleItems = 3;
+			inline const float ListExtraWidth = 96.0f;
+			inline const float ListPadding = 10.0f;
+			inline const float ListBorderSize = 1.0f;
+			inline const float ListRounding = 6.0f;
+			inline const float ListEmptyStateY = 28.0f;
+
+			inline float CalculateListWidth(float actionButtonWidth)
+			{
+				return actionButtonWidth * 2.0f + Layout::ActionButtonsSpacing + ListExtraWidth;
+			}
+
+			inline float CalculateListHeight()
+			{
+				return ListPadding * 2.0f + VisibleItems * 52.0f + (VisibleItems - 1) * ListPadding;
+			}
+		}
+
+		namespace RecentProjectRow
+		{
+			inline const float Height = 52.0f;
+			inline const float Spacing = RecentProjects::ListPadding;
+			inline const float Rounding = 6.0f;
+			inline const float TextPaddingX = 12.0f;
+			inline const float TitleOffsetY = 8.0f;
+			inline const float PathOffsetY = 28.0f;
+			inline const float BadgeGap = 12.0f;
+		}
+	}
 }

--- a/Editor/Include/Ludus/Editor/Core/EditorHostBuilder.h
+++ b/Editor/Include/Ludus/Editor/Core/EditorHostBuilder.h
@@ -4,7 +4,9 @@
 #include <optional>
 
 #include <Ludus/Editor/Core/EditorConfiguration.h>
+#include <Ludus/Editor/Core/EditorPreferences.h>
 #include <Ludus/Editor/Core/EditorStartupOptions.h>
+#include <Ludus/Editor/Persistence/EditorPersistence.h>
 #include <Ludus/Engine/Runtime/ApplicationHostBuilder.h>
 #include <Ludus/Engine/Runtime/RuntimeOptions.h>
 #include <Ludus/Engine/Windowing/WindowOptions.h>
@@ -16,7 +18,9 @@ namespace Ludus::Editor::Core
 	private:
 		Ludus::Engine::Runtime::ApplicationHostBuilder m_ApplicationHostBuilder;
 		Ludus::Editor::Core::EditorConfiguration m_EditorConfiguration = Ludus::Editor::Core::EditorConfiguration::Default();
-		Ludus::Editor::Core::EditorStartupOptions m_StartupOptions;
+		Ludus::Editor::Persistence::EditorPersistence m_EditorPersistence = Ludus::Editor::Persistence::EditorPersistence::DefaultText();
+		Ludus::Editor::Core::EditorPreferences m_EditorPreferences = Ludus::Editor::Core::EditorPreferences::Default();
+		Ludus::Editor::Core::EditorStartupOptions m_EditorStartupOptions = Ludus::Editor::Core::EditorStartupOptions::Default();
 
 		std::optional<Ludus::Engine::Runtime::RuntimeOptions> m_RuntimeOptions;
 		std::optional<Ludus::Engine::Windowing::WindowOptions> m_WindowOptions;
@@ -30,8 +34,10 @@ namespace Ludus::Editor::Core
 		std::unique_ptr<Ludus::Engine::Runtime::ApplicationHost> Build();
 
 		EditorHostBuilder& WithEditorConfiguration(Ludus::Editor::Core::EditorConfiguration editorConfiguration);
+		EditorHostBuilder& WithEditorPersistence(Ludus::Editor::Persistence::EditorPersistence editorPersistence);
+		EditorHostBuilder& WithEditorPreferences(Ludus::Editor::Core::EditorPreferences editorPreferences);
+		EditorHostBuilder& WithEditorStartupOptions(EditorStartupOptions startupOptions);
 		EditorHostBuilder& WithRuntimeOptions(Ludus::Engine::Runtime::RuntimeOptions runtimeOptions);
-		EditorHostBuilder& WithStartupOptions(EditorStartupOptions startupOptions);
 		EditorHostBuilder& WithWindowOptions(Ludus::Engine::Windowing::WindowOptions windowOptions);
 
 		EditorHostBuilder& UseEditor();

--- a/Editor/Include/Ludus/Editor/Core/EditorLauncher.h
+++ b/Editor/Include/Ludus/Editor/Core/EditorLauncher.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <Ludus/Editor/Core/EditorStartupOptions.h>
+
+namespace Ludus::Editor::Core
+{
+	struct EditorLauncher
+	{
+		static int Run(EditorStartupOptions editorStartupOptions);
+	};
+}

--- a/Editor/Include/Ludus/Editor/Core/EditorPersistenceContext.h
+++ b/Editor/Include/Ludus/Editor/Core/EditorPersistenceContext.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <Ludus/Editor/Persistence/IEditorPreferencesPersistence.h>
+#include <Ludus/Editor/Persistence/IProjectManifestPersistence.h>
+#include <Ludus/Engine/Persistence/IRuntimeLaunchSettingsPersistence.h>
+#include <Ludus/Engine/Persistence/IRuntimeManifestPersistence.h>
+#include <Ludus/Engine/Persistence/IScenePersistence.h>
+
+namespace Ludus::Editor::Core
+{
+	struct EditorPersistenceContext
+	{
+		const Ludus::Editor::Persistence::IEditorPreferencesPersistence& EditorPreferences;
+		const Ludus::Editor::Persistence::IProjectManifestPersistence& ProjectManifest;
+		const Ludus::Engine::Persistence::IRuntimeLaunchSettingsPersistence& RuntimeLaunchSettings;
+		const Ludus::Engine::Persistence::IRuntimeManifestPersistence& RuntimeManifest;
+		const Ludus::Engine::Persistence::IScenePersistence& Scene;
+
+		static EditorPersistenceContext Create(
+			const Ludus::Editor::Persistence::IEditorPreferencesPersistence& editorPreferences,
+			const Ludus::Editor::Persistence::IProjectManifestPersistence& projectManifest,
+			const Ludus::Engine::Persistence::IRuntimeLaunchSettingsPersistence& runtimeLaunchSettings,
+			const Ludus::Engine::Persistence::IRuntimeManifestPersistence& runtimeManifest,
+			const Ludus::Engine::Persistence::IScenePersistence& scene
+		)
+		{
+			return {
+				.EditorPreferences = editorPreferences,
+				.ProjectManifest = projectManifest,
+				.RuntimeLaunchSettings = runtimeLaunchSettings,
+				.RuntimeManifest = runtimeManifest,
+				.Scene = scene
+			};
+		}
+	};
+}

--- a/Editor/Include/Ludus/Editor/Core/EditorPreferences.h
+++ b/Editor/Include/Ludus/Editor/Core/EditorPreferences.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <algorithm>
+#include <filesystem>
+#include <iterator>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include <Ludus/Editor/Core/RecentlyOpenedProject.h>
+#include <Ludus/UI/Theme/ThemeId.h>
+
+namespace Ludus::Editor::Core
+{
+	inline constexpr size_t MaxRecentlyOpenedProjects = 10;
+
+	struct EditorPreferences
+	{
+		Ludus::UI::Theme::ThemeId ActiveThemeId = Ludus::UI::Theme::ThemeId::LudusDark;
+		std::vector<RecentlyOpenedProject> RecentlyOpenedProjects;
+
+		void AddRecentlyOpenedProject(std::string_view name, const std::filesystem::path& path)
+		{
+			std::erase_if(RecentlyOpenedProjects, [&](const RecentlyOpenedProject& project)
+			{
+				return project.Path == path;
+			});
+
+			if (RecentlyOpenedProjects.size() == MaxRecentlyOpenedProjects)
+			{
+				RecentlyOpenedProjects.pop_back();
+			}
+
+			RecentlyOpenedProjects.insert(RecentlyOpenedProjects.begin(), { std::string(name), path });
+		}
+
+		static EditorPreferences Default()
+		{
+			EditorPreferences editorPreferences;
+			return editorPreferences;
+		}
+	};
+}

--- a/Editor/Include/Ludus/Editor/Core/EditorSession.h
+++ b/Editor/Include/Ludus/Editor/Core/EditorSession.h
@@ -13,17 +13,17 @@ namespace Ludus::Editor::Core
 	class EditorSession
 	{
 	private:
+		const Ludus::Editor::Persistence::ProjectSessionLoader& m_ProjectSessionLoader;
 		Ludus::Engine::Runtime::IHostContext& m_HostContext;
 		Ludus::Editor::Core::EditorShell& m_Shell;
-		Ludus::Editor::Persistence::ProjectSessionLoader& m_ProjectSessionLoader;
 
 		Ludus::Editor::Core::ProjectSession LoadProjectSession(Ludus::Editor::Core::ProjectManifest projectManifest);
 
 	public:
 		EditorSession(
+			const Ludus::Editor::Persistence::ProjectSessionLoader& projectSessionLoader,
 			Ludus::Engine::Runtime::IHostContext& hostContext,
-			Ludus::Editor::Core::EditorShell& shell,
-			Ludus::Editor::Persistence::ProjectSessionLoader& projectSessionLoader
+			Ludus::Editor::Core::EditorShell& shell
 		);
 
 		void ApplyTransitions(

--- a/Editor/Include/Ludus/Editor/Core/EditorShell.h
+++ b/Editor/Include/Ludus/Editor/Core/EditorShell.h
@@ -1,17 +1,20 @@
 #pragma once
 
+#include <utility>
+
 #include <Ludus/Editor/Build/BuildManager.h>
 #include <Ludus/Editor/Core/EditorState.h>
 
 namespace Ludus::Editor::Core
 {
-	struct EditorShell
+	class EditorShell
 	{
+	public:
 		Ludus::Editor::Build::BuildManager Build;
 		EditorState State;
 
-		EditorShell()
-			: Build(), State()
+		explicit EditorShell(Ludus::Editor::Build::BuildManager buildManager)
+			: Build(std::move(buildManager)), State()
 		{
 			Build.Initialize();
 		}

--- a/Editor/Include/Ludus/Editor/Core/EditorStartupOptions.h
+++ b/Editor/Include/Ludus/Editor/Core/EditorStartupOptions.h
@@ -13,6 +13,11 @@ namespace Ludus::Editor::Core
 		std::optional<std::filesystem::path> StartupProjectPath;
 		bool EnableImGuiDemo = false;
 
+		static EditorStartupOptions Default()
+		{
+			return { };
+		}
+
 		static EditorStartupOptions FromCommandLineArgs(int argc, char* argv[])
 		{
 			EditorStartupOptions options { };

--- a/Editor/Include/Ludus/Editor/Core/EditorSystem.h
+++ b/Editor/Include/Ludus/Editor/Core/EditorSystem.h
@@ -2,43 +2,46 @@
 
 #include <optional>
 
-#include <Ludus/Editor/Commands/ProjectSessionCommandContext.h>
-#include <Ludus/Editor/Commands/StartupCommandContext.h>
 #include <Ludus/Editor/Core/EditorConfiguration.h>
+#include <Ludus/Editor/Core/EditorPersistenceContext.h>
+#include <Ludus/Editor/Core/EditorPreferences.h>
 #include <Ludus/Editor/Core/EditorSession.h>
 #include <Ludus/Editor/Core/EditorShell.h>
 #include <Ludus/Editor/Core/EditorStartupOptions.h>
 #include <Ludus/Editor/Core/ProjectSession.h>
 #include <Ludus/Editor/Core/WelcomeWindow.h>
 #include <Ludus/Editor/Panels/PanelRegistry.h>
-#include <Ludus/Editor/Persistence/LmlProjectManifestPersistence.h>
+#include <Ludus/Editor/Persistence/EditorPersistence.h>
 #include <Ludus/Editor/Persistence/ProjectSessionLoader.h>
 #include <Ludus/Engine/Events/EventHandler.h>
-#include <Ludus/Engine/Persistence/LmlRuntimeLaunchSettingsPersistence.h>
-#include <Ludus/Engine/Persistence/LmlRuntimeManifestPersistence.h>
-#include <Ludus/Engine/Persistence/LmlScenePersistence.h>
 #include <Ludus/Engine/Runtime/IHostContext.h>
 #include <Ludus/Engine/Runtime/ISystem.h>
+
+namespace Ludus::Editor::Commands
+{
+	struct ProjectSessionCommandContext;
+	struct StartupCommandContext;
+}
 
 namespace Ludus::Editor::Core
 {
 	class EditorSystem final : public Ludus::Engine::Runtime::ISystem, public Ludus::Engine::Events::EventHandler
 	{
 	private:
+		const Ludus::Editor::Persistence::EditorPersistence m_EditorPersistence;
+		const Ludus::Editor::Core::EditorPersistenceContext m_Persistence;
+		const Ludus::Editor::Persistence::ProjectSessionLoader m_ProjectSessionLoader;
+
+		EditorConfiguration m_EditorConfiguration;
+		EditorPreferences m_EditorPreferences;
+		EditorStartupOptions m_EditorStartupOptions;
+
 		EditorShell m_Shell;
 		std::optional<ProjectSession> m_ProjectSession;
 		Ludus::Engine::Runtime::IHostContext& m_HostContext;
-		Ludus::Engine::Persistence::LmlScenePersistence m_ScenePersistence;
-		Ludus::Engine::Persistence::LmlRuntimeManifestPersistence m_RuntimeManifestPersistence;
-		Ludus::Engine::Persistence::LmlRuntimeLaunchSettingsPersistence m_RuntimeLaunchSettingsPersistence;
-		Ludus::Editor::Persistence::LmlProjectManifestPersistence m_ProjectManifestPersistence;
-		Ludus::Editor::Persistence::ProjectSessionLoader m_ProjectSessionLoader;
 		Ludus::Editor::Core::EditorSession m_Session;
 		Ludus::Editor::Panels::PanelRegistry m_PanelRegistry;
 		WelcomeWindow m_WelcomeWindow;
-
-		EditorConfiguration m_EditorConfiguration;
-		EditorStartupOptions m_EditorStartupOptions;
 
 		Ludus::Editor::Commands::StartupCommandContext CreateStartupCommandContext();
 		Ludus::Editor::Commands::ProjectSessionCommandContext CreateProjectSessionCommandContext();
@@ -47,6 +50,7 @@ namespace Ludus::Editor::Core
 		void DelegateEditCommands();
 		void DelegateRequestCommands();
 
+		void ApplyEditorPreferences();
 		void ApplyStartupOptions();
 		void RegisterPanels();
 
@@ -62,6 +66,8 @@ namespace Ludus::Editor::Core
 		EditorSystem(
 			Ludus::Engine::Runtime::IHostContext& hostContext,
 			EditorConfiguration editorConfiguration,
+			Ludus::Editor::Persistence::EditorPersistence editorPersistence,
+			EditorPreferences editorPreferences,
 			EditorStartupOptions editorStartupOptions
 		);
 		~EditorSystem() = default;

--- a/Editor/Include/Ludus/Editor/Core/RecentlyOpenedProject.h
+++ b/Editor/Include/Ludus/Editor/Core/RecentlyOpenedProject.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <filesystem>
+#include <string>
+
+namespace Ludus::Editor::Core
+{
+	struct RecentlyOpenedProject
+	{
+		std::string DisplayName;
+		std::filesystem::path Path;
+	};
+}

--- a/Editor/Include/Ludus/Editor/Core/WelcomeWindow.h
+++ b/Editor/Include/Ludus/Editor/Core/WelcomeWindow.h
@@ -2,15 +2,24 @@
 
 #include <filesystem>
 #include <optional>
+#include <string>
+#include <vector>
 
 #include <Ludus/Editor/Commands/CommandSet.h>
+#include <Ludus/Editor/Core/RecentlyOpenedProject.h>
 
 namespace Ludus::Editor::Core
 {
 	class WelcomeWindow
 	{
+	private:
+		std::vector<RecentlyOpenedProject>& m_RecentlyOpenedProjects;
+		std::string m_Error;
+
 	public:
-		WelcomeWindow() = default;
+		WelcomeWindow(
+			std::vector<RecentlyOpenedProject>& recentlyOpenedProjects
+		);
 		~WelcomeWindow() = default;
 
 		std::optional<Ludus::Editor::Commands::CommandSet> Update();

--- a/Editor/Include/Ludus/Editor/Panels/PanelRegistry.h
+++ b/Editor/Include/Ludus/Editor/Panels/PanelRegistry.h
@@ -80,13 +80,10 @@ namespace Ludus::Editor::Panels
 
 			const auto previousSize = m_Panels.size();
 
-			std::erase_if(
-				m_Panels,
-				[this](const std::unique_ptr<IPanel>& panel)
+			std::erase_if(m_Panels, [this](const std::unique_ptr<IPanel>& panel)
 			{
 				return std::ranges::find(m_ScheduledRemovals, panel->GetHandle()) != m_ScheduledRemovals.end();
-			}
-			);
+			});
 
 			m_ScheduledRemovals.clear();
 			return m_Panels.size() != previousSize;

--- a/Editor/Include/Ludus/Editor/Persistence/EditorPersistence.h
+++ b/Editor/Include/Ludus/Editor/Persistence/EditorPersistence.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <memory>
+
+#include <Ludus/Editor/Persistence/IEditorPreferencesPersistence.h>
+#include <Ludus/Editor/Persistence/IProjectManifestPersistence.h>
+#include <Ludus/Editor/Persistence/LmlEditorPreferencesPersistence.h>
+#include <Ludus/Editor/Persistence/LmlProjectManifestPersistence.h>
+
+namespace Ludus::Editor::Persistence
+{
+	class EditorPersistence
+	{
+	private:
+		std::unique_ptr<IEditorPreferencesPersistence> m_EditorPreferences;
+		std::unique_ptr<IProjectManifestPersistence> m_ProjectManifest;
+
+		EditorPersistence(
+			std::unique_ptr<IEditorPreferencesPersistence> editorPreferences,
+			std::unique_ptr<IProjectManifestPersistence> projectManifest
+		) :
+			m_EditorPreferences(std::move(editorPreferences)),
+			m_ProjectManifest(std::move(projectManifest))
+		{}
+
+	public:
+		static EditorPersistence DefaultText()
+		{
+			return {
+				std::make_unique<LmlEditorPreferencesPersistence>(),
+				std::make_unique<LmlProjectManifestPersistence>()
+			};
+		}
+
+		const IEditorPreferencesPersistence& EditorPreferences() const { return *m_EditorPreferences; }
+		const IProjectManifestPersistence& ProjectManifest() const { return *m_ProjectManifest; }
+	};
+}

--- a/Editor/Include/Ludus/Editor/Persistence/IEditorPreferencesPersistence.h
+++ b/Editor/Include/Ludus/Editor/Persistence/IEditorPreferencesPersistence.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <filesystem>
+
+#include <Ludus/Editor/Core/EditorPreferences.h>
+
+namespace Ludus::Editor::Persistence
+{
+	class IEditorPreferencesPersistence
+	{
+	public:
+		virtual ~IEditorPreferencesPersistence() = default;
+
+		virtual void Save(const Ludus::Editor::Core::EditorPreferences& editorPreferences, const std::filesystem::path& path) const = 0;
+		virtual Ludus::Editor::Core::EditorPreferences Load(const std::filesystem::path& path) const = 0;
+	};
+}

--- a/Editor/Include/Ludus/Editor/Persistence/IProjectManifestPersistence.h
+++ b/Editor/Include/Ludus/Editor/Persistence/IProjectManifestPersistence.h
@@ -11,7 +11,7 @@ namespace Ludus::Editor::Persistence
 	public:
 		virtual ~IProjectManifestPersistence() = default;
 
-		virtual void Save(const Ludus::Editor::Core::ProjectManifest& projectManifest, const std::filesystem::path& path) = 0;
-		virtual Ludus::Editor::Core::ProjectManifest Load(const std::filesystem::path& path) = 0;
+		virtual void Save(const Ludus::Editor::Core::ProjectManifest& projectManifest, const std::filesystem::path& path) const = 0;
+		virtual Ludus::Editor::Core::ProjectManifest Load(const std::filesystem::path& path) const = 0;
 	};
 }

--- a/Editor/Include/Ludus/Editor/Persistence/LmlEditorPreferencesPersistence.h
+++ b/Editor/Include/Ludus/Editor/Persistence/LmlEditorPreferencesPersistence.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <filesystem>
+
+#include <Ludus/Editor/Persistence/IEditorPreferencesPersistence.h>
+
+namespace Ludus::Editor::Persistence
+{
+	class LmlEditorPreferencesPersistence final : public IEditorPreferencesPersistence
+	{
+	public:
+		LmlEditorPreferencesPersistence() = default;
+
+		void Save(const Ludus::Editor::Core::EditorPreferences& editorPreferences, const std::filesystem::path& path) const override;
+		Ludus::Editor::Core::EditorPreferences Load(const std::filesystem::path& path) const override;
+	};
+}

--- a/Editor/Include/Ludus/Editor/Persistence/LmlProjectManifestPersistence.h
+++ b/Editor/Include/Ludus/Editor/Persistence/LmlProjectManifestPersistence.h
@@ -11,7 +11,7 @@ namespace Ludus::Editor::Persistence
 	public:
 		LmlProjectManifestPersistence() = default;
 
-		void Save(const Ludus::Editor::Core::ProjectManifest& projectManifest, const std::filesystem::path& path) override;
-		Ludus::Editor::Core::ProjectManifest Load(const std::filesystem::path& path) override;
+		void Save(const Ludus::Editor::Core::ProjectManifest& projectManifest, const std::filesystem::path& path) const override;
+		Ludus::Editor::Core::ProjectManifest Load(const std::filesystem::path& path) const override;
 	};
 }

--- a/Editor/Include/Ludus/Editor/Persistence/ProjectPaths.h
+++ b/Editor/Include/Ludus/Editor/Persistence/ProjectPaths.h
@@ -12,6 +12,7 @@ namespace Ludus::Editor::Persistence::ProjectPaths
 	namespace Constants
 	{
 		inline constexpr std::string_view LudusDirectory = "Ludus";
+		inline constexpr std::string_view EditorDirectory = "Editor";
 		inline constexpr std::string_view ProjectsDirectory = "Projects";
 		inline constexpr std::string_view SourceDirectory = "Source";
 		inline constexpr std::string_view InvalidFileNameCharacters = "<>:\"/\\|?*";
@@ -20,12 +21,18 @@ namespace Ludus::Editor::Persistence::ProjectPaths
 		inline constexpr std::string_view ScriptsSolutionFile = "Scripts.sln";
 		inline constexpr std::string_view CppExtension = ".cpp";
 		inline constexpr std::string_view ProjectManifestExtension = ".project.ludus";
+		inline constexpr std::string_view EditorPreferencesFile = "editor.preferences.ludus";
 		inline constexpr std::string_view ScriptsDirectory = "Scripts";
 	}
 
 	inline std::filesystem::path LudusRoot()
 	{
 		return Ludus::Engine::Platform::Paths::LocalAppData() / std::string(Constants::LudusDirectory);
+	}
+
+	inline std::filesystem::path EditorRoot()
+	{
+		return LudusRoot() / std::string(Constants::EditorDirectory);
 	}
 
 	inline std::filesystem::path ProjectsRoot()
@@ -110,6 +117,11 @@ namespace Ludus::Editor::Persistence::ProjectPaths
 		return { };
 	}
 
+	inline std::filesystem::path EditorPreferencesFile()
+	{
+		return EditorRoot() / std::string(Constants::EditorPreferencesFile);
+	}
+
 	inline std::filesystem::path ProjectManifestFile(std::string_view projectName)
 	{
 		return std::string(projectName) + std::string(Constants::ProjectManifestExtension);
@@ -148,6 +160,11 @@ namespace Ludus::Editor::Persistence::ProjectPaths
 	inline std::filesystem::path ScriptsSolutionFile(const std::filesystem::path& projectRoot)
 	{
 		return ScriptsSourceDirectory(projectRoot) / std::string(Constants::ScriptsSolutionFile);
+	}
+
+	inline void EnsureEditorRootExists()
+	{
+		std::filesystem::create_directories(EditorRoot());
 	}
 
 	inline void EnsureProjectsRootExists()

--- a/Editor/Include/Ludus/Editor/Persistence/ProjectSessionLoader.h
+++ b/Editor/Include/Ludus/Editor/Persistence/ProjectSessionLoader.h
@@ -24,20 +24,20 @@ namespace Ludus::Editor::Persistence
 	class ProjectSessionLoader
 	{
 	private:
-		Ludus::Engine::Persistence::IScenePersistence& m_ScenePersistence;
-		Ludus::Engine::Persistence::IRuntimeManifestPersistence& m_RuntimeManifestPersistence;
-		Ludus::Engine::Persistence::IRuntimeLaunchSettingsPersistence& m_RuntimeLaunchSettingsPersistence;
-		Ludus::Editor::Persistence::IProjectManifestPersistence& m_ProjectManifestPersistence;
+		const Ludus::Engine::Persistence::IScenePersistence& m_ScenePersistence;
+		const Ludus::Engine::Persistence::IRuntimeManifestPersistence& m_RuntimeManifestPersistence;
+		const Ludus::Engine::Persistence::IRuntimeLaunchSettingsPersistence& m_RuntimeLaunchSettingsPersistence;
+		const Ludus::Editor::Persistence::IProjectManifestPersistence& m_ProjectManifestPersistence;
 
 	public:
 		ProjectSessionLoader(
-			Ludus::Engine::Persistence::IScenePersistence& scenePersistence,
-			Ludus::Engine::Persistence::IRuntimeManifestPersistence& runtimeManifestPersistence,
-			Ludus::Engine::Persistence::IRuntimeLaunchSettingsPersistence& runtimeLaunchSettingsPersistence,
-			Ludus::Editor::Persistence::IProjectManifestPersistence& projectManifestPersistence
+			const Ludus::Engine::Persistence::IScenePersistence& scenePersistence,
+			const Ludus::Engine::Persistence::IRuntimeManifestPersistence& runtimeManifestPersistence,
+			const Ludus::Engine::Persistence::IRuntimeLaunchSettingsPersistence& runtimeLaunchSettingsPersistence,
+			const Ludus::Editor::Persistence::IProjectManifestPersistence& projectManifestPersistence
 		);
 
-		LoadedProjectData Load(const std::filesystem::path& projectManifestPath);
-		LoadedProjectData Load(Ludus::Editor::Core::ProjectManifest projectManifest);
+		LoadedProjectData Load(const std::filesystem::path& projectManifestPath) const;
+		LoadedProjectData Load(Ludus::Editor::Core::ProjectManifest projectManifest) const;
 	};
 }

--- a/Editor/Include/Ludus/Editor/Serialization/EditorPreferencesSchema.h
+++ b/Editor/Include/Ludus/Editor/Serialization/EditorPreferencesSchema.h
@@ -1,0 +1,128 @@
+#pragma once
+
+#include <Ludus/Editor/Core/EditorPreferences.h>
+#include <Ludus/Editor/Core/RecentlyOpenedProject.h>
+#include <Ludus/Engine/Core/Enums/EnumTraits.h>
+#include <Ludus/Engine/Core/Expected.h>
+#include <Ludus/Engine/FileSystem/FileSystem.h>
+#include <Ludus/Engine/Serialization/Core/ITokenStreamReader.h>
+#include <Ludus/Engine/Serialization/Core/ITokenStreamWriter.h>
+#include <Ludus/Engine/Serialization/Core/SerializationException.h>
+#include <Ludus/Engine/Serialization/Core/TokenRead.h>
+
+namespace Ludus::Editor::Serialization::Schemas
+{
+	using EditorPreferences = Ludus::Editor::Core::EditorPreferences;
+	using ITokenStreamWriter = Ludus::Engine::Serialization::Core::ITokenStreamWriter;
+	using ITokenStreamReader = Ludus::Engine::Serialization::Core::ITokenStreamReader;
+	using SerializationException = Ludus::Engine::Serialization::Core::SerializationException;
+	using Token = Ludus::Engine::Serialization::Core::Token;
+
+	struct EditorPreferencesSchema
+	{
+		static void Serialize(ITokenStreamWriter& writer, const EditorPreferences& editorPreferences)
+		{
+			writer.Emit(Token::StartObject { });
+
+			const std::string activeThemeId = Ludus::Engine::Core::Enums::GetDisplayName(editorPreferences.ActiveThemeId);
+			writer.Emit(Token::Key { "ActiveThemeId" });
+			writer.Emit(Token::String { activeThemeId });
+
+			writer.Emit(Token::Key { "RecentlyOpenedProjects" });
+			writer.Emit(Token::StartArray { });
+
+			for (const auto& recentlyOpenedProject : editorPreferences.RecentlyOpenedProjects)
+			{
+				writer.Emit(Token::StartObject { });
+
+				writer.Emit(Token::Key { "DisplayName" });
+				writer.Emit(Token::String { recentlyOpenedProject.DisplayName });
+
+				writer.Emit(Token::Key { "Path" });
+				const auto recentlyOpenedProjectPath = Ludus::Engine::FileSystem::ToPortablePathString(recentlyOpenedProject.Path);
+				writer.Emit(Token::String { recentlyOpenedProjectPath });
+
+				writer.Emit(Token::EndObject { });
+			}
+
+			writer.Emit(Token::EndArray { });
+
+			writer.Emit(Token::EndObject { });
+		}
+
+		static Ludus::Engine::Core::Expected<EditorPreferences, SerializationException> Deserialize(ITokenStreamReader& reader)
+		{
+			EditorPreferences editorPreferences;
+
+			try
+			{
+				Ludus::Engine::Serialization::Core::ReadObject(reader, [&](std::string_view key)
+				{
+					if (key == "ActiveThemeId")
+					{
+						std::string themeIdValue = std::string(
+							Ludus::Engine::Serialization::Core::ConsumeAs<Token::String>(reader).Data
+						);
+						Ludus::UI::Theme::ThemeId parsed;
+						if (Ludus::UI::Theme::TryParse(themeIdValue, parsed))
+						{
+							editorPreferences.ActiveThemeId = parsed;
+						}
+						return;
+					}
+					if (key == "RecentlyOpenedProjects")
+					{
+						Ludus::Engine::Serialization::Core::ConsumeAs<Token::StartArray>(reader);
+
+						while (!Ludus::Engine::Serialization::Core::Is<Token::EndArray>(reader.Peek()))
+						{
+							Ludus::Editor::Core::RecentlyOpenedProject recentlyOpenedProject;
+							bool hasDisplayName = false;
+							bool hasPath = false;
+
+							Ludus::Engine::Serialization::Core::ReadObject(reader, [&](std::string_view recentlyOpenedProjectKey)
+							{
+								if (recentlyOpenedProjectKey == "DisplayName")
+								{
+									recentlyOpenedProject.DisplayName = std::string(Ludus::Engine::Serialization::Core::ConsumeAs<Token::String>(reader).Data);
+									hasDisplayName = true;
+									return;
+								}
+								if (recentlyOpenedProjectKey == "Path")
+								{
+									recentlyOpenedProject.Path = std::filesystem::path(
+										std::string(Ludus::Engine::Serialization::Core::ConsumeAs<Token::String>(reader).Data)
+									);
+									hasPath = true;
+									return;
+								}
+
+								Ludus::Engine::Serialization::Core::SkipValue(reader);
+							});
+
+							if (!hasDisplayName || !hasPath)
+							{
+								throw SerializationException("RecentlyOpenedProject entry is incomplete.");
+							}
+
+							editorPreferences.RecentlyOpenedProjects.emplace_back(std::move(recentlyOpenedProject));
+						}
+
+						Ludus::Engine::Serialization::Core::ConsumeAs<Token::EndArray>(reader);
+						return;
+					}
+				});
+
+				return editorPreferences;
+			}
+			catch (const SerializationException& ex)
+			{
+				const auto error = Ludus::Engine::Serialization::Core::WithContext(
+					ex, "ProjectManifestSchema::Deserialize"
+				);
+
+				return Ludus::Engine::Core::Unexpected<SerializationException>::Create(error);
+			}
+		}
+	};
+}

--- a/Editor/Include/Ludus/Editor/Widgets/Buttons.h
+++ b/Editor/Include/Ludus/Editor/Widgets/Buttons.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <string_view>
+
+#include <Ludus/Engine/Math/Vector2D.h>
+
+namespace Ludus::Editor::Widgets
+{
+	struct WidgetState
+	{
+		bool Active;
+		bool Hovered;
+		bool Pressed;
+		Ludus::Engine::Math::Vector2D Min;
+		Ludus::Engine::Math::Vector2D Max;
+	};
+
+	struct RecentProjectRowData
+	{
+		std::string_view Id;
+		std::string_view DisplayName;
+		std::string_view Path;
+		bool IsPathMissing = false;
+	};
+
+	WidgetState ButtonBase(const char* id, Ludus::Engine::Math::Vector2D size);
+
+	bool RecentProjectRow(const RecentProjectRowData& rowData);
+}

--- a/Editor/Include/Ludus/Editor/Widgets/Layout.h
+++ b/Editor/Include/Ludus/Editor/Widgets/Layout.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <string_view>
+
+#include <Ludus/Engine/Debug/Debug.h>
+#include <Ludus/Engine/Math/Vector2D.h>
+#include <Ludus/UI/Context/LayoutContext.h>
+
+namespace Ludus::Editor::Widgets::Layout
+{
+	inline Ludus::Engine::Math::Vector2D GetCenteredTextPositionAtY(std::string_view text, float y, float containerWidth)
+	{
+		const auto textSize = Ludus::UI::Context::LayoutContext::CalculateTextSize(std::string(text));
+
+		return {
+			(containerWidth - textSize.X) * 0.5f,
+			y
+		};
+	}
+
+	inline Ludus::Engine::Math::Vector2D GetCenteredRowElementPositionAtY(
+		float y,
+		float containerWidth,
+		float elementWidth,
+		float spacing,
+		int elementCount,
+		int elementIndex
+	)
+	{
+		LUDUS_ASSERT(elementCount > 0, "The element count in GetCenteredRowElementPositionAtY must be above zero.");
+		LUDUS_ASSERT(elementIndex >= 0, "The element index in GetCenteredRowElementPositionAtY must be non-negative.");
+		LUDUS_ASSERT(elementIndex < elementCount, "The element index in GetCenteredRowElementPositionAtY must be within range.");
+
+		const auto totalWidth = elementCount * elementWidth + (elementCount - 1) * spacing;
+		const auto offset = elementIndex * (elementWidth + spacing);
+
+		return {
+			(containerWidth - totalWidth) * 0.5f + offset,
+			y
+		};
+	}
+}

--- a/Editor/Resources/Templates/RuntimeHost/RuntimeHostModule.cpp.template
+++ b/Editor/Resources/Templates/RuntimeHost/RuntimeHostModule.cpp.template
@@ -2,5 +2,5 @@
 
 int main()
 {
-	return Ludus::Engine::Runtime::RunDefaultRuntime("${LUDUS_RUNTIME_NAME}");
+	return Ludus::Engine::Runtime::RuntimeLauncher::Run("${LUDUS_RUNTIME_NAME}");
 }

--- a/Editor/Source/Ludus/Editor/Build/BuildManager.cpp
+++ b/Editor/Source/Ludus/Editor/Build/BuildManager.cpp
@@ -14,6 +14,8 @@
 #include <Ludus/Editor/Build/RuntimePackage/RuntimeHostPackagePipeline.h>
 #include <Ludus/Editor/Persistence/BuildPaths.h>
 #include <Ludus/Engine/FileSystem/FileSystem.h>
+#include <Ludus/Engine/Persistence/IRuntimeLaunchSettingsPersistence.h>
+#include <Ludus/Engine/Persistence/IRuntimeManifestPersistence.h>
 
 namespace Ludus::Editor::Build
 {
@@ -26,12 +28,24 @@ namespace Ludus::Editor::Build
 		m_PackagePipeline = std::move(packagePipeline);
 	}
 
-	BuildManager::BuildManager()
-		: BuildManager(
-			std::make_unique<Ludus::Editor::Build::MSBuild::MSBuildPipeline>(),
-			std::make_unique<Ludus::Editor::Build::RuntimePackage::RuntimeHostPackagePipeline>()
-		)
-	{ }
+	BuildManager BuildManager::Create(
+		const Ludus::Engine::Persistence::IRuntimeManifestPersistence& runtimeManifestPersistence,
+		const Ludus::Engine::Persistence::IRuntimeLaunchSettingsPersistence& runtimeLaunchSettingsPersistence
+	)
+	{
+		return BuildManager(
+			std::make_unique<Ludus::Editor::Build::MSBuild::MSBuildPipeline>(runtimeManifestPersistence),
+			std::make_unique<Ludus::Editor::Build::RuntimePackage::RuntimeHostPackagePipeline>(
+				runtimeManifestPersistence,
+				runtimeLaunchSettingsPersistence
+			)
+		);
+	}
+
+	BuildManager::~BuildManager() = default;
+
+	BuildManager::BuildManager(BuildManager&&) noexcept = default;
+	BuildManager& BuildManager::operator=(BuildManager&&) noexcept = default;
 
 	void BuildManager::Initialize()
 	{

--- a/Editor/Source/Ludus/Editor/Build/MSBuild/MSBuildPipeline.cpp
+++ b/Editor/Source/Ludus/Editor/Build/MSBuild/MSBuildPipeline.cpp
@@ -12,6 +12,7 @@
 #include <Ludus/Editor/Build/MSBuild/ScriptBuildSettings.h>
 #include <Ludus/Editor/Persistence/BuildPaths.h>
 #include <Ludus/Editor/Persistence/RepositoryPaths.h>
+#include <Ludus/Engine/Persistence/IRuntimeManifestPersistence.h>
 
 namespace
 {
@@ -26,9 +27,13 @@ namespace
 
 namespace Ludus::Editor::Build::MSBuild
 {
-	MSBuildPipeline::MSBuildPipeline()
-		: m_Context(), m_RuntimeHostPipeline(m_Context), m_ScriptPipeline(m_Context)
-	{ }
+	MSBuildPipeline::MSBuildPipeline(
+		const Ludus::Engine::Persistence::IRuntimeManifestPersistence& runtimeManifestPersistence
+	) :
+		m_Context(),
+		m_RuntimeHostPipeline(m_Context, runtimeManifestPersistence),
+		m_ScriptPipeline(m_Context)
+	{}
 
 	void MSBuildPipeline::Initialize()
 	{

--- a/Editor/Source/Ludus/Editor/Build/MSBuild/MSBuildRuntimeHostPipeline.cpp
+++ b/Editor/Source/Ludus/Editor/Build/MSBuild/MSBuildRuntimeHostPipeline.cpp
@@ -13,7 +13,7 @@
 #include <Ludus/Engine/Core/Strings.h>
 #include <Ludus/Engine/Debug/Debug.h>
 #include <Ludus/Engine/FileSystem/FileSystem.h>
-#include <Ludus/Engine/Persistence/LmlRuntimeManifestPersistence.h>
+#include <Ludus/Engine/Persistence/IRuntimeManifestPersistence.h>
 #include <Ludus/Engine/Persistence/Paths.h>
 #include <Ludus/Engine/Platform/Guid.h>
 #include <Ludus/Engine/Platform/Process.h>
@@ -54,12 +54,12 @@ namespace
 	}
 
 	void StageRuntimeHostManifest(
+		const Ludus::Engine::Persistence::IRuntimeManifestPersistence& runtimeManifestPersistence,
 		const std::filesystem::path& manifestFrom,
 		const std::filesystem::path& outputRoot,
 		std::string_view runtimeName
 	)
 	{
-		Ludus::Engine::Persistence::LmlRuntimeManifestPersistence runtimeManifestPersistence;
 		auto runtimeManifest = runtimeManifestPersistence.Load(manifestFrom);
 
 		Ludus::Editor::Build::RewriteScenePathsForPackagedRuntime(runtimeManifest);
@@ -163,9 +163,13 @@ namespace Ludus::Editor::Build::MSBuild
 		Ludus::Engine::FileSystem::WriteAllText(modulePath, text);
 	}
 
-	MSBuildRuntimeHostPipeline::MSBuildRuntimeHostPipeline(MSBuildContext& context)
-		: m_Context(context)
-	{ }
+	MSBuildRuntimeHostPipeline::MSBuildRuntimeHostPipeline(
+		MSBuildContext& context,
+		const Ludus::Engine::Persistence::IRuntimeManifestPersistence& runtimeManifestPersistence
+	) :
+		m_Context(context),
+		m_RuntimeManifestPersistence(runtimeManifestPersistence)
+	{}
 
 	void MSBuildRuntimeHostPipeline::RunBuild(
 		const std::filesystem::path& projectRoot,
@@ -250,6 +254,7 @@ namespace Ludus::Editor::Build::MSBuild
 		);
 
 		StageRuntimeHostManifest(
+			m_RuntimeManifestPersistence,
 			Ludus::Engine::Persistence::Paths::RuntimeManifestFile(projectRoot, projectName),
 			runtimeHostOutputDirectory,
 			projectName

--- a/Editor/Source/Ludus/Editor/Build/RuntimePackage/RuntimeHostPackagePipeline.cpp
+++ b/Editor/Source/Ludus/Editor/Build/RuntimePackage/RuntimeHostPackagePipeline.cpp
@@ -6,20 +6,20 @@
 #include <Ludus/Editor/Build/RuntimePackage/RuntimeHostPackagePipeline.h>
 #include <Ludus/Editor/Persistence/BuildPaths.h>
 #include <Ludus/Engine/FileSystem/FileSystem.h>
-#include <Ludus/Engine/Persistence/LmlRuntimeLaunchSettingsPersistence.h>
-#include <Ludus/Engine/Persistence/LmlRuntimeManifestPersistence.h>
+#include <Ludus/Engine/Persistence/IRuntimeLaunchSettingsPersistence.h>
+#include <Ludus/Engine/Persistence/IRuntimeManifestPersistence.h>
 #include <Ludus/Engine/Persistence/Paths.h>
 #include <Ludus/Engine/Runtime/RuntimeManifest.h>
 
 namespace
 {
 	void StagePackagedRuntimeManifest(
+		const Ludus::Engine::Persistence::IRuntimeManifestPersistence& runtimeManifestPersistence,
 		const std::filesystem::path& manifestFrom,
 		const std::filesystem::path& outputRoot,
 		std::string_view runtimeName
 	)
 	{
-		Ludus::Engine::Persistence::LmlRuntimeManifestPersistence runtimeManifestPersistence;
 		auto runtimeManifest = runtimeManifestPersistence.Load(manifestFrom);
 
 		Ludus::Editor::Build::RewriteScenePathsForPackagedRuntime(runtimeManifest);
@@ -31,12 +31,12 @@ namespace
 	}
 
 	void StagePackagedRuntimeLaunchSettings(
+		const Ludus::Engine::Persistence::IRuntimeLaunchSettingsPersistence& runtimeLaunchSettingsPersistence,
 		const std::filesystem::path& settingsFrom,
 		const std::filesystem::path& outputRoot,
 		std::string_view runtimeName
 	)
 	{
-		Ludus::Engine::Persistence::LmlRuntimeLaunchSettingsPersistence runtimeLaunchSettingsPersistence;
 		auto runtimeLaunchSettings = runtimeLaunchSettingsPersistence.Load(settingsFrom);
 
 		runtimeLaunchSettingsPersistence.Save(
@@ -48,8 +48,16 @@ namespace
 
 namespace Ludus::Editor::Build::RuntimePackage
 {
+	RuntimeHostPackagePipeline::RuntimeHostPackagePipeline(
+		const Ludus::Engine::Persistence::IRuntimeManifestPersistence& runtimeManifestPersistence,
+		const Ludus::Engine::Persistence::IRuntimeLaunchSettingsPersistence& runtimeLaunchSettingsPersistence
+	) :
+		m_RuntimeManifestPersistence(runtimeManifestPersistence),
+		m_RuntimeLaunchSettingsPersistence(runtimeLaunchSettingsPersistence)
+	{}
+
 	void RuntimeHostPackagePipeline::Initialize()
-	{ }
+	{}
 
 	void RuntimeHostPackagePipeline::BuildPackage(
 		const std::filesystem::path& projectRoot,
@@ -83,11 +91,13 @@ namespace Ludus::Editor::Build::RuntimePackage
 			Ludus::Engine::Persistence::Paths::ScenesDirectory(buildOutputDirectory)
 		);
 		StagePackagedRuntimeManifest(
+			m_RuntimeManifestPersistence,
 			Ludus::Engine::Persistence::Paths::RuntimeManifestFile(projectRoot, projectRoot.filename().string()),
 			buildOutputDirectory,
 			projectRoot.filename().string()
 		);
 		StagePackagedRuntimeLaunchSettings(
+			m_RuntimeLaunchSettingsPersistence,
 			Ludus::Engine::Persistence::Paths::RuntimeLaunchSettingsFile(projectRoot, projectRoot.filename().string()),
 			buildOutputDirectory,
 			projectRoot.filename().string()

--- a/Editor/Source/Ludus/Editor/Commands/RequestCommand.cpp
+++ b/Editor/Source/Ludus/Editor/Commands/RequestCommand.cpp
@@ -76,7 +76,7 @@ namespace Ludus::Editor::Commands
 			void operator()(const RequestCommand::SetExecutionFlag& command) const { Requests::EditorState::SetExecutionFlag(command, Context); }
 			void operator()(const RequestCommand::UnsetExecutionFlag& command) const { Requests::EditorState::UnsetExecutionFlag(command, Context); }
 			void operator()(const RequestCommand::SetPanelVisibility&) const { LUDUS_ASSERT(false, "SetPanelVisibility is unavailable during startup."); }
-			void operator()(const RequestCommand::SetTheme&) const { LUDUS_ASSERT(false, "SetTheme is unavailable during startup."); }
+			void operator()(const RequestCommand::SetTheme& command) const { Requests::EditorState::SetTheme(command, Context); }
 			void operator()(const RequestCommand::CloseApplication&) const { Requests::EditorState::CloseApplication(Context); }
 			void operator()(const RequestCommand::ResolveUnsavedChanges&) const { LUDUS_ASSERT(false, "ResolveUnsavedChanges is unavailable during startup."); }
 

--- a/Editor/Source/Ludus/Editor/Commands/Requests/DeferredAction.cpp
+++ b/Editor/Source/Ludus/Editor/Commands/Requests/DeferredAction.cpp
@@ -19,11 +19,9 @@ namespace Ludus::Editor::Commands::Requests
 		{
 			return {
 				.Shell = context.Shell,
-				.ScenePersistence = context.ScenePersistence,
-				.RuntimeManifestPersistence = context.RuntimeManifestPersistence,
-				.RuntimeLaunchSettingsPersistence = context.RuntimeLaunchSettingsPersistence,
-				.ProjectManifestPersistence = context.ProjectManifestPersistence,
-				.PanelRegistry = context.PanelRegistry
+				.Preferences = context.Preferences,
+				.PanelRegistry = context.PanelRegistry,
+				.Persistence = context.Persistence
 			};
 		}
 	}

--- a/Editor/Source/Ludus/Editor/Commands/Requests/EditorState.cpp
+++ b/Editor/Source/Ludus/Editor/Commands/Requests/EditorState.cpp
@@ -80,6 +80,11 @@ namespace Ludus::Editor::Commands::Requests::EditorState
 		SetExecutionFlagAction(command.Flag, context);
 	}
 
+	void SetTheme(const RequestCommand::SetTheme& command, StartupCommandContext& context)
+	{
+		SetThemeAction(command.ThemeId, context);
+	}
+
 	void UnsetExecutionFlag(const RequestCommand::UnsetExecutionFlag& command, StartupCommandContext& context)
 	{
 		UnsetExecutionFlagAction(command.Flag, context);

--- a/Editor/Source/Ludus/Editor/Commands/Requests/EditorStateActions.cpp
+++ b/Editor/Source/Ludus/Editor/Commands/Requests/EditorStateActions.cpp
@@ -3,12 +3,42 @@
 #include <Ludus/Editor/Commands/ProjectSessionCommandContext.h>
 #include <Ludus/Editor/Commands/Requests/EditorStateActions.h>
 #include <Ludus/Editor/Commands/StartupCommandContext.h>
+#include <Ludus/Editor/Persistence/IEditorPreferencesPersistence.h>
+#include <Ludus/Editor/Persistence/ProjectPaths.h>
 #include <Ludus/UI/Context/ThemeContext.h>
 
 namespace Ludus::Editor::Commands::Requests::EditorState
 {
+	namespace
+	{
+		void SaveEditorPreferences(
+			Ludus::Editor::Core::EditorPreferences& editorPreferences,
+			const Ludus::Editor::Persistence::IEditorPreferencesPersistence& editorPreferencesPersistence
+		)
+		{
+			Ludus::Editor::Persistence::ProjectPaths::EnsureEditorRootExists();
+			editorPreferencesPersistence.Save(editorPreferences, Ludus::Editor::Persistence::ProjectPaths::EditorPreferencesFile());
+		}
+
+		void SetTheme(
+			Ludus::UI::Theme::ThemeId themeId,
+			Ludus::Editor::Core::ActiveThemeState& themeState,
+			Ludus::Editor::Core::EditorPreferences& editorPreferences
+		)
+		{
+			Ludus::UI::Context::ThemeContext::SetActiveTheme(themeId);
+			themeState.ActiveThemeId = themeId;
+			editorPreferences.ActiveThemeId = themeId;
+		}
+	}
+
 	void CloseApplicationAction(ProjectSessionCommandContext& context)
 	{
+		SaveEditorPreferences(
+			context.Preferences,
+			context.Persistence.EditorPreferences
+		);
+
 		context.HostContext.SetWindowShouldClose();
 	}
 
@@ -38,8 +68,7 @@ namespace Ludus::Editor::Commands::Requests::EditorState
 
 	void SetThemeAction(Ludus::UI::Theme::ThemeId themeId, ProjectSessionCommandContext& context)
 	{
-		Ludus::UI::Context::ThemeContext::SetActiveTheme(themeId);
-		context.Shell.State.Theme.ActiveThemeId = themeId;
+		SetTheme(themeId, context.Shell.State.Theme, context.Preferences);
 	}
 
 	void UnsetExecutionFlagAction(Ludus::Editor::Core::EditorExecutionFlags flag, ProjectSessionCommandContext& context)
@@ -49,12 +78,22 @@ namespace Ludus::Editor::Commands::Requests::EditorState
 
 	void CloseApplicationAction(StartupCommandContext& context)
 	{
+		SaveEditorPreferences(
+			context.Preferences,
+			context.Persistence.EditorPreferences
+		);
+
 		context.HostContext.SetWindowShouldClose();
 	}
 
 	void SetExecutionFlagAction(Ludus::Editor::Core::EditorExecutionFlags flag, StartupCommandContext& context)
 	{
 		context.Shell.State.Execution.SetFlag(context.HostContext.GetExecutionFlags(), flag);
+	}
+
+	void SetThemeAction(Ludus::UI::Theme::ThemeId themeId, StartupCommandContext& context)
+	{
+		SetTheme(themeId, context.Shell.State.Theme, context.Preferences);
 	}
 
 	void UnsetExecutionFlagAction(Ludus::Editor::Core::EditorExecutionFlags flag, StartupCommandContext& context)

--- a/Editor/Source/Ludus/Editor/Commands/Requests/ProjectActions.cpp
+++ b/Editor/Source/Ludus/Editor/Commands/Requests/ProjectActions.cpp
@@ -7,6 +7,7 @@
 #include <Ludus/Editor/Commands/ProjectSessionCommandContext.h>
 #include <Ludus/Editor/Commands/Requests/ProjectTransitionContext.h>
 #include <Ludus/Editor/Core/ProjectTemplates.h>
+#include <Ludus/Editor/Core/RecentlyOpenedProject.h>
 #include <Ludus/Editor/Core/SceneQueries.h>
 #include <Ludus/Editor/Panels/PanelHelpers.h>
 #include <Ludus/Editor/Persistence/ProjectPaths.h>
@@ -19,10 +20,7 @@ namespace Ludus::Editor::Commands::Requests::Projects
 			const std::filesystem::path& projectRoot,
 			std::string_view projectName,
 			Ludus::Editor::Core::PendingProjectTransition& pendingProjectTransition,
-			Ludus::Engine::Persistence::IScenePersistence& scenePersistence,
-			Ludus::Engine::Persistence::IRuntimeManifestPersistence& runtimeManifestPersistence,
-			Ludus::Engine::Persistence::IRuntimeLaunchSettingsPersistence& runtimeLaunchSettingsPersistence,
-			Ludus::Editor::Persistence::IProjectManifestPersistence& projectManifestPersistence
+			Ludus::Editor::Core::EditorPersistenceContext& persistence
 		)
 		{
 			Ludus::Editor::Persistence::ProjectPaths::EnsureProjectLayoutExists(projectRoot);
@@ -30,7 +28,7 @@ namespace Ludus::Editor::Commands::Requests::Projects
 			// Create default scene.
 			const auto scene = Ludus::Editor::Core::ProjectTemplates::CreateDefaultScene();
 			const auto scenePath = Ludus::Editor::Persistence::ProjectPaths::SceneFile(projectRoot, scene.Name);
-			scenePersistence.Save(
+			persistence.Scene.Save(
 				scene,
 				scenePath
 			);
@@ -42,7 +40,7 @@ namespace Ludus::Editor::Commands::Requests::Projects
 				{ }
 			);
 			const auto runtimeManifestPath = Ludus::Engine::Persistence::Paths::RuntimeManifestFile(projectRoot, projectName);
-			runtimeManifestPersistence.Save(
+			persistence.RuntimeManifest.Save(
 				runtimeManifest,
 				runtimeManifestPath
 			);
@@ -50,7 +48,7 @@ namespace Ludus::Editor::Commands::Requests::Projects
 			// Create runtime settings.
 			const auto runtimeLaunchSettings = Ludus::Engine::Runtime::RuntimeLaunchSettings();
 			const auto runtimeLaunchSettingsPath = Ludus::Engine::Persistence::Paths::RuntimeLaunchSettingsFile(projectRoot, projectName);
-			runtimeLaunchSettingsPersistence.Save(
+			persistence.RuntimeLaunchSettings.Save(
 				runtimeLaunchSettings,
 				runtimeLaunchSettingsPath
 			);
@@ -60,7 +58,7 @@ namespace Ludus::Editor::Commands::Requests::Projects
 				projectRoot,
 				runtimeManifestPath
 			);
-			projectManifestPersistence.Save(
+			persistence.ProjectManifest.Save(
 				projectManifest,
 				Ludus::Editor::Persistence::ProjectPaths::ProjectManifestFile(projectRoot, projectName)
 			);
@@ -76,6 +74,18 @@ namespace Ludus::Editor::Commands::Requests::Projects
 		{
 			Ludus::Editor::Panels::RefreshContentPanel(projectRoot, context.PanelRegistry);
 		}
+
+		void RefreshRecentlyOpenedProjects(
+			const std::filesystem::path& projectRoot,
+			std::string_view projectName,
+			ProjectTransitionContext context
+		)
+		{
+			context.Preferences.AddRecentlyOpenedProject(
+				projectName,
+				Ludus::Editor::Persistence::ProjectPaths::ProjectManifestFile(projectRoot, projectName)
+			);
+		}
 	}
 
 	void CreateProjectAction(const std::string& name, ProjectTransitionContext context)
@@ -87,13 +97,11 @@ namespace Ludus::Editor::Commands::Requests::Projects
 			projectRoot,
 			name,
 			context.Shell.State.PendingProjectTransition,
-			context.ScenePersistence,
-			context.RuntimeManifestPersistence,
-			context.RuntimeLaunchSettingsPersistence,
-			context.ProjectManifestPersistence
+			context.Persistence
 		);
 
 		RefreshContentPanel(projectRoot, context);
+		RefreshRecentlyOpenedProjects(projectRoot, name, context);
 	}
 
 	void CreateProjectAsAction(const std::filesystem::path& path, const std::string& name, ProjectTransitionContext context)
@@ -104,22 +112,23 @@ namespace Ludus::Editor::Commands::Requests::Projects
 			path,
 			name,
 			context.Shell.State.PendingProjectTransition,
-			context.ScenePersistence,
-			context.RuntimeManifestPersistence,
-			context.RuntimeLaunchSettingsPersistence,
-			context.ProjectManifestPersistence
+			context.Persistence
 		);
 
 		RefreshContentPanel(path, context);
+		RefreshRecentlyOpenedProjects(path, name, context);
 	}
 
 	void OpenProjectAction(const std::filesystem::path& path, ProjectTransitionContext context)
 	{
-		auto projectManifest = context.ProjectManifestPersistence.Load(path);
+		auto projectManifest = context.Persistence.ProjectManifest.Load(path);
 		const auto projectRoot = projectManifest.ProjectRoot;
+		const auto projectName = projectManifest.RuntimeManifestPath.filename().stem().stem().string();
+
 		context.Shell.State.PendingProjectTransition = Ludus::Editor::Core::PendingProjectTransition::OpenProject({ std::move(projectManifest) });
 
 		RefreshContentPanel(projectRoot, context);
+		RefreshRecentlyOpenedProjects(projectRoot, projectName, context);
 	}
 
 	void CloseProjectAction(ProjectSessionCommandContext& context)
@@ -156,7 +165,7 @@ namespace Ludus::Editor::Commands::Requests::Projects
 			}
 
 			const auto activeSceneId = editorState.GetActiveSceneId();
-			context.ScenePersistence.Save(
+			context.Persistence.Scene.Save(
 				context.ProjectSession.RuntimeState.GetEditorScene(activeSceneId),
 				editorState.GetActiveSceneSavePath()
 			);
@@ -168,7 +177,7 @@ namespace Ludus::Editor::Commands::Requests::Projects
 
 		if (editorState.IsProjectManifestDirty())
 		{
-			context.ProjectManifestPersistence.Save(
+			context.Persistence.ProjectManifest.Save(
 				persistence.GetProjectManifest(),
 				persistence.GetProjectManifestPath()
 			);
@@ -178,7 +187,7 @@ namespace Ludus::Editor::Commands::Requests::Projects
 
 		if (editorState.IsRuntimeManifestDirty())
 		{
-			context.RuntimeManifestPersistence.Save(
+			context.Persistence.RuntimeManifest.Save(
 				persistence.GetRuntimeManifest(),
 				persistence.GetRuntimeManifestPath()
 			);
@@ -188,7 +197,7 @@ namespace Ludus::Editor::Commands::Requests::Projects
 
 		if (editorState.IsRuntimeLaunchSettingsDirty())
 		{
-			context.RuntimeLaunchSettingsPersistence.Save(
+			context.Persistence.RuntimeLaunchSettings.Save(
 				persistence.GetRuntimeLaunchSettings(),
 				persistence.GetRuntimeLaunchSettingsPath()
 			);

--- a/Editor/Source/Ludus/Editor/Commands/Requests/Projects.cpp
+++ b/Editor/Source/Ludus/Editor/Commands/Requests/Projects.cpp
@@ -4,8 +4,8 @@
 #include <Ludus/Editor/Commands/RequestCommand.h>
 #include <Ludus/Editor/Commands/Requests/DeferredAction.h>
 #include <Ludus/Editor/Commands/Requests/ProjectActions.h>
-#include <Ludus/Editor/Commands/Requests/Projects.h>
 #include <Ludus/Editor/Commands/Requests/ProjectTransitionContext.h>
+#include <Ludus/Editor/Commands/Requests/Projects.h>
 #include <Ludus/Editor/Commands/StartupCommandContext.h>
 
 namespace Ludus::Editor::Commands::Requests::Projects
@@ -16,11 +16,9 @@ namespace Ludus::Editor::Commands::Requests::Projects
 		{
 			return {
 				.Shell = context.Shell,
-				.ScenePersistence = context.ScenePersistence,
-				.RuntimeManifestPersistence = context.RuntimeManifestPersistence,
-				.RuntimeLaunchSettingsPersistence = context.RuntimeLaunchSettingsPersistence,
-				.ProjectManifestPersistence = context.ProjectManifestPersistence,
-				.PanelRegistry = context.PanelRegistry
+				.Preferences = context.Preferences,
+				.PanelRegistry = context.PanelRegistry,
+				.Persistence = context.Persistence
 			};
 		}
 	}

--- a/Editor/Source/Ludus/Editor/Commands/Requests/SceneActions.cpp
+++ b/Editor/Source/Ludus/Editor/Commands/Requests/SceneActions.cpp
@@ -42,12 +42,12 @@ namespace Ludus::Editor::Commands::Requests::Scenes
 			const std::filesystem::path& path
 		)
 		{
-			context.ScenePersistence.Save(context.ProjectSession.RuntimeState.GetEditorScene(id), path);
+			context.Persistence.Scene.Save(context.ProjectSession.RuntimeState.GetEditorScene(id), path);
 		}
 
 		void SaveRuntimeManifest(ProjectSessionCommandContext& context)
 		{
-			context.RuntimeManifestPersistence.Save(
+			context.Persistence.RuntimeManifest.Save(
 				context.ProjectSession.Persistence.GetRuntimeManifest(),
 				context.ProjectSession.Persistence.GetRuntimeManifestPath()
 			);
@@ -88,7 +88,7 @@ namespace Ludus::Editor::Commands::Requests::Scenes
 
 	void OpenSceneAction(const std::filesystem::path& path, ProjectSessionCommandContext& context)
 	{
-		auto scene = context.ScenePersistence.Load(path);
+		auto scene = context.Persistence.Scene.Load(path);
 		context.ProjectSession.SetActiveScene(std::move(scene), path);
 	}
 

--- a/Editor/Source/Ludus/Editor/Commands/Requests/Scenes.cpp
+++ b/Editor/Source/Ludus/Editor/Commands/Requests/Scenes.cpp
@@ -54,7 +54,7 @@ namespace Ludus::Editor::Commands::Requests::Scenes
 			std::filesystem::path path;
 			if (Ludus::Engine::Platform::Modals::SaveFileDialog(
 				path,
-				"scene.ludus",
+				Ludus::Engine::Persistence::Paths::Constants::SceneExtension,
 				Ludus::Engine::Persistence::Paths::ScenesDirectory(context.ProjectSession.Persistence.GetProjectRoot()),
 				"Untitled"
 			))

--- a/Editor/Source/Ludus/Editor/Commands/UI/Dialogs.cpp
+++ b/Editor/Source/Ludus/Editor/Commands/UI/Dialogs.cpp
@@ -45,7 +45,7 @@ namespace Ludus::Editor::Commands::UI::Dialogs
 			std::filesystem::path path;
 			if (Ludus::Engine::Platform::Modals::SaveFileDialog(
 				path,
-				"scene.ludus",
+				Ludus::Engine::Persistence::Paths::Constants::SceneExtension,
 				Ludus::Engine::Persistence::Paths::ScenesDirectory(context.ProjectSession.Persistence.GetProjectRoot()),
 				"Untitled"
 			))

--- a/Editor/Source/Ludus/Editor/Core/EditorHostBuilder.cpp
+++ b/Editor/Source/Ludus/Editor/Core/EditorHostBuilder.cpp
@@ -35,7 +35,9 @@ namespace Ludus::Editor::Core
 			host->AddUpdateSystem<Ludus::Editor::Core::EditorSystem>(
 				*host,
 				std::move(m_EditorConfiguration),
-				std::move(m_StartupOptions)
+				std::move(m_EditorPersistence),
+				std::move(m_EditorPreferences),
+				std::move(m_EditorStartupOptions)
 			);
 		}
 
@@ -54,16 +56,30 @@ namespace Ludus::Editor::Core
 		return *this;
 	}
 
-	EditorHostBuilder& EditorHostBuilder::WithRuntimeOptions(Ludus::Engine::Runtime::RuntimeOptions runtimeOptions)
+	EditorHostBuilder& EditorHostBuilder::WithEditorPersistence(Ludus::Editor::Persistence::EditorPersistence editorPersistence)
 	{
-		m_RuntimeOptions = std::move(runtimeOptions);
+		m_EditorPersistence = std::move(editorPersistence);
 
 		return *this;
 	}
 
-	EditorHostBuilder& EditorHostBuilder::WithStartupOptions(EditorStartupOptions startupOptions)
+	EditorHostBuilder& EditorHostBuilder::WithEditorPreferences(Ludus::Editor::Core::EditorPreferences editorPreferences)
 	{
-		m_StartupOptions = std::move(startupOptions);
+		m_EditorPreferences = std::move(editorPreferences);
+
+		return *this;
+	}
+
+	EditorHostBuilder& EditorHostBuilder::WithEditorStartupOptions(EditorStartupOptions startupOptions)
+	{
+		m_EditorStartupOptions = std::move(startupOptions);
+
+		return *this;
+	}
+
+	EditorHostBuilder& EditorHostBuilder::WithRuntimeOptions(Ludus::Engine::Runtime::RuntimeOptions runtimeOptions)
+	{
+		m_RuntimeOptions = std::move(runtimeOptions);
 
 		return *this;
 	}

--- a/Editor/Source/Ludus/Editor/Core/EditorLauncher.cpp
+++ b/Editor/Source/Ludus/Editor/Core/EditorLauncher.cpp
@@ -1,0 +1,37 @@
+#include "pch.h"
+
+#include <filesystem>
+
+#include <Ludus/Editor/Core/EditorHostBuilder.h>
+#include <Ludus/Editor/Core/EditorLauncher.h>
+#include <Ludus/Editor/Core/EditorPreferences.h>
+#include <Ludus/Editor/Core/EditorStartupOptions.h>
+#include <Ludus/Editor/Persistence/EditorPersistence.h>
+#include <Ludus/Editor/Persistence/ProjectPaths.h>
+
+namespace Ludus::Editor::Core
+{
+	int EditorLauncher::Run(EditorStartupOptions editorStartupOptions)
+	{
+		auto editorPreferences = EditorPreferences::Default();
+		auto editorPersistence = Ludus::Editor::Persistence::EditorPersistence::DefaultText();
+
+		const auto editorPreferencesPath = Ludus::Editor::Persistence::ProjectPaths::EditorPreferencesFile();
+		if (std::filesystem::exists(editorPreferencesPath))
+		{
+			editorPreferences = editorPersistence.EditorPreferences().Load(editorPreferencesPath);
+		}
+
+		auto host = EditorHostBuilder::Create()
+			.WithEditorStartupOptions(std::move(editorStartupOptions))
+			.WithEditorPersistence(std::move(editorPersistence))
+			.WithEditorPreferences(std::move(editorPreferences))
+			.UseEditorHostDefaults()
+			.UseEditor()
+			.Build();
+
+		host->Run();
+
+		return 0;
+	}
+}

--- a/Editor/Source/Ludus/Editor/Core/EditorSession.cpp
+++ b/Editor/Source/Ludus/Editor/Core/EditorSession.cpp
@@ -121,14 +121,14 @@ namespace Ludus::Editor::Core
 	}
 
 	EditorSession::EditorSession(
+		const Ludus::Editor::Persistence::ProjectSessionLoader& projectSessionLoader,
 		Ludus::Engine::Runtime::IHostContext& hostContext,
-		Ludus::Editor::Core::EditorShell& shell,
-		Ludus::Editor::Persistence::ProjectSessionLoader& projectSessionLoader
+		Ludus::Editor::Core::EditorShell& shell
 	) :
 		m_HostContext(hostContext),
 		m_Shell(shell),
 		m_ProjectSessionLoader(projectSessionLoader)
-	{ }
+	{}
 
 	void EditorSession::ApplyTransitions(
 		Ludus::Editor::Core::PendingProjectTransition& pendingTransition,

--- a/Editor/Source/Ludus/Editor/Core/EditorSystem.cpp
+++ b/Editor/Source/Ludus/Editor/Core/EditorSystem.cpp
@@ -4,16 +4,21 @@
 #include <utility>
 #include <vector>
 
+#include <Ludus/Editor/Build/BuildManager.h>
 #include <Ludus/Editor/Commands/EditCommand.h>
 #include <Ludus/Editor/Commands/ProjectSessionCommandContext.h>
 #include <Ludus/Editor/Commands/RequestCommand.h>
 #include <Ludus/Editor/Commands/StartupCommandContext.h>
 #include <Ludus/Editor/Commands/UICommand.h>
+#include <Ludus/Editor/Core/EditorConfiguration.h>
 #include <Ludus/Editor/Core/EditorExecutionFlags.h>
+#include <Ludus/Editor/Core/EditorPreferences.h>
 #include <Ludus/Editor/Core/EditorSystem.h>
+#include <Ludus/Editor/Persistence/EditorPersistence.h>
 #include <Ludus/Engine/Debug/Debug.h>
 #include <Ludus/Engine/Events/Event.h>
 #include <Ludus/Engine/Events/EventType.h>
+#include <Ludus/Engine/Persistence/EnginePersistence.h>
 
 namespace Ludus::Editor::Core
 {
@@ -52,41 +57,50 @@ namespace Ludus::Editor::Core
 
 	EditorSystem::EditorSystem(
 		Ludus::Engine::Runtime::IHostContext& hostContext,
-		Ludus::Editor::Core::EditorConfiguration editorConfiguration,
+		EditorConfiguration editorConfiguration,
+		Ludus::Editor::Persistence::EditorPersistence editorPersistence,
+		EditorPreferences editorPreferences,
 		EditorStartupOptions editorStartupOptions
 	) :
-		m_EditorConfiguration(std::move(editorConfiguration)),
-		m_EditorStartupOptions(std::move(editorStartupOptions)),
-		m_HostContext(hostContext),
-		m_ScenePersistence(),
-		m_RuntimeManifestPersistence(),
-		m_RuntimeLaunchSettingsPersistence(),
-		m_ProjectManifestPersistence(),
-		m_ProjectSessionLoader(
-			m_ScenePersistence,
-			m_RuntimeManifestPersistence,
-			m_RuntimeLaunchSettingsPersistence,
-			m_ProjectManifestPersistence
+		m_EditorPersistence(std::move(editorPersistence)),
+		m_Persistence(
+			m_EditorPersistence.EditorPreferences(),
+			m_EditorPersistence.ProjectManifest(),
+			hostContext.GetEnginePersistence().RuntimeLaunchSettings(),
+			hostContext.GetEnginePersistence().RuntimeManifest(),
+			hostContext.GetEnginePersistence().Scene()
 		),
+		m_ProjectSessionLoader(
+			m_Persistence.Scene,
+			m_Persistence.RuntimeManifest,
+			m_Persistence.RuntimeLaunchSettings,
+			m_Persistence.ProjectManifest
+		),
+		m_EditorConfiguration(std::move(editorConfiguration)),
+		m_EditorPreferences(std::move(editorPreferences)),
+		m_EditorStartupOptions(std::move(editorStartupOptions)),
+		m_Shell(Ludus::Editor::Build::BuildManager::Create(
+			m_Persistence.RuntimeManifest,
+			m_Persistence.RuntimeLaunchSettings
+		)),
+		m_HostContext(hostContext),
 		m_Session(
+			m_ProjectSessionLoader,
 			m_HostContext,
-			m_Shell,
-			m_ProjectSessionLoader
+			m_Shell
 		),
 		m_PanelRegistry(),
-		m_WelcomeWindow()
-	{ }
+		m_WelcomeWindow(m_EditorPreferences.RecentlyOpenedProjects)
+	{}
 
 	Ludus::Editor::Commands::StartupCommandContext EditorSystem::CreateStartupCommandContext()
 	{
 		return {
 			.Shell = m_Shell,
 			.HostContext = m_HostContext,
-			.ScenePersistence = m_ScenePersistence,
-			.RuntimeManifestPersistence = m_RuntimeManifestPersistence,
-			.RuntimeLaunchSettingsPersistence = m_RuntimeLaunchSettingsPersistence,
-			.ProjectManifestPersistence = m_ProjectManifestPersistence,
-			.PanelRegistry = m_PanelRegistry
+			.Preferences = m_EditorPreferences,
+			.PanelRegistry = m_PanelRegistry,
+			.Persistence = m_Persistence
 		};
 	}
 
@@ -96,13 +110,11 @@ namespace Ludus::Editor::Core
 
 		return {
 			.Shell = m_Shell,
-			.ProjectSession = *m_ProjectSession,
 			.HostContext = m_HostContext,
-			.ScenePersistence = m_ScenePersistence,
-			.RuntimeManifestPersistence = m_RuntimeManifestPersistence,
-			.RuntimeLaunchSettingsPersistence = m_RuntimeLaunchSettingsPersistence,
-			.ProjectManifestPersistence = m_ProjectManifestPersistence,
-			.PanelRegistry = m_PanelRegistry
+			.ProjectSession = *m_ProjectSession,
+			.Preferences = m_EditorPreferences,
+			.PanelRegistry = m_PanelRegistry,
+			.Persistence = m_Persistence
 		};
 	}
 
@@ -229,6 +241,16 @@ namespace Ludus::Editor::Core
 		m_HostContext.SetWindowTitle(title);
 	}
 
+	void Ludus::Editor::Core::EditorSystem::ApplyEditorPreferences()
+	{
+		if (m_Shell.State.Theme.ActiveThemeId != m_EditorPreferences.ActiveThemeId)
+		{
+			m_Shell.State.Commands.AddRequestCommand(
+				Ludus::Editor::Commands::RequestCommand::SetTheme { m_EditorPreferences.ActiveThemeId }
+			);
+		}
+	}
+
 	void Ludus::Editor::Core::EditorSystem::ApplyStartupOptions()
 	{
 		if (m_EditorStartupOptions.StartupProjectPath)
@@ -260,7 +282,10 @@ namespace Ludus::Editor::Core
 	void Ludus::Editor::Core::EditorSystem::OnAttachImpl()
 	{
 		m_HostContext.SubscribeWindowCloseEvent(*this);
+
+		ApplyEditorPreferences();
 		ApplyStartupOptions();
+
 		RegisterPanels();
 	}
 

--- a/Editor/Source/Ludus/Editor/Core/WelcomeWindow.cpp
+++ b/Editor/Source/Ludus/Editor/Core/WelcomeWindow.cpp
@@ -1,5 +1,6 @@
 #include "pch.h"
 
+#include <filesystem>
 #include <string>
 
 #include <Ludus/Editor/Commands/RequestCommand.h>
@@ -8,13 +9,15 @@
 #include <Ludus/Editor/Core/ProjectManifest.h>
 #include <Ludus/Editor/Core/WelcomeWindow.h>
 #include <Ludus/Editor/Persistence/ProjectPaths.h>
+#include <Ludus/Editor/Widgets/Buttons.h>
+#include <Ludus/Editor/Widgets/Layout.h>
 #include <Ludus/Engine/Core/Version.h>
 #include <Ludus/Engine/Math/Vector2D.h>
 #include <Ludus/Engine/Platform/Modals.h>
-#include <Ludus/UI/Context/LayoutContext.h>
 #include <Ludus/UI/Context/ThemeContext.h>
 #include <Ludus/UI/Context/ViewportContext.h>
 #include <Ludus/UI/Context/WindowContext.h>
+#include <Ludus/UI/Scope/ChildScope.h>
 #include <Ludus/UI/Scope/FontScope.h>
 #include <Ludus/UI/Scope/StyleScope.h>
 #include <Ludus/UI/Scope/WindowScope.h>
@@ -23,55 +26,415 @@
 
 namespace Ludus::Editor::Core
 {
+	namespace
+	{
+		Ludus::Editor::Commands::CommandSet CreateProjectCommandSet()
+		{
+			Ludus::Editor::Commands::CommandSet out;
+			out.UICommands.emplace_back(
+				Ludus::Editor::Commands::UICommand::OpenCreateProjectDialog { }
+			);
+			return out;
+		}
+
+		Ludus::Editor::Commands::CommandSet OpenProjectCommandSet(const std::filesystem::path& path)
+		{
+			Ludus::Editor::Commands::CommandSet out;
+			out.RequestCommands.emplace_back(
+				Ludus::Editor::Commands::RequestCommand::OpenProject { path }
+			);
+			return out;
+		}
+
+		void DrawWelcomeHeader(const Ludus::Engine::Math::Vector2D& windowSize)
+		{
+			const std::string title = "LUDUS";
+			const std::string subtitle = "Create or open a project";
+
+			{
+				Ludus::UI::Scope::FontScope font(Ludus::Editor::Core::Constants::Welcome::Layout::TitleFontSize);
+				Ludus::UI::Context::WindowContext::SetCursorPosition(
+					Ludus::Editor::Widgets::Layout::GetCenteredTextPositionAtY(
+						title,
+						Ludus::Editor::Core::Constants::Welcome::Layout::TitleY,
+						windowSize.X
+					)
+				);
+				Ludus::UI::Widgets::TextUnformatted(title);
+			}
+
+			{
+				const auto subtitleTextColor = Ludus::UI::Scope::StyleColor(
+					Ludus::UI::Scope::Color::Text,
+					Ludus::UI::Context::ThemeContext::TextSecondary()
+				);
+
+				Ludus::UI::Scope::StyleColorScope subtitleColor({ subtitleTextColor });
+
+				Ludus::UI::Context::WindowContext::SetCursorPosition(
+					Ludus::Editor::Widgets::Layout::GetCenteredTextPositionAtY(
+						subtitle,
+						Ludus::Editor::Core::Constants::Welcome::Layout::SubtitleY,
+						windowSize.X
+					)
+				);
+				Ludus::UI::Widgets::TextUnformatted(subtitle);
+			}
+		}
+
+		std::optional<Ludus::Editor::Commands::CommandSet> DrawWelcomeActionButtons(
+			float windowWidth,
+			const Ludus::Engine::Math::Vector2D& actionButtonSize
+		)
+		{
+			const auto actionButtonsSpacing = Ludus::Editor::Core::Constants::Welcome::Layout::ActionButtonsSpacing;
+
+			{
+				const auto buttonColor = Ludus::UI::Scope::StyleColor(
+					Ludus::UI::Scope::Color::Button,
+					Ludus::UI::Context::ThemeContext::Accent()
+				);
+				const auto buttonHoveredColor = Ludus::UI::Scope::StyleColor(
+					Ludus::UI::Scope::Color::ButtonHovered,
+					Ludus::UI::Context::ThemeContext::AccentHover()
+				);
+				const auto buttonActiveColor = Ludus::UI::Scope::StyleColor(
+					Ludus::UI::Scope::Color::ButtonActive,
+					Ludus::UI::Context::ThemeContext::AccentActive()
+				);
+
+				Ludus::UI::Scope::StyleColorScope primaryButtonColors(
+					{
+						buttonColor,
+						buttonHoveredColor,
+						buttonActiveColor
+					}
+				);
+
+				Ludus::UI::Context::WindowContext::SetCursorPosition(
+					Ludus::Editor::Widgets::Layout::GetCenteredRowElementPositionAtY(
+						Ludus::Editor::Core::Constants::Welcome::Layout::ActionButtonsY,
+						windowWidth,
+						actionButtonSize.X,
+						actionButtonsSpacing,
+						2,
+						0
+					)
+				);
+
+				if (Ludus::UI::Widgets::Button("Create Project", actionButtonSize))
+				{
+					return CreateProjectCommandSet();
+				}
+			}
+
+			Ludus::UI::Context::WindowContext::SetCursorPosition(
+				Ludus::Editor::Widgets::Layout::GetCenteredRowElementPositionAtY(
+					Ludus::Editor::Core::Constants::Welcome::Layout::ActionButtonsY,
+					windowWidth,
+					actionButtonSize.X,
+					actionButtonsSpacing,
+					2,
+					1
+				)
+			);
+
+			if (Ludus::UI::Widgets::Button("Open Project", actionButtonSize))
+			{
+				std::filesystem::path path;
+				if (Ludus::Engine::Platform::Modals::OpenFileDialog(
+					path,
+					Ludus::Editor::Persistence::ProjectPaths::Constants::ProjectManifestExtension,
+					Ludus::Editor::Persistence::ProjectPaths::ProjectsRoot()
+				))
+				{
+					return OpenProjectCommandSet(path);
+				}
+			}
+
+			return std::nullopt;
+		}
+
+		std::optional<Ludus::Editor::Commands::CommandSet> DrawRecentProjectsSection(
+			std::vector<RecentlyOpenedProject>& recentlyOpenedProjects,
+			std::string& error,
+			const Ludus::Engine::Math::Vector2D& windowSize,
+			float recentListWidth,
+			float recentListHeight
+		)
+		{
+			const std::string recentProjectsLabel = "Recently Opened Projects";
+
+			{
+				const auto subtitleTextColor = Ludus::UI::Scope::StyleColor(
+					Ludus::UI::Scope::Color::Text,
+					Ludus::UI::Context::ThemeContext::TextSecondary()
+				);
+
+				Ludus::UI::Scope::StyleColorScope subtitleColor({ subtitleTextColor });
+
+				Ludus::UI::Context::WindowContext::SetCursorPosition(
+					Ludus::Editor::Widgets::Layout::GetCenteredTextPositionAtY(
+						recentProjectsLabel,
+						Ludus::Editor::Core::Constants::Welcome::Layout::RecentProjectsLabelY,
+						windowSize.X
+					)
+				);
+
+				Ludus::UI::Widgets::TextUnformatted(recentProjectsLabel);
+			}
+
+			const auto childBorderSize = Ludus::UI::Scope::StyleVar::Float(
+				Ludus::UI::Scope::Variable::ChildBorderSize,
+				Ludus::Editor::Core::Constants::Welcome::RecentProjects::ListBorderSize
+			);
+			const auto childRounding = Ludus::UI::Scope::StyleVar::Float(
+				Ludus::UI::Scope::Variable::ChildRounding,
+				Ludus::Editor::Core::Constants::Welcome::RecentProjects::ListRounding
+			);
+			const auto childPadding = Ludus::UI::Scope::StyleVar::Vector(
+				Ludus::UI::Scope::Variable::WindowPadding,
+				{
+					Ludus::Editor::Core::Constants::Welcome::RecentProjects::ListPadding,
+					Ludus::Editor::Core::Constants::Welcome::RecentProjects::ListPadding
+				}
+			);
+			const auto childItemSpacing = Ludus::UI::Scope::StyleVar::Vector(
+				Ludus::UI::Scope::Variable::ItemSpacing,
+				{
+					0.0f,
+					Ludus::Editor::Core::Constants::Welcome::RecentProjectRow::Spacing
+				}
+			);
+
+			Ludus::UI::Scope::StyleVarScope childStyle(
+				{
+					childBorderSize,
+					childRounding,
+					childPadding,
+					childItemSpacing
+				}
+			);
+
+			const auto childBackgroundColor = Ludus::UI::Scope::StyleColor(
+				Ludus::UI::Scope::Color::ChildBg,
+				Ludus::UI::Context::ThemeContext::PanelBackground()
+			);
+			const auto childBorderColor = Ludus::UI::Scope::StyleColor(
+				Ludus::UI::Scope::Color::Border,
+				Ludus::UI::Context::ThemeContext::BorderSubtle()
+			);
+
+			Ludus::UI::Scope::StyleColorScope childColors(
+				{
+					childBackgroundColor,
+					childBorderColor
+				}
+			);
+
+			Ludus::UI::Context::WindowContext::SetCursorPosition(
+				{
+					(windowSize.X - recentListWidth) * 0.5f,
+					Ludus::Editor::Core::Constants::Welcome::Layout::RecentListY
+				}
+			);
+
+			Ludus::UI::Scope::ChildScope child(
+				"WelcomeRecentProjects",
+				{ recentListWidth, recentListHeight },
+				Ludus::UI::Flags::Child::AlwaysUseWindowPadding | Ludus::UI::Flags::Child::Borders
+			);
+
+			if (!child)
+			{
+				return std::nullopt;
+			}
+
+			if (recentlyOpenedProjects.empty())
+			{
+				const std::string emptyState = "No recent projects yet.";
+
+				const auto emptyStateTextColor = Ludus::UI::Scope::StyleColor(
+					Ludus::UI::Scope::Color::Text,
+					Ludus::UI::Context::ThemeContext::TextDisabled()
+				);
+
+				Ludus::UI::Scope::StyleColorScope emptyStateColor({ emptyStateTextColor });
+
+				Ludus::UI::Context::WindowContext::SetCursorPosition(
+					Ludus::Editor::Widgets::Layout::GetCenteredTextPositionAtY(
+						emptyState,
+						Ludus::Editor::Core::Constants::Welcome::RecentProjects::ListEmptyStateY,
+						Ludus::UI::Context::WindowContext::GetContentRegionAvailable().X
+					)
+				);
+
+				Ludus::UI::Widgets::TextUnformatted(emptyState);
+				return std::nullopt;
+			}
+
+			std::optional<std::size_t> missingProjectIndexToRemove;
+
+			for (std::size_t projectIndex = 0; projectIndex < recentlyOpenedProjects.size(); ++projectIndex)
+			{
+				const auto& project = recentlyOpenedProjects[projectIndex];
+				const auto pathExists = std::filesystem::exists(project.Path);
+				const auto projectPath = project.Path.string();
+
+				if (Ludus::Editor::Widgets::RecentProjectRow(
+					{
+						.Id = project.DisplayName,
+						.DisplayName = project.DisplayName,
+						.Path = projectPath,
+						.IsPathMissing = !pathExists
+					}
+				))
+				{
+					if (pathExists)
+					{
+						error.clear();
+						return OpenProjectCommandSet(project.Path);
+					}
+
+					missingProjectIndexToRemove = projectIndex;
+				}
+			}
+
+			if (missingProjectIndexToRemove)
+			{
+				const auto removedProject = recentlyOpenedProjects[*missingProjectIndexToRemove];
+				std::erase_if(recentlyOpenedProjects, [&](const RecentlyOpenedProject& project)
+				{
+					return project.Path == removedProject.Path;
+				});
+				error = "Removed missing project '" + removedProject.DisplayName + "' from recent projects.";
+			}
+
+			return std::nullopt;
+		}
+
+		void DrawWelcomeFooter(const Ludus::Engine::Math::Vector2D& windowSize)
+		{
+			const std::string version = Ludus::Engine::Core::Version::ToString(
+				Ludus::Editor::Core::ProjectManifest::CurrentVersion
+			);
+
+			const auto footerTextColor = Ludus::UI::Scope::StyleColor(
+				Ludus::UI::Scope::Color::Text,
+				Ludus::UI::Context::ThemeContext::TextDisabled()
+			);
+
+			Ludus::UI::Scope::StyleColorScope footerColor({ footerTextColor });
+
+			Ludus::UI::Context::WindowContext::SetCursorPosition(
+				Ludus::Editor::Widgets::Layout::GetCenteredTextPositionAtY(
+					version,
+					windowSize.Y - Ludus::Editor::Core::Constants::Welcome::Layout::FooterBottomOffset,
+					windowSize.X
+				)
+			);
+
+			Ludus::UI::Widgets::TextUnformatted(version);
+		}
+	}
+
+	WelcomeWindow::WelcomeWindow(std::vector<RecentlyOpenedProject>& recentlyOpenedProjects) :
+		m_RecentlyOpenedProjects(recentlyOpenedProjects)
+	{}
+
 	std::optional<Ludus::Editor::Commands::CommandSet> WelcomeWindow::Update()
 	{
 		const auto viewport = Ludus::UI::Context::ViewportContext::GetMainViewport();
-
-		Ludus::UI::Context::WindowContext::SetNextWindowPosition(viewport.Position);
-		Ludus::UI::Context::WindowContext::SetNextWindowSize(viewport.Size);
-		Ludus::UI::Context::WindowContext::SetNextWindowViewport(viewport.Id);
-
-		Ludus::UI::Scope::StyleVarScope backgroundStyle({
-			Ludus::UI::Scope::StyleVar::Float(Ludus::UI::Scope::Variable::WindowRounding, 0.0f),
-			Ludus::UI::Scope::StyleVar::Float(Ludus::UI::Scope::Variable::WindowBorderSize, 0.0f),
-			Ludus::UI::Scope::StyleVar::Vector(Ludus::UI::Scope::Variable::WindowPadding, { 0.0f, 0.0f })
-			});
-
-		Ludus::UI::Scope::StyleColorScope backgroundColor({
-			{ Ludus::UI::Scope::Color::WindowBg, Ludus::UI::Context::ThemeContext::OverlayBackground() }
-			});
-
-		Ludus::UI::Scope::WindowScope backgroundWindow(
-			"WelcomeBackground##Background",
-			nullptr,
-			Ludus::Editor::Core::Constants::WelcomeBackgroundWindowFlags
-		);
-
-		const auto windowSize = Ludus::Editor::Core::Constants::WelcomeWindowSize;
+		const auto windowSize = Ludus::Editor::Core::Constants::Welcome::Layout::WindowSize;
+		const auto actionButtonSize = Ludus::Editor::Core::Constants::Welcome::Layout::ActionButtonSize;
+		const auto recentListWidth = Ludus::Editor::Core::Constants::Welcome::RecentProjects::CalculateListWidth(actionButtonSize.X);
+		const auto recentListHeight = Ludus::Editor::Core::Constants::Welcome::RecentProjects::CalculateListHeight();
 
 		const Ludus::Engine::Math::Vector2D windowPosition {
 			viewport.Position.X + (viewport.Size.X - windowSize.X) * 0.5f,
 			viewport.Position.Y + (viewport.Size.Y - windowSize.Y) * 0.5f
 		};
 
+		// Fullscreen overlay background.
+		Ludus::UI::Context::WindowContext::SetNextWindowPosition(viewport.Position);
+		Ludus::UI::Context::WindowContext::SetNextWindowSize(viewport.Size);
+		Ludus::UI::Context::WindowContext::SetNextWindowViewport(viewport.Id);
+
+		const auto backgroundWindowRounding = Ludus::UI::Scope::StyleVar::Float(
+			Ludus::UI::Scope::Variable::WindowRounding,
+			0.0f
+		);
+		const auto backgroundWindowBorderSize = Ludus::UI::Scope::StyleVar::Float(
+			Ludus::UI::Scope::Variable::WindowBorderSize,
+			0.0f
+		);
+		const auto backgroundWindowPadding = Ludus::UI::Scope::StyleVar::Vector(
+			Ludus::UI::Scope::Variable::WindowPadding,
+			{ 0.0f, 0.0f }
+		);
+
+		Ludus::UI::Scope::StyleVarScope backgroundStyle(
+			{
+				backgroundWindowRounding,
+				backgroundWindowBorderSize,
+				backgroundWindowPadding
+			}
+		);
+
+		const auto backgroundWindowColor = Ludus::UI::Scope::StyleColor(
+			Ludus::UI::Scope::Color::WindowBg,
+			Ludus::UI::Context::ThemeContext::OverlayBackground()
+		);
+
+		Ludus::UI::Scope::StyleColorScope backgroundColors({ backgroundWindowColor });
+
+		Ludus::UI::Scope::WindowScope backgroundWindow(
+			"WelcomeBackground##Background",
+			nullptr,
+			Ludus::Editor::Core::Constants::Flags::WelcomeBackgroundWindow
+		);
+
+		// Centered welcome window.
 		Ludus::UI::Context::WindowContext::SetNextWindowPosition(windowPosition);
 		Ludus::UI::Context::WindowContext::SetNextWindowSize(windowSize);
 		Ludus::UI::Context::WindowContext::SetNextWindowViewport(viewport.Id);
 
-		Ludus::UI::Scope::StyleVarScope welcomeWindowStyle({
-			Ludus::UI::Scope::StyleVar::Float(Ludus::UI::Scope::Variable::WindowBorderSize, 1.0f),
-			Ludus::UI::Scope::StyleVar::Float(Ludus::UI::Scope::Variable::WindowRounding, 6.0f)
-			});
+		const auto welcomeWindowBorderSize = Ludus::UI::Scope::StyleVar::Float(
+			Ludus::UI::Scope::Variable::WindowBorderSize,
+			Ludus::Editor::Core::Constants::Welcome::Layout::WindowBorderSize
+		);
+		const auto welcomeWindowRounding = Ludus::UI::Scope::StyleVar::Float(
+			Ludus::UI::Scope::Variable::WindowRounding,
+			Ludus::Editor::Core::Constants::Welcome::Layout::WindowRounding
+		);
 
-		Ludus::UI::Scope::StyleColorScope welcomeWindowColors({
-			{ Ludus::UI::Scope::Color::WindowBg, Ludus::UI::Context::ThemeContext::PanelBackground() },
-			{ Ludus::UI::Scope::Color::Border, Ludus::UI::Context::ThemeContext::BorderSubtle() }
-			});
+		Ludus::UI::Scope::StyleVarScope welcomeWindowStyle(
+			{
+				welcomeWindowBorderSize,
+				welcomeWindowRounding
+			}
+		);
+
+		const auto panelBackgroundColor = Ludus::UI::Scope::StyleColor(
+			Ludus::UI::Scope::Color::WindowBg,
+			Ludus::UI::Context::ThemeContext::PanelBackground()
+		);
+		const auto panelBorderColor = Ludus::UI::Scope::StyleColor(
+			Ludus::UI::Scope::Color::Border,
+			Ludus::UI::Context::ThemeContext::BorderSubtle()
+		);
+
+		Ludus::UI::Scope::StyleColorScope welcomeWindowColors(
+			{
+				panelBackgroundColor,
+				panelBorderColor
+			}
+		);
 
 		Ludus::UI::Scope::WindowScope window(
 			"Welcome to Ludus",
 			nullptr,
-			Ludus::Editor::Core::Constants::WelcomeWindowFlags
+			Ludus::Editor::Core::Constants::Flags::WelcomeWindow
 		);
 
 		if (!window)
@@ -79,96 +442,45 @@ namespace Ludus::Editor::Core
 			return std::nullopt;
 		}
 
-		const std::string title = "LUDUS";
-		const std::string subtitle = "Create or open a project";
-		const std::string version = Ludus::Engine::Core::Version::ToString(
-			Ludus::Editor::Core::ProjectManifest::CurrentVersion
-		);
-		const auto buttonSize = Ludus::Editor::Core::Constants::WelcomeActionButtonSize;
+		DrawWelcomeHeader(windowSize);
 
-		const auto centerTextAtY = [&](const std::string& text, float y)
+		if (auto commands = DrawWelcomeActionButtons(windowSize.X, actionButtonSize))
 		{
-			const auto textSize = Ludus::UI::Context::LayoutContext::CalculateTextSize(text);
-			Ludus::UI::Context::WindowContext::SetCursorPosition({
-				(windowSize.X - textSize.X) * 0.5f,
-				y
-				});
-		};
-
-		const auto centerButtonAtY = [&](float y)
-		{
-			Ludus::UI::Context::WindowContext::SetCursorPosition({
-				(windowSize.X - buttonSize.X) * 0.5f,
-				y
-				});
-		};
-
-		// Title
-		{
-			Ludus::UI::Scope::FontScope font(42.0f);
-			centerTextAtY(title, 28.0f);
-			Ludus::UI::Widgets::TextUnformatted(title);
+			m_Error.clear();
+			return commands;
 		}
 
-		// Subtitle
 		{
-			Ludus::UI::Scope::StyleColorScope subtitleColor({
-				{ Ludus::UI::Scope::Color::Text, Ludus::UI::Context::ThemeContext::TextSecondary() }
-				});
-
-			centerTextAtY(subtitle, 84.0f);
-			Ludus::UI::Widgets::TextUnformatted(subtitle);
-		}
-
-		// Primary action
-		{
-			Ludus::UI::Scope::StyleColorScope primaryButtonColors({
-				{ Ludus::UI::Scope::Color::Button, Ludus::UI::Context::ThemeContext::Accent() },
-				{ Ludus::UI::Scope::Color::ButtonHovered, Ludus::UI::Context::ThemeContext::AccentHover() },
-				{ Ludus::UI::Scope::Color::ButtonActive, Ludus::UI::Context::ThemeContext::AccentActive() }
-				});
-
-			centerButtonAtY(138.0f);
-
-			if (Ludus::UI::Widgets::Button("Create Project", buttonSize))
+			if (auto commands = DrawRecentProjectsSection(
+				m_RecentlyOpenedProjects,
+				m_Error,
+				windowSize,
+				recentListWidth,
+				recentListHeight
+			))
 			{
-				Ludus::Editor::Commands::CommandSet out;
-				out.UICommands.emplace_back(
-					Ludus::Editor::Commands::UICommand::OpenCreateProjectDialog { }
+				return commands;
+			}
+
+			// Error.
+			if (!m_Error.empty())
+			{
+				Ludus::UI::Context::WindowContext::SetCursorPosition(
+					Ludus::Editor::Widgets::Layout::GetCenteredTextPositionAtY(
+						m_Error,
+						windowSize.Y - Ludus::Editor::Core::Constants::Welcome::Layout::ErrorBottomOffset,
+						windowSize.X
+					)
 				);
-				return out;
+
+				Ludus::UI::Widgets::TextUnformattedColor(
+					m_Error,
+					Ludus::UI::Context::ThemeContext::Error()
+				);
 			}
 		}
 
-		// Secondary action
-		centerButtonAtY(208.0f);
-
-		if (Ludus::UI::Widgets::Button("Open Project", buttonSize))
-		{
-			std::filesystem::path path;
-
-			if (Ludus::Engine::Platform::Modals::OpenFileDialog(
-				path,
-				"project.ludus",
-				Ludus::Editor::Persistence::ProjectPaths::ProjectsRoot()))
-			{
-				Ludus::Editor::Commands::CommandSet out;
-				out.RequestCommands.emplace_back(
-					Ludus::Editor::Commands::RequestCommand::OpenProject { path }
-				);
-				return out;
-			}
-		}
-
-		// Footer
-		{
-			Ludus::UI::Scope::StyleColorScope footerColor({
-				{ Ludus::UI::Scope::Color::Text, Ludus::UI::Context::ThemeContext::TextDisabled() }
-				});
-
-			centerTextAtY(version, windowSize.Y - 28.0f);
-			Ludus::UI::Widgets::TextUnformatted(version);
-		}
+		DrawWelcomeFooter(windowSize);
 
 		return std::nullopt;
 	}

--- a/Editor/Source/Ludus/Editor/Dialogs/AddScriptDialog.cpp
+++ b/Editor/Source/Ludus/Editor/Dialogs/AddScriptDialog.cpp
@@ -37,7 +37,7 @@ namespace Ludus::Editor::Dialogs
 		m_EntityId(entityId),
 		m_ScriptNames(std::move(scriptNames)),
 		m_ScriptReferences(std::move(scriptReferences))
-	{ }
+	{}
 
 	AddScriptDialog::Outcome AddScriptDialog::Draw()
 	{
@@ -124,7 +124,7 @@ namespace Ludus::Editor::Dialogs
 					m_ActiveTab == AddScriptTab::Select && m_SelectName == "None"
 				);
 
-				if (Ludus::UI::Widgets::Button("Create", Ludus::Editor::Core::Constants::ModalActionButtonSize))
+				if (Ludus::UI::Widgets::Button("Create", Ludus::Editor::Core::Constants::Shared::ModalActionButtonSize))
 				{
 					if (m_ActiveTab == AddScriptTab::Create)
 					{
@@ -152,9 +152,9 @@ namespace Ludus::Editor::Dialogs
 				}
 			}
 
-			Ludus::UI::Context::LayoutContext::SameLine(0.0f, Ludus::Editor::Core::Constants::StandardInlineSpacing);
+			Ludus::UI::Context::LayoutContext::SameLine(0.0f, Ludus::Editor::Core::Constants::Shared::StandardInlineSpacing);
 
-			if (Ludus::UI::Widgets::Button("Cancel", Ludus::Editor::Core::Constants::ModalActionButtonSize))
+			if (Ludus::UI::Widgets::Button("Cancel", Ludus::Editor::Core::Constants::Shared::ModalActionButtonSize))
 			{
 				m_CreateName.clear();
 				m_SelectName.clear();

--- a/Editor/Source/Ludus/Editor/Dialogs/CreateProjectDialog.cpp
+++ b/Editor/Source/Ludus/Editor/Dialogs/CreateProjectDialog.cpp
@@ -40,7 +40,7 @@ namespace Ludus::Editor::Dialogs
 				Ludus::UI::Widgets::TextUnformattedColor(m_Error.c_str(), Ludus::UI::Context::ThemeContext::Error());
 			}
 
-			if (Ludus::UI::Widgets::Button("Create", Ludus::Editor::Core::Constants::ModalActionButtonSize))
+			if (Ludus::UI::Widgets::Button("Create", Ludus::Editor::Core::Constants::Shared::ModalActionButtonSize))
 			{
 				m_Error = Ludus::Editor::Persistence::ProjectPaths::ValidateFileName(m_Name);
 				if (m_Error.empty())
@@ -55,9 +55,9 @@ namespace Ludus::Editor::Dialogs
 				}
 			}
 
-			Ludus::UI::Context::LayoutContext::SameLine(0.0f, Ludus::Editor::Core::Constants::StandardInlineSpacing);
+			Ludus::UI::Context::LayoutContext::SameLine(0.0f, Ludus::Editor::Core::Constants::Shared::StandardInlineSpacing);
 
-			if (Ludus::UI::Widgets::Button("Cancel", Ludus::Editor::Core::Constants::ModalActionButtonSize))
+			if (Ludus::UI::Widgets::Button("Cancel", Ludus::Editor::Core::Constants::Shared::ModalActionButtonSize))
 			{
 				m_Name.clear();
 				m_IsOpen = false;

--- a/Editor/Source/Ludus/Editor/Dialogs/RenameSceneDialog.cpp
+++ b/Editor/Source/Ludus/Editor/Dialogs/RenameSceneDialog.cpp
@@ -21,7 +21,7 @@ namespace Ludus::Editor::Dialogs
 {
 	RenameSceneDialog::RenameSceneDialog(Ludus::Engine::Core::SceneId sceneId, std::filesystem::path currentPath)
 		: m_SceneId(sceneId), m_CurrentPath(currentPath)
-	{ }
+	{}
 
 	RenameSceneDialog::Outcome RenameSceneDialog::Draw()
 	{
@@ -47,7 +47,7 @@ namespace Ludus::Editor::Dialogs
 				Ludus::UI::Widgets::TextUnformattedColor(m_Error.c_str(), Ludus::UI::Context::ThemeContext::Error());
 			}
 
-			if (Ludus::UI::Widgets::Button("Rename", Ludus::Editor::Core::Constants::ModalActionButtonSize))
+			if (Ludus::UI::Widgets::Button("Rename", Ludus::Editor::Core::Constants::Shared::ModalActionButtonSize))
 			{
 				m_Error = Ludus::Editor::Persistence::ProjectPaths::ValidateFileName(m_Name);
 				if (m_Error.empty())
@@ -62,9 +62,9 @@ namespace Ludus::Editor::Dialogs
 				}
 			}
 
-			Ludus::UI::Context::LayoutContext::SameLine(0.0f, Ludus::Editor::Core::Constants::StandardInlineSpacing);
+			Ludus::UI::Context::LayoutContext::SameLine(0.0f, Ludus::Editor::Core::Constants::Shared::StandardInlineSpacing);
 
-			if (Ludus::UI::Widgets::Button("Cancel", Ludus::Editor::Core::Constants::ModalActionButtonSize))
+			if (Ludus::UI::Widgets::Button("Cancel", Ludus::Editor::Core::Constants::Shared::ModalActionButtonSize))
 			{
 				m_Name.clear();
 				m_IsOpen = false;

--- a/Editor/Source/Ludus/Editor/Dialogs/UnsavedChangesDialog.cpp
+++ b/Editor/Source/Ludus/Editor/Dialogs/UnsavedChangesDialog.cpp
@@ -20,7 +20,7 @@ namespace Ludus::Editor::Dialogs
 		Ludus::Editor::Commands::Requests::DeferredAction deferredAction
 	) :
 		m_DeferredAction(std::move(deferredAction))
-	{ }
+	{}
 
 	UnsavedChangesDialog::Outcome UnsavedChangesDialog::Draw()
 	{
@@ -37,23 +37,23 @@ namespace Ludus::Editor::Dialogs
 		{
 			Ludus::UI::Widgets::TextUnformatted("Save changes?");
 
-			if (Ludus::UI::Widgets::Button("Save", Ludus::Editor::Core::Constants::ModalActionButtonSize))
+			if (Ludus::UI::Widgets::Button("Save", Ludus::Editor::Core::Constants::Shared::ModalActionButtonSize))
 			{
 				m_IsOpen = false;
 				return Outcome::Confirm(UnsavedChangesResult::Save);
 			}
 
-			Ludus::UI::Context::LayoutContext::SameLine(0.0f, Ludus::Editor::Core::Constants::StandardInlineSpacing);
+			Ludus::UI::Context::LayoutContext::SameLine(0.0f, Ludus::Editor::Core::Constants::Shared::StandardInlineSpacing);
 
-			if (Ludus::UI::Widgets::Button("Don't save", Ludus::Editor::Core::Constants::ModalActionButtonSize))
+			if (Ludus::UI::Widgets::Button("Don't save", Ludus::Editor::Core::Constants::Shared::ModalActionButtonSize))
 			{
 				m_IsOpen = false;
 				return Outcome::Confirm(UnsavedChangesResult::DontSave);
 			}
 
-			Ludus::UI::Context::LayoutContext::SameLine(0.0f, Ludus::Editor::Core::Constants::StandardInlineSpacing);
+			Ludus::UI::Context::LayoutContext::SameLine(0.0f, Ludus::Editor::Core::Constants::Shared::StandardInlineSpacing);
 
-			if (Ludus::UI::Widgets::Button("Cancel", Ludus::Editor::Core::Constants::ModalActionButtonSize))
+			if (Ludus::UI::Widgets::Button("Cancel", Ludus::Editor::Core::Constants::Shared::ModalActionButtonSize))
 			{
 				m_IsOpen = false;
 				return Outcome::Confirm(UnsavedChangesResult::Cancel);

--- a/Editor/Source/Ludus/Editor/Panels/ConsolePanel.cpp
+++ b/Editor/Source/Ludus/Editor/Panels/ConsolePanel.cpp
@@ -15,7 +15,7 @@ namespace Ludus::Editor::Panels
 {
 	bool ConsolePanel::UpdateImpl(Ludus::Editor::Core::ProjectSessionContext& context)
 	{
-		const auto flags = Ludus::Editor::Core::Constants::PanelFlags | Ludus::UI::Flags::Window::HorizontalScrollbar;
+		const auto flags = Ludus::Editor::Core::Constants::Flags::Panel | Ludus::UI::Flags::Window::HorizontalScrollbar;
 		auto windowTitle = CreateWindowTitleWithIcon(ICON_FILE_LINES, "Console");
 
 		if (Ludus::UI::Scope::WindowScope window(windowTitle.c_str(), &m_Open, flags); window)

--- a/Editor/Source/Ludus/Editor/Panels/ContentPanel.cpp
+++ b/Editor/Source/Ludus/Editor/Panels/ContentPanel.cpp
@@ -12,7 +12,7 @@ namespace Ludus::Editor::Panels
 {
 	bool ContentPanel::UpdateImpl(Ludus::Editor::Core::ProjectSessionContext& context)
 	{
-		const auto flags = Ludus::Editor::Core::Constants::PanelFlags | Ludus::UI::Flags::Window::HorizontalScrollbar;
+		const auto flags = Ludus::Editor::Core::Constants::Flags::Panel | Ludus::UI::Flags::Window::HorizontalScrollbar;
 		auto windowTitle = CreateWindowTitleWithIcon(ICON_FOLDER_CLOSED, "Content");
 
 		if (Ludus::UI::Scope::WindowScope window(windowTitle.c_str(), &m_Open, flags); window)

--- a/Editor/Source/Ludus/Editor/Panels/DockPanel.cpp
+++ b/Editor/Source/Ludus/Editor/Panels/DockPanel.cpp
@@ -72,7 +72,7 @@ namespace Ludus::Editor::Panels
 			std::filesystem::path path;
 			if (Ludus::Engine::Platform::Modals::SaveFileDialog(
 				path,
-				"scene.ludus",
+				Ludus::Engine::Persistence::Paths::Constants::SceneExtension,
 				Ludus::Engine::Persistence::Paths::ScenesDirectory(projectRoot),
 				"Untitled"
 			))
@@ -105,7 +105,7 @@ namespace Ludus::Editor::Panels
 						std::filesystem::path path;
 						if (Ludus::Engine::Platform::Modals::OpenFileDialog(
 							path,
-							"scene.ludus",
+							Ludus::Engine::Persistence::Paths::Constants::SceneExtension,
 							Ludus::Engine::Persistence::Paths::ScenesDirectory(projectRoot)
 						))
 						{
@@ -158,7 +158,7 @@ namespace Ludus::Editor::Panels
 					std::filesystem::path path;
 					if (Ludus::Engine::Platform::Modals::OpenFileDialog(
 						path,
-						"project.ludus",
+						Ludus::Editor::Persistence::ProjectPaths::Constants::ProjectManifestExtension,
 						Ludus::Editor::Persistence::ProjectPaths::ProjectsRoot()
 					))
 					{
@@ -326,8 +326,8 @@ namespace Ludus::Editor::Panels
 
 	void DockPanel::DrawToolBar(Ludus::Editor::Core::ProjectSessionContext& context)
 	{
-		const auto buttonWidth = Ludus::Editor::Core::Constants::ToolbarButtonExtent;
-		const auto spacing = Ludus::Editor::Core::Constants::StandardInlineSpacing;
+		const auto buttonWidth = Ludus::Editor::Core::Constants::Shared::ToolbarButtonExtent;
+		const auto spacing = Ludus::Editor::Core::Constants::Shared::StandardInlineSpacing;
 		const auto buttonCount = 2;
 
 		const auto totalWidth = buttonCount * buttonWidth + (buttonCount - 1) * spacing;
@@ -416,7 +416,7 @@ namespace Ludus::Editor::Panels
 
 		// The dock panel should never close, as it enables docking for all other panels.
 		auto windowTitle = CreateWindowTitle("DockPanel");
-		if (Ludus::UI::Scope::WindowScope window(windowTitle.c_str(), nullptr, Ludus::Editor::Core::Constants::DockPanelWindowFlags); window)
+		if (Ludus::UI::Scope::WindowScope window(windowTitle.c_str(), nullptr, Ludus::Editor::Core::Constants::Flags::DockPanelWindow); window)
 		{
 			DrawMenuBar(context);
 			DrawToolBar(context);

--- a/Editor/Source/Ludus/Editor/Panels/HierarchyPanel.cpp
+++ b/Editor/Source/Ludus/Editor/Panels/HierarchyPanel.cpp
@@ -271,7 +271,7 @@ namespace Ludus::Editor::Panels
 	bool HierarchyPanel::UpdateImpl(Ludus::Editor::Core::ProjectSessionContext& context)
 	{
 		auto windowTitle = CreateWindowTitleWithIcon(ICON_DIAGRAM_PROJECT, "Hierarchy");
-		if (Ludus::UI::Scope::WindowScope window(windowTitle.c_str(), &m_Open, Ludus::Editor::Core::Constants::PanelFlags); window)
+		if (Ludus::UI::Scope::WindowScope window(windowTitle.c_str(), &m_Open, Ludus::Editor::Core::Constants::Flags::Panel); window)
 		{
 			auto& registry = context.ProjectSession.RuntimeState.GetActiveSceneRegistry();
 

--- a/Editor/Source/Ludus/Editor/Panels/InspectorPanel.cpp
+++ b/Editor/Source/Ludus/Editor/Panels/InspectorPanel.cpp
@@ -521,7 +521,7 @@ namespace Ludus::Editor::Panels
 	bool InspectorPanel::UpdateImpl(Ludus::Editor::Core::ProjectSessionContext& context)
 	{
 		auto windowTitle = CreateWindowTitleWithIcon(ICON_SLIDERS, "Inspector");
-		if (Ludus::UI::Scope::WindowScope window(windowTitle.c_str(), &m_Open, Ludus::Editor::Core::Constants::PanelFlags); window)
+		if (Ludus::UI::Scope::WindowScope window(windowTitle.c_str(), &m_Open, Ludus::Editor::Core::Constants::Flags::Panel); window)
 		{
 			auto& selection = context.ProjectSession.EditorState.GetSelection();
 			if (!selection.HasEntity())

--- a/Editor/Source/Ludus/Editor/Panels/ViewportPanel.cpp
+++ b/Editor/Source/Ludus/Editor/Panels/ViewportPanel.cpp
@@ -36,7 +36,7 @@ namespace Ludus::Editor::Panels
 		m_Target(std::nullopt),
 		m_PreviousTargetSize(),
 		m_DisplayMode(displayMode)
-	{ }
+	{}
 
 	Ludus::Engine::Math::Vector2D ViewportPanel::GetViewportAspectSize(float targetAspectRatio)
 	{
@@ -164,19 +164,17 @@ namespace Ludus::Editor::Panels
 
 	bool ViewportPanel::UpdateImpl(Ludus::Editor::Core::ProjectSessionContext& context)
 	{
-		auto flags = Ludus::Editor::Core::Constants::PanelFlags
+		auto flags = Ludus::Editor::Core::Constants::Flags::Panel
 			| Ludus::UI::Flags::Window::NoScrollbar
 			| Ludus::UI::Flags::Window::NoScrollWithMouse;
 
 		// While simulation is active, suppress UI navigation inputs in all viewport windows.
-		const auto isNavigationInputLocked =
-			context.ProjectSession.RuntimeState.IsSimulationActive();
-		if (isNavigationInputLocked)
+		if (context.ProjectSession.RuntimeState.IsSimulationActive())
 		{
 			flags |= Ludus::UI::Flags::Window::NoNavInputs;
 		}
 
-		Ludus::UI::Scope::StyleVarScope styleVar({ Ludus::UI::Scope::StyleVar::Vector(Ludus::UI::Scope::Variable::WindowPadding, { 0.0f, 0.0f }) });
+		Ludus::UI::Scope::StyleVarScope styleVar(Ludus::UI::Scope::StyleVar::Vector(Ludus::UI::Scope::Variable::WindowPadding, { 0.0f, 0.0f }));
 
 		auto windowTitle = CreateUniqueWindowTitle(m_Title);
 		if (Ludus::UI::Scope::WindowScope window(windowTitle.c_str(), &m_Open, flags); window)

--- a/Editor/Source/Ludus/Editor/Persistence/LmlEditorPreferencesPersistence.cpp
+++ b/Editor/Source/Ludus/Editor/Persistence/LmlEditorPreferencesPersistence.cpp
@@ -1,0 +1,45 @@
+#include "pch.h"
+
+#include <stdexcept>
+#include <utility>
+
+#include <Ludus/Editor/Persistence/LmlEditorPreferencesPersistence.h>
+#include <Ludus/Editor/Serialization/EditorPreferencesSchema.h>
+#include <Ludus/Engine/FileSystem/FileSystem.h>
+#include <Ludus/Engine/Serialization/Codecs/LmlDomCodec.h>
+#include <Ludus/Engine/Serialization/Core/DomDocument.h>
+#include <Ludus/Engine/Serialization/Core/DomTokenStreamReader.h>
+#include <Ludus/Engine/Serialization/Core/DomTokenStreamWriter.h>
+
+namespace Ludus::Editor::Persistence
+{
+	void LmlEditorPreferencesPersistence::Save(const Ludus::Editor::Core::EditorPreferences& editorPreferences, const std::filesystem::path& path) const
+	{
+		Ludus::Engine::Serialization::Core::DomDocument document;
+		Ludus::Engine::Serialization::Core::DomTokenStreamWriter writer { document };
+		Ludus::Editor::Serialization::Schemas::EditorPreferencesSchema::Serialize(writer, editorPreferences);
+
+		Ludus::Engine::Serialization::Codecs::LmlDomCodec codec;
+		const auto text = codec.Encode(*document.GetRoot());
+		Ludus::Engine::FileSystem::WriteAllText(path, text);
+	}
+
+	Ludus::Editor::Core::EditorPreferences LmlEditorPreferencesPersistence::Load(const std::filesystem::path& path) const
+	{
+		const auto text = Ludus::Engine::FileSystem::ReadAllText(path);
+		Ludus::Engine::Serialization::Codecs::LmlDomCodec codec;
+		auto node = codec.Decode(text);
+
+		Ludus::Engine::Serialization::Core::DomDocument document;
+		document.SetRoot(std::move(node));
+
+		Ludus::Engine::Serialization::Core::DomTokenStreamReader reader { document };
+		auto result = Ludus::Editor::Serialization::Schemas::EditorPreferencesSchema::Deserialize(reader);
+		if (!result.HasValue())
+		{
+			throw std::runtime_error(result.GetError().what());
+		}
+
+		return std::move(result.GetValue());
+	}
+}

--- a/Editor/Source/Ludus/Editor/Persistence/LmlProjectManifestPersistence.cpp
+++ b/Editor/Source/Ludus/Editor/Persistence/LmlProjectManifestPersistence.cpp
@@ -13,10 +13,7 @@
 
 namespace Ludus::Editor::Persistence
 {
-	void LmlProjectManifestPersistence::Save(
-		const Ludus::Editor::Core::ProjectManifest& projectManifest,
-		const std::filesystem::path& path
-	)
+	void LmlProjectManifestPersistence::Save(const Ludus::Editor::Core::ProjectManifest& projectManifest, const std::filesystem::path& path) const
 	{
 		Ludus::Engine::Serialization::Core::DomDocument document;
 		Ludus::Engine::Serialization::Core::DomTokenStreamWriter writer { document };
@@ -27,7 +24,7 @@ namespace Ludus::Editor::Persistence
 		Ludus::Engine::FileSystem::WriteAllText(path, text);
 	}
 
-	Ludus::Editor::Core::ProjectManifest LmlProjectManifestPersistence::Load(const std::filesystem::path& path)
+	Ludus::Editor::Core::ProjectManifest LmlProjectManifestPersistence::Load(const std::filesystem::path& path) const
 	{
 		const auto text = Ludus::Engine::FileSystem::ReadAllText(path);
 		Ludus::Engine::Serialization::Codecs::LmlDomCodec codec;

--- a/Editor/Source/Ludus/Editor/Persistence/ProjectSessionLoader.cpp
+++ b/Editor/Source/Ludus/Editor/Persistence/ProjectSessionLoader.cpp
@@ -17,23 +17,23 @@
 namespace Ludus::Editor::Persistence
 {
 	ProjectSessionLoader::ProjectSessionLoader(
-		Ludus::Engine::Persistence::IScenePersistence& scenePersistence,
-		Ludus::Engine::Persistence::IRuntimeManifestPersistence& runtimeManifestPersistence,
-		Ludus::Engine::Persistence::IRuntimeLaunchSettingsPersistence& runtimeLaunchSettingsPersistence,
-		Ludus::Editor::Persistence::IProjectManifestPersistence& projectManifestPersistence
+		const Ludus::Engine::Persistence::IScenePersistence& scenePersistence,
+		const Ludus::Engine::Persistence::IRuntimeManifestPersistence& runtimeManifestPersistence,
+		const Ludus::Engine::Persistence::IRuntimeLaunchSettingsPersistence& runtimeLaunchSettingsPersistence,
+		const Ludus::Editor::Persistence::IProjectManifestPersistence& projectManifestPersistence
 	) :
 		m_ScenePersistence(scenePersistence),
 		m_RuntimeManifestPersistence(runtimeManifestPersistence),
 		m_RuntimeLaunchSettingsPersistence(runtimeLaunchSettingsPersistence),
 		m_ProjectManifestPersistence(projectManifestPersistence)
-	{ }
+	{}
 
-	LoadedProjectData ProjectSessionLoader::Load(const std::filesystem::path& projectManifestPath)
+	LoadedProjectData ProjectSessionLoader::Load(const std::filesystem::path& projectManifestPath) const
 	{
 		return Load(m_ProjectManifestPersistence.Load(projectManifestPath));
 	}
 
-	LoadedProjectData ProjectSessionLoader::Load(Ludus::Editor::Core::ProjectManifest projectManifest)
+	LoadedProjectData ProjectSessionLoader::Load(Ludus::Editor::Core::ProjectManifest projectManifest) const
 	{
 		const auto runtimeName = projectManifest.ProjectRoot.filename().string();
 		auto runtimeManifest = m_RuntimeManifestPersistence.Load(projectManifest.RuntimeManifestPath);

--- a/Editor/Source/Ludus/Editor/Widgets/Buttons.cpp
+++ b/Editor/Source/Ludus/Editor/Widgets/Buttons.cpp
@@ -1,0 +1,217 @@
+#include "pch.h"
+
+#include <algorithm>
+#include <string>
+#include <vector>
+
+#include <Ludus/Editor/Core/Constants.h>
+#include <Ludus/Editor/Widgets/Buttons.h>
+#include <Ludus/Engine/Core/Strings.h>
+#include <Ludus/UI/Context/InputContext.h>
+#include <Ludus/UI/Context/LayoutContext.h>
+#include <Ludus/UI/Context/ThemeContext.h>
+#include <Ludus/UI/Context/WindowContext.h>
+#include <Ludus/UI/Types/DrawList.h>
+#include <Ludus/UI/Widgets/Buttons.h>
+
+namespace Ludus::Editor::Widgets
+{
+	namespace
+	{
+		float MeasureTextWidth(std::string_view text)
+		{
+			return Ludus::UI::Context::LayoutContext::CalculateTextSize(std::string(text)).X;
+		}
+
+		std::vector<float> MeasureCharacterWidths(std::string_view text)
+		{
+			std::vector<float> characterWidths;
+			characterWidths.reserve(text.size());
+
+			for (const char character : text)
+			{
+				characterWidths.push_back(MeasureTextWidth(std::string_view(&character, 1)));
+			}
+
+			return characterWidths;
+		}
+
+		std::string TruncateDisplayNameToWidth(std::string_view text, float maxWidth)
+		{
+			if (text.empty() || MeasureTextWidth(text) <= maxWidth)
+			{
+				return std::string(text);
+			}
+
+			const auto ellipsisWidth = MeasureTextWidth(Ludus::Engine::Core::Strings::DefaultEllipsis);
+			if (ellipsisWidth > maxWidth)
+			{
+				return { };
+			}
+
+			const auto characterWidths = MeasureCharacterWidths(text);
+			float currentWidth = ellipsisWidth;
+
+			std::size_t leftCount = 0;
+			for (; leftCount < characterWidths.size(); ++leftCount)
+			{
+				if (currentWidth + characterWidths[leftCount] > maxWidth)
+				{
+					break;
+				}
+
+				currentWidth += characterWidths[leftCount];
+			}
+
+			return Ludus::Engine::Core::Strings::EllipsizeAt(text, leftCount);
+		}
+
+		std::string TruncateProjectPathToWidth(std::string_view path, float maxWidth)
+		{
+			if (path.empty() || MeasureTextWidth(path) <= maxWidth)
+			{
+				return std::string(path);
+			}
+
+			const auto ellipsisWidth = MeasureTextWidth(Ludus::Engine::Core::Strings::DefaultEllipsis);
+			if (ellipsisWidth > maxWidth)
+			{
+				return { };
+			}
+
+			const auto characterWidths = MeasureCharacterWidths(path);
+			std::size_t leftCount = path.size() / 2;
+			std::size_t rightCount = path.size() - leftCount;
+
+			float leftWidth = 0.0f;
+			for (std::size_t index = 0; index < leftCount; ++index)
+			{
+				leftWidth += characterWidths[index];
+			}
+
+			float rightWidth = 0.0f;
+			for (std::size_t index = path.size() - rightCount; index < path.size(); ++index)
+			{
+				rightWidth += characterWidths[index];
+			}
+
+			while (leftCount > 0 && rightCount > 0)
+			{
+				if (leftWidth + ellipsisWidth + rightWidth <= maxWidth)
+				{
+					return Ludus::Engine::Core::Strings::EllipsizeAt(path, leftCount, rightCount);
+				}
+
+				if (rightCount >= leftCount)
+				{
+					rightWidth -= characterWidths[path.size() - rightCount];
+					--rightCount;
+				}
+				else
+				{
+					leftWidth -= characterWidths[leftCount - 1];
+					--leftCount;
+				}
+			}
+
+			return std::string(Ludus::Engine::Core::Strings::DefaultEllipsis);
+		}
+	}
+
+	WidgetState ButtonBase(const char* id, const Ludus::Engine::Math::Vector2D size)
+	{
+		const auto min = Ludus::UI::Context::WindowContext::GetCursorScreenPosition();
+		const auto pressed = Ludus::UI::Widgets::InvisibleButton(id, size);
+
+		return
+		{
+			.Active = Ludus::UI::Context::InputContext::IsItemActive(),
+			.Hovered = Ludus::UI::Context::InputContext::IsItemHovered(),
+			.Pressed = pressed,
+			.Min = min,
+			.Max = { min.X + size.X, min.Y + size.Y }
+		};
+	}
+
+	bool RecentProjectRow(const RecentProjectRowData& rowData)
+	{
+		const auto width = Ludus::UI::Context::WindowContext::GetContentRegionAvailable().X;
+		const auto height = Ludus::Editor::Core::Constants::Welcome::RecentProjectRow::Height;
+
+		const auto widgetState = ButtonBase(rowData.Id.data(), { width, height });
+
+		const auto background = widgetState.Active
+			? Ludus::UI::Context::ThemeContext::ControlActive()
+			: widgetState.Hovered
+			? Ludus::UI::Context::ThemeContext::RowHover()
+			: Ludus::UI::Context::ThemeContext::ControlBackground();
+
+		const auto border = rowData.IsPathMissing
+			? Ludus::UI::Context::ThemeContext::Error()
+			: widgetState.Hovered
+			? Ludus::UI::Context::ThemeContext::BorderStrong()
+			: Ludus::UI::Context::ThemeContext::BorderSubtle();
+
+		const std::string missingBadgeText = "Missing";
+		const auto badgeWidth = rowData.IsPathMissing
+			? Ludus::UI::Context::LayoutContext::CalculateTextSize(missingBadgeText).X
+			: 0.0f;
+
+		const auto badgeReservedWidth = rowData.IsPathMissing
+			? badgeWidth + Ludus::Editor::Core::Constants::Welcome::RecentProjectRow::BadgeGap
+			: 0.0f;
+
+		const auto availableTextWidth = std::max(
+			0.0f,
+			width
+			- Ludus::Editor::Core::Constants::Welcome::RecentProjectRow::TextPaddingX * 2.0f
+			- badgeReservedWidth);
+
+		const auto titleText = TruncateDisplayNameToWidth(rowData.DisplayName, availableTextWidth);
+		const auto pathText = TruncateProjectPathToWidth(rowData.Path, availableTextWidth);
+
+		auto drawList = Ludus::UI::Types::DrawList();
+		drawList.AddRectFilled(
+			widgetState.Min,
+			widgetState.Max,
+			background,
+			Ludus::Editor::Core::Constants::Welcome::RecentProjectRow::Rounding);
+
+		drawList.AddRect(
+			widgetState.Min,
+			widgetState.Max,
+			border,
+			Ludus::Editor::Core::Constants::Welcome::RecentProjectRow::Rounding);
+
+		drawList.AddText(
+			{
+				widgetState.Min.X + Ludus::Editor::Core::Constants::Welcome::RecentProjectRow::TextPaddingX,
+				widgetState.Min.Y + Ludus::Editor::Core::Constants::Welcome::RecentProjectRow::TitleOffsetY
+			},
+			Ludus::UI::Context::ThemeContext::TextPrimary(),
+			titleText.c_str());
+
+		drawList.AddText(
+			{
+				widgetState.Min.X + Ludus::Editor::Core::Constants::Welcome::RecentProjectRow::TextPaddingX,
+				widgetState.Min.Y + Ludus::Editor::Core::Constants::Welcome::RecentProjectRow::PathOffsetY
+			},
+			Ludus::UI::Context::ThemeContext::TextSecondary(),
+			pathText.c_str());
+
+		if (rowData.IsPathMissing)
+		{
+			drawList.AddText(
+				{
+					widgetState.Max.X
+					- Ludus::Editor::Core::Constants::Welcome::RecentProjectRow::TextPaddingX
+				- badgeWidth,
+				widgetState.Min.Y + Ludus::Editor::Core::Constants::Welcome::RecentProjectRow::TitleOffsetY
+				},
+				Ludus::UI::Context::ThemeContext::Error(),
+				missingBadgeText.c_str());
+		}
+
+		return widgetState.Pressed;
+	}
+}

--- a/Editor/Source/Ludus/Editor/Widgets/Input.cpp
+++ b/Editor/Source/Ludus/Editor/Widgets/Input.cpp
@@ -61,9 +61,9 @@ namespace Ludus::Editor::Widgets
 		bool changed = false;
 
 		const auto cellPaddingX = Ludus::UI::Context::ThemeContext::GetActiveMetrics().CellPadding.X;
-		Ludus::UI::Scope::StyleVarScope cellPaddingScope({
+		Ludus::UI::Scope::StyleVarScope cellPaddingScope(
 			Ludus::UI::Scope::StyleVar::Vector(Ludus::UI::Scope::Variable::CellPadding, { cellPaddingX, 0.0f })
-			});
+		);
 
 		if (Ludus::UI::Scope::TableScope table(id, 2); table)
 		{

--- a/EditorHost/main.cpp
+++ b/EditorHost/main.cpp
@@ -1,13 +1,9 @@
-#include <Ludus/Editor/Core/EditorHostBuilder.h>
+#include <Ludus/Editor/Core/EditorLauncher.h>
 #include <Ludus/Editor/Core/EditorStartupOptions.h>
 
 int main(int argc, char* argv[])
 {
-	auto host = Ludus::Editor::Core::EditorHostBuilder::Create()
-		.WithStartupOptions(Ludus::Editor::Core::EditorStartupOptions::FromCommandLineArgs(argc, argv))
-		.UseEditorHostDefaults()
-		.UseEditor()
-		.Build();
-
-	host->Run();
+	return Ludus::Editor::Core::EditorLauncher::Run(
+		Ludus::Editor::Core::EditorStartupOptions::FromCommandLineArgs(argc, argv)
+	);
 }

--- a/EditorTests/Ludus/EditorTests/Persistence/ProjectPathsTests.cpp
+++ b/EditorTests/Ludus/EditorTests/Persistence/ProjectPathsTests.cpp
@@ -34,6 +34,18 @@ namespace Ludus::EditorTests::Persistence
 		ASSERT_EQ(path, expected);
 	}
 
+	TEST(ProjectPaths, EditorRoot_Should_ReturnEditorDirectoryUnderLudusRoot)
+	{
+		// Arrange.
+		const auto expected = ProjectPaths::LudusRoot() / "Editor";
+
+		// Act.
+		const auto path = ProjectPaths::EditorRoot();
+
+		// Assert.
+		ASSERT_EQ(path, expected);
+	}
+
 	TEST(ProjectPaths, ProjectsRoot_Should_ReturnProjectsDirectoryUnderLudusRoot)
 	{
 		// Arrange.
@@ -170,6 +182,18 @@ namespace Ludus::EditorTests::Persistence
 
 		// Assert.
 		ASSERT_TRUE(error.empty());
+	}
+
+	TEST(ProjectPaths, EditorPreferencesFile_Should_ReturnPreferencesFileUnderEditorRoot)
+	{
+		// Arrange.
+		const auto expected = ProjectPaths::EditorRoot() / "editor.preferences.ludus";
+
+		// Act.
+		const auto path = ProjectPaths::EditorPreferencesFile();
+
+		// Assert.
+		ASSERT_EQ(path, expected);
 	}
 
 	TEST(ProjectPaths, ScriptsDirectory_Should_ReturnScriptsPath)

--- a/Engine/Engine.vcxproj
+++ b/Engine/Engine.vcxproj
@@ -31,6 +31,7 @@
     <ClInclude Include="Include\Ludus\Engine\Components\ScriptComponent.h" />
     <ClInclude Include="Include\Ludus\Engine\Core\Enums\EnumBits.h" />
     <ClInclude Include="Include\Ludus\Engine\Core\Id.h" />
+    <ClInclude Include="Include\Ludus\Engine\Persistence\EnginePersistence.h" />
     <ClInclude Include="Include\Ludus\Engine\Runtime\PendingSceneTransition.h" />
     <ClInclude Include="Include\Ludus\Engine\Runtime\SceneRuntimeState.h" />
     <ClInclude Include="Include\Ludus\Engine\Runtime\SceneSystem.h" />

--- a/Engine/Include/Ludus/Engine/Core/Strings.h
+++ b/Engine/Include/Ludus/Engine/Core/Strings.h
@@ -1,11 +1,15 @@
 #pragma once
 
+#include <algorithm>
+#include <filesystem>
 #include <stdexcept>
 #include <string>
 #include <string_view>
 
 namespace Ludus::Engine::Core::Strings
 {
+	inline const std::string_view DefaultEllipsis = "...";
+
 	inline std::string ReplaceAll(std::string value, std::string_view from, std::string_view to)
 	{
 		if (from.empty())
@@ -60,5 +64,53 @@ namespace Ludus::Engine::Core::Strings
 		}
 
 		text.replace(contentStart, contentLength, region);
+	}
+
+	inline std::string NormalizeFileExtension(std::string_view extension)
+	{
+		while (!extension.empty() && (extension.front() == '*' || extension.front() == '.'))
+		{
+			extension.remove_prefix(1);
+		}
+
+		return std::string(extension);
+	}
+
+	inline std::string EllipsizeAt(
+		std::string_view text,
+		std::size_t leftCount,
+		std::size_t rightCount = 0,
+		std::string_view ellipsis = DefaultEllipsis
+	)
+	{
+		if (text.empty())
+		{
+			return std::string(text);
+		}
+
+		leftCount = std::min(leftCount, text.size());
+		rightCount = std::min(rightCount, text.size() - leftCount);
+
+		if (leftCount + rightCount >= text.size())
+		{
+			return std::string(text);
+		}
+
+		if (ellipsis.empty())
+		{
+			return std::string(text.substr(0, leftCount)) + std::string(text.substr(text.size() - rightCount));
+		}
+
+		std::string result;
+		result.reserve(leftCount + ellipsis.size() + rightCount);
+		result.append(text.substr(0, leftCount));
+		result.append(ellipsis);
+
+		if (rightCount > 0)
+		{
+			result.append(text.substr(text.size() - rightCount));
+		}
+
+		return result;
 	}
 }

--- a/Engine/Include/Ludus/Engine/Persistence/EnginePersistence.h
+++ b/Engine/Include/Ludus/Engine/Persistence/EnginePersistence.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <memory>
+
+#include <Ludus/Engine/Persistence/IRuntimeLaunchSettingsPersistence.h>
+#include <Ludus/Engine/Persistence/IRuntimeManifestPersistence.h>
+#include <Ludus/Engine/Persistence/IScenePersistence.h>
+#include <Ludus/Engine/Persistence/LmlRuntimeLaunchSettingsPersistence.h>
+#include <Ludus/Engine/Persistence/LmlRuntimeManifestPersistence.h>
+#include <Ludus/Engine/Persistence/LmlScenePersistence.h>
+
+namespace Ludus::Engine::Persistence
+{
+	class EnginePersistence
+	{
+	private:
+		std::unique_ptr<IRuntimeLaunchSettingsPersistence> m_RuntimeLaunchSettings;
+		std::unique_ptr<IRuntimeManifestPersistence> m_RuntimeManifest;
+		std::unique_ptr<IScenePersistence> m_Scene;
+
+		EnginePersistence(
+			std::unique_ptr<IRuntimeLaunchSettingsPersistence> runtimeLaunchSettings,
+			std::unique_ptr<IRuntimeManifestPersistence> runtimeManifest,
+			std::unique_ptr<IScenePersistence> scene
+		) :
+			m_RuntimeLaunchSettings(std::move(runtimeLaunchSettings)),
+			m_RuntimeManifest(std::move(runtimeManifest)),
+			m_Scene(std::move(scene))
+		{}
+
+	public:
+		static EnginePersistence DefaultText()
+		{
+			return {
+				std::make_unique<LmlRuntimeLaunchSettingsPersistence>(),
+				std::make_unique<LmlRuntimeManifestPersistence>(),
+				std::make_unique<LmlScenePersistence>()
+			};
+		}
+
+		const IRuntimeLaunchSettingsPersistence& RuntimeLaunchSettings() const { return *m_RuntimeLaunchSettings; }
+		const IRuntimeManifestPersistence& RuntimeManifest() const { return *m_RuntimeManifest; }
+		const IScenePersistence& Scene() const { return *m_Scene; }
+	};
+}

--- a/Engine/Include/Ludus/Engine/Persistence/IRuntimeLaunchSettingsPersistence.h
+++ b/Engine/Include/Ludus/Engine/Persistence/IRuntimeLaunchSettingsPersistence.h
@@ -11,7 +11,7 @@ namespace Ludus::Engine::Persistence
 	public:
 		virtual ~IRuntimeLaunchSettingsPersistence() = default;
 
-		virtual void Save(const Ludus::Engine::Runtime::RuntimeLaunchSettings& runtimeLaunchSettings, const std::filesystem::path& path) = 0;
-		virtual Ludus::Engine::Runtime::RuntimeLaunchSettings Load(const std::filesystem::path& path) = 0;
+		virtual void Save(const Ludus::Engine::Runtime::RuntimeLaunchSettings& runtimeLaunchSettings, const std::filesystem::path& path) const = 0;
+		virtual Ludus::Engine::Runtime::RuntimeLaunchSettings Load(const std::filesystem::path& path) const = 0;
 	};
 }

--- a/Engine/Include/Ludus/Engine/Persistence/IRuntimeManifestPersistence.h
+++ b/Engine/Include/Ludus/Engine/Persistence/IRuntimeManifestPersistence.h
@@ -11,7 +11,7 @@ namespace Ludus::Engine::Persistence
 	public:
 		virtual ~IRuntimeManifestPersistence() = default;
 
-		virtual void Save(const Ludus::Engine::Runtime::RuntimeManifest& runtimeManifest, const std::filesystem::path& path) = 0;
-		virtual Ludus::Engine::Runtime::RuntimeManifest Load(const std::filesystem::path& path) = 0;
+		virtual void Save(const Ludus::Engine::Runtime::RuntimeManifest& runtimeManifest, const std::filesystem::path& path) const = 0;
+		virtual Ludus::Engine::Runtime::RuntimeManifest Load(const std::filesystem::path& path) const = 0;
 	};
 }

--- a/Engine/Include/Ludus/Engine/Persistence/IScenePersistence.h
+++ b/Engine/Include/Ludus/Engine/Persistence/IScenePersistence.h
@@ -11,7 +11,7 @@ namespace Ludus::Engine::Persistence
 	public:
 		virtual ~IScenePersistence() = default;
 
-		virtual void Save(const Ludus::Engine::Core::Scene& scene, const std::filesystem::path& path) = 0;
-		virtual Ludus::Engine::Core::Scene Load(const std::filesystem::path& path) = 0;
+		virtual void Save(const Ludus::Engine::Core::Scene& scene, const std::filesystem::path& path) const = 0;
+		virtual Ludus::Engine::Core::Scene Load(const std::filesystem::path& path) const = 0;
 	};
 }

--- a/Engine/Include/Ludus/Engine/Persistence/LmlRuntimeLaunchSettingsPersistence.h
+++ b/Engine/Include/Ludus/Engine/Persistence/LmlRuntimeLaunchSettingsPersistence.h
@@ -12,7 +12,7 @@ namespace Ludus::Engine::Persistence
 	public:
 		LmlRuntimeLaunchSettingsPersistence() = default;
 
-		void Save(const Ludus::Engine::Runtime::RuntimeLaunchSettings& runtimeLaunchSettings, const std::filesystem::path& path) override;
-		Ludus::Engine::Runtime::RuntimeLaunchSettings Load(const std::filesystem::path& path) override;
+		void Save(const Ludus::Engine::Runtime::RuntimeLaunchSettings& runtimeLaunchSettings, const std::filesystem::path& path) const override;
+		Ludus::Engine::Runtime::RuntimeLaunchSettings Load(const std::filesystem::path& path) const override;
 	};
 }

--- a/Engine/Include/Ludus/Engine/Persistence/LmlRuntimeManifestPersistence.h
+++ b/Engine/Include/Ludus/Engine/Persistence/LmlRuntimeManifestPersistence.h
@@ -12,7 +12,7 @@ namespace Ludus::Engine::Persistence
 	public:
 		LmlRuntimeManifestPersistence() = default;
 
-		void Save(const Ludus::Engine::Runtime::RuntimeManifest& runtimeManifest, const std::filesystem::path& path) override;
-		Ludus::Engine::Runtime::RuntimeManifest Load(const std::filesystem::path& path) override;
+		void Save(const Ludus::Engine::Runtime::RuntimeManifest& runtimeManifest, const std::filesystem::path& path) const override;
+		Ludus::Engine::Runtime::RuntimeManifest Load(const std::filesystem::path& path) const override;
 	};
 }

--- a/Engine/Include/Ludus/Engine/Persistence/LmlScenePersistence.h
+++ b/Engine/Include/Ludus/Engine/Persistence/LmlScenePersistence.h
@@ -12,7 +12,7 @@ namespace Ludus::Engine::Persistence
 	public:
 		LmlScenePersistence() = default;
 
-		void Save(const Ludus::Engine::Core::Scene& scene, const std::filesystem::path& path) override;
-		Ludus::Engine::Core::Scene Load(const std::filesystem::path& path) override;
+		void Save(const Ludus::Engine::Core::Scene& scene, const std::filesystem::path& path) const override;
+		Ludus::Engine::Core::Scene Load(const std::filesystem::path& path) const override;
 	};
 }

--- a/Engine/Include/Ludus/Engine/Runtime/ApplicationHost.h
+++ b/Engine/Include/Ludus/Engine/Runtime/ApplicationHost.h
@@ -8,6 +8,7 @@
 #include <Ludus/Engine/Events/EventHandler.h>
 #include <Ludus/Engine/Graphics/GLContext.h>
 #include <Ludus/Engine/Graphics/RenderTarget.h>
+#include <Ludus/Engine/Persistence/EnginePersistence.h>
 #include <Ludus/Engine/Runtime/IHostContext.h>
 #include <Ludus/Engine/Runtime/RuntimeOptions.h>
 #include <Ludus/Engine/Runtime/SystemScheduler.h>
@@ -33,6 +34,7 @@ namespace Ludus::Engine::Runtime
 	class ApplicationHost : public Ludus::Engine::Events::EventHandler, public IHostContext
 	{
 	private:
+		const Ludus::Engine::Persistence::EnginePersistence m_Persistence;
 		Ludus::Engine::Events::EventBus m_EventBus;
 		Ludus::Engine::Core::Enums::FlagSet m_ExecutionFlags;
 		Ludus::Engine::Windowing::Input m_Input;
@@ -48,6 +50,7 @@ namespace Ludus::Engine::Runtime
 		virtual bool ProcessEvent(const Ludus::Engine::Events::Event& event) override;
 
 		ApplicationHost(
+			Ludus::Engine::Persistence::EnginePersistence enginePersistence,
 			Ludus::Engine::Runtime::RuntimeOptions runtimeOptions,
 			Ludus::Engine::Windowing::WindowOptions windowOptions
 		);
@@ -56,6 +59,7 @@ namespace Ludus::Engine::Runtime
 		~ApplicationHost();
 
 		static std::unique_ptr<ApplicationHost> Create(
+			Ludus::Engine::Persistence::EnginePersistence enginePersistence = Ludus::Engine::Persistence::EnginePersistence::DefaultText(),
 			Ludus::Engine::Runtime::RuntimeOptions runtimeOptions = Ludus::Engine::Runtime::RuntimeOptions(),
 			Ludus::Engine::Windowing::WindowOptions windowOptions = Ludus::Engine::Windowing::WindowOptions()
 		);
@@ -77,6 +81,8 @@ namespace Ludus::Engine::Runtime
 		virtual GLFWwindow* GetWindowHandle() const override;
 
 		virtual Ludus::Engine::Windowing::Input& GetInput() override;
+
+		virtual const Ludus::Engine::Persistence::EnginePersistence& GetEnginePersistence() const override;
 
 		virtual Ludus::Engine::Graphics::RenderTarget& GetMainRenderTarget() override;
 

--- a/Engine/Include/Ludus/Engine/Runtime/ApplicationHostBuilder.h
+++ b/Engine/Include/Ludus/Engine/Runtime/ApplicationHostBuilder.h
@@ -6,6 +6,7 @@
 #include <utility>
 #include <vector>
 
+#include <Ludus/Engine/Persistence/EnginePersistence.h>
 #include <Ludus/Engine/Runtime/ApplicationHost.h>
 #include <Ludus/Engine/Runtime/RuntimeOptions.h>
 #include <Ludus/Engine/Runtime/SystemDescriptor.h>
@@ -18,6 +19,7 @@ namespace Ludus::Engine::Runtime
 	class ApplicationHostBuilder
 	{
 	private:
+		Ludus::Engine::Persistence::EnginePersistence m_EnginePersistence = Ludus::Engine::Persistence::EnginePersistence::DefaultText();
 		Ludus::Engine::Runtime::RuntimeOptions m_RuntimeOptions;
 		Ludus::Engine::Windowing::WindowOptions m_WindowOptions;
 
@@ -28,8 +30,9 @@ namespace Ludus::Engine::Runtime
 
 		std::unique_ptr<Ludus::Engine::Runtime::ApplicationHost> Build();
 
-		ApplicationHostBuilder& WithRuntimeOptions(Ludus::Engine::Runtime::RuntimeOptions runtimeOptions);
-		ApplicationHostBuilder& WithWindowOptions(Ludus::Engine::Windowing::WindowOptions windowOptions);
+		ApplicationHostBuilder& WithEnginePersistence(Ludus::Engine::Persistence::EnginePersistence enginePersistence);
+		ApplicationHostBuilder& WithRuntimeOptions(const Ludus::Engine::Runtime::RuntimeOptions& runtimeOptions);
+		ApplicationHostBuilder& WithWindowOptions(const Ludus::Engine::Windowing::WindowOptions& windowOptions);
 
 		ApplicationHostBuilder& Configure(ApplicationHostBuilderCommand command);
 

--- a/Engine/Include/Ludus/Engine/Runtime/IHostContext.h
+++ b/Engine/Include/Ludus/Engine/Runtime/IHostContext.h
@@ -19,6 +19,11 @@ namespace Ludus::Engine::Events
 	struct EventHandler;
 }
 
+namespace Ludus::Engine::Persistence
+{
+	class EnginePersistence;
+}
+
 namespace Ludus::Engine::Runtime
 {
 	class RuntimeInstance;
@@ -41,9 +46,11 @@ namespace Ludus::Engine::Runtime
 		virtual void AttachRuntime(RuntimeInstance* runtime) = 0;
 		virtual void DetachRuntime() = 0;
 
+		virtual const Ludus::Engine::Persistence::EnginePersistence& GetEnginePersistence() const = 0;
 		virtual Ludus::Engine::Math::Size<int> GetFramebufferSize() const = 0;
 		virtual Ludus::Engine::Math::Size<int> GetWindowSize() const = 0;
 		virtual GLFWwindow* GetWindowHandle() const = 0;
+
 		virtual Ludus::Engine::Graphics::RenderTarget& GetMainRenderTarget() = 0;
 		virtual Ludus::Engine::Core::Enums::FlagSet& GetExecutionFlags() = 0;
 		virtual Ludus::Engine::Windowing::Input& GetInput() = 0;

--- a/Engine/Include/Ludus/Engine/Runtime/RuntimeLauncher.h
+++ b/Engine/Include/Ludus/Engine/Runtime/RuntimeLauncher.h
@@ -4,5 +4,8 @@
 
 namespace Ludus::Engine::Runtime
 {
-	int RunDefaultRuntime(std::string_view runtimeName);
+	struct RuntimeLauncher
+	{
+		static int Run(std::string_view runtimeName);
+	};
 }

--- a/Engine/Include/Ludus/Engine/Runtime/SceneSystem.h
+++ b/Engine/Include/Ludus/Engine/Runtime/SceneSystem.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <memory>
-
 #include <Ludus/Engine/Runtime/ISystem.h>
 
 namespace Ludus::Engine::Core
@@ -24,20 +22,15 @@ namespace Ludus::Engine::Runtime
 	class SceneSystem final : public Ludus::Engine::Runtime::ISystem
 	{
 	private:
+		const Ludus::Engine::Persistence::IScenePersistence& m_ScenePersistence;
 		Ludus::Engine::Core::SceneRegistry& m_SceneRegistry;
 		Ludus::Engine::Runtime::SceneRuntimeState& m_SceneRuntimeState;
-		std::unique_ptr<Ludus::Engine::Persistence::IScenePersistence> m_ScenePersistence;
 
 	public:
 		SceneSystem(
+			const Ludus::Engine::Persistence::IScenePersistence& scenePersistence,
 			Ludus::Engine::Core::SceneRegistry& sceneRegistry,
 			Ludus::Engine::Runtime::SceneRuntimeState& sceneRuntimeState
-		);
-
-		SceneSystem(
-			Ludus::Engine::Core::SceneRegistry& sceneRegistry,
-			Ludus::Engine::Runtime::SceneRuntimeState& sceneRuntimeState,
-			std::unique_ptr<Ludus::Engine::Persistence::IScenePersistence> scenePersistence
 		);
 
 		~SceneSystem();

--- a/Engine/Source/Ludus/Engine/Persistence/LmlRuntimeLaunchSettingsPersistence.cpp
+++ b/Engine/Source/Ludus/Engine/Persistence/LmlRuntimeLaunchSettingsPersistence.cpp
@@ -13,7 +13,7 @@
 
 namespace Ludus::Engine::Persistence
 {
-	void LmlRuntimeLaunchSettingsPersistence::Save(const Ludus::Engine::Runtime::RuntimeLaunchSettings& runtimeLaunchSettings, const std::filesystem::path& path)
+	void LmlRuntimeLaunchSettingsPersistence::Save(const Ludus::Engine::Runtime::RuntimeLaunchSettings& runtimeLaunchSettings, const std::filesystem::path& path) const
 	{
 		Ludus::Engine::Serialization::Core::DomDocument document;
 		Ludus::Engine::Serialization::Core::DomTokenStreamWriter writer { document };
@@ -24,7 +24,7 @@ namespace Ludus::Engine::Persistence
 		Ludus::Engine::FileSystem::WriteAllText(path, text);
 	}
 
-	Ludus::Engine::Runtime::RuntimeLaunchSettings LmlRuntimeLaunchSettingsPersistence::Load(const std::filesystem::path& path)
+	Ludus::Engine::Runtime::RuntimeLaunchSettings LmlRuntimeLaunchSettingsPersistence::Load(const std::filesystem::path& path) const
 	{
 		const auto text = Ludus::Engine::FileSystem::ReadAllText(path);
 		Ludus::Engine::Serialization::Codecs::LmlDomCodec codec;

--- a/Engine/Source/Ludus/Engine/Persistence/LmlRuntimeManifestPersistence.cpp
+++ b/Engine/Source/Ludus/Engine/Persistence/LmlRuntimeManifestPersistence.cpp
@@ -13,7 +13,7 @@
 
 namespace Ludus::Engine::Persistence
 {
-	void LmlRuntimeManifestPersistence::Save(const Ludus::Engine::Runtime::RuntimeManifest& runtimeManifest, const std::filesystem::path& path)
+	void LmlRuntimeManifestPersistence::Save(const Ludus::Engine::Runtime::RuntimeManifest& runtimeManifest, const std::filesystem::path& path) const
 	{
 		Ludus::Engine::Serialization::Core::DomDocument document;
 		Ludus::Engine::Serialization::Core::DomTokenStreamWriter writer { document };
@@ -24,7 +24,7 @@ namespace Ludus::Engine::Persistence
 		Ludus::Engine::FileSystem::WriteAllText(path, text);
 	}
 
-	Ludus::Engine::Runtime::RuntimeManifest LmlRuntimeManifestPersistence::Load(const std::filesystem::path& path)
+	Ludus::Engine::Runtime::RuntimeManifest LmlRuntimeManifestPersistence::Load(const std::filesystem::path& path) const
 	{
 		const auto text = Ludus::Engine::FileSystem::ReadAllText(path);
 		Ludus::Engine::Serialization::Codecs::LmlDomCodec codec;

--- a/Engine/Source/Ludus/Engine/Persistence/LmlScenePersistence.cpp
+++ b/Engine/Source/Ludus/Engine/Persistence/LmlScenePersistence.cpp
@@ -13,7 +13,7 @@
 
 namespace Ludus::Engine::Persistence
 {
-	void LmlScenePersistence::Save(const Ludus::Engine::Core::Scene& scene, const std::filesystem::path& path)
+	void LmlScenePersistence::Save(const Ludus::Engine::Core::Scene& scene, const std::filesystem::path& path) const
 	{
 		Ludus::Engine::Serialization::Core::DomDocument document;
 		Ludus::Engine::Serialization::Core::DomTokenStreamWriter writer { document };
@@ -24,7 +24,7 @@ namespace Ludus::Engine::Persistence
 		Ludus::Engine::FileSystem::WriteAllText(path, text);
 	}
 
-	Ludus::Engine::Core::Scene LmlScenePersistence::Load(const std::filesystem::path& path)
+	Ludus::Engine::Core::Scene LmlScenePersistence::Load(const std::filesystem::path& path) const
 	{
 		const auto text = Ludus::Engine::FileSystem::ReadAllText(path);
 		Ludus::Engine::Serialization::Codecs::LmlDomCodec codec;

--- a/Engine/Source/Ludus/Engine/Platform/Windows/Modals.Windows.cpp
+++ b/Engine/Source/Ludus/Engine/Platform/Windows/Modals.Windows.cpp
@@ -11,6 +11,8 @@
 #include <filesystem>
 #include <string_view>
 
+#include <Ludus/Engine/Core/Strings.h>
+
 #include "WinText.h"
 
 // Windows classic samples - Common File Dialogs.
@@ -33,21 +35,17 @@ namespace Ludus::Engine::Platform::Modals
 
 	static UINT FileTypeIndexFromExtension(std::string_view extension)
 	{
-		// Normalize extension parameter.
-		if (!extension.empty() && extension.front() == '.')
-		{
-			extension.remove_prefix(1);
-		}
+		const auto normalizedExtension = Ludus::Engine::Core::Strings::NormalizeFileExtension(extension);
 
-		if (extension == "project.ludus")
+		if (normalizedExtension == "project.ludus")
 		{
 			return INDEX_LUDUSPROJECT;
 		}
-		if (extension == "runtime.ludus")
+		if (normalizedExtension == "runtime.ludus")
 		{
 			return INDEX_LUDUSRUNTIME;
 		}
-		if (extension == "scene.ludus")
+		if (normalizedExtension == "scene.ludus")
 		{
 			return INDEX_LUDUSSCENE;
 		}
@@ -121,7 +119,8 @@ namespace Ludus::Engine::Platform::Modals
 						hr = openDialog->SetFileTypeIndex(filterIndex);
 						if (SUCCEEDED(hr))
 						{
-							auto defaultExtensionWide = Ludus::Engine::Platform::Windows::Detail::Utf8ToWide(defaultExtension);
+							const auto normalizedExtension = Ludus::Engine::Core::Strings::NormalizeFileExtension(defaultExtension);
+							auto defaultExtensionWide = Ludus::Engine::Platform::Windows::Detail::Utf8ToWide(normalizedExtension);
 							if (!defaultExtensionWide.empty())
 							{
 								hr = openDialog->SetDefaultExtension(defaultExtensionWide.c_str());
@@ -207,7 +206,8 @@ namespace Ludus::Engine::Platform::Modals
 						hr = saveDialog->SetFileTypeIndex(filterIndex);
 						if (SUCCEEDED(hr))
 						{
-							std::wstring defExtW = Ludus::Engine::Platform::Windows::Detail::Utf8ToWide(defaultExtension);
+							const auto normalizedExtension = Ludus::Engine::Core::Strings::NormalizeFileExtension(defaultExtension);
+							std::wstring defExtW = Ludus::Engine::Platform::Windows::Detail::Utf8ToWide(normalizedExtension);
 							if (!defExtW.empty())
 							{
 								hr = saveDialog->SetDefaultExtension(defExtW.c_str());

--- a/Engine/Source/Ludus/Engine/Runtime/ApplicationHost.cpp
+++ b/Engine/Source/Ludus/Engine/Runtime/ApplicationHost.cpp
@@ -1,6 +1,7 @@
 #include "pch.h"
 
 #include <Ludus/Engine/Events/WindowEvents.h>
+#include <Ludus/Engine/Persistence/EnginePersistence.h>
 #include <Ludus/Engine/Runtime/ApplicationHost.h>
 #include <Ludus/Engine/Runtime/RuntimeInstance.h>
 
@@ -54,9 +55,12 @@ namespace Ludus::Engine::Runtime
 	}
 
 	ApplicationHost::ApplicationHost(
+		Ludus::Engine::Persistence::EnginePersistence enginePersistence,
 		Ludus::Engine::Runtime::RuntimeOptions runtimeOptions,
 		Ludus::Engine::Windowing::WindowOptions windowOptions
-	) : m_EventBus(),
+	) :
+		m_Persistence(std::move(enginePersistence)),
+		m_EventBus(),
 		m_ExecutionFlags(runtimeOptions.ExecutionMask),
 		m_Input(),
 		m_Time(),
@@ -83,11 +87,12 @@ namespace Ludus::Engine::Runtime
 	ApplicationHost::~ApplicationHost() = default;
 
 	std::unique_ptr<ApplicationHost> ApplicationHost::Create(
+		Ludus::Engine::Persistence::EnginePersistence enginePersistence,
 		Ludus::Engine::Runtime::RuntimeOptions runtimeOptions,
 		Ludus::Engine::Windowing::WindowOptions windowOptions
 	)
 	{
-		auto host = std::unique_ptr<ApplicationHost>(new ApplicationHost(runtimeOptions, windowOptions));
+		auto host = std::unique_ptr<ApplicationHost>(new ApplicationHost(std::move(enginePersistence), runtimeOptions, windowOptions));
 		return host;
 	}
 
@@ -108,6 +113,7 @@ namespace Ludus::Engine::Runtime
 	{
 		if (m_Runtime)
 		{
+			m_Runtime->Shutdown();
 			m_Runtime = nullptr;
 		}
 	}
@@ -186,15 +192,15 @@ namespace Ludus::Engine::Runtime
 
 		m_Scheduler.DetachSystems();
 
-		if (m_Runtime)
-		{
-			m_Runtime->Shutdown();
-		}
-
 		DetachRuntime();
 	}
 
 #pragma region Host Context
+
+	const Ludus::Engine::Persistence::EnginePersistence& ApplicationHost::GetEnginePersistence() const
+	{
+		return m_Persistence;
+	}
 
 	Ludus::Engine::Math::Size<int> ApplicationHost::GetFramebufferSize() const
 	{

--- a/Engine/Source/Ludus/Engine/Runtime/ApplicationHostBuilder.cpp
+++ b/Engine/Source/Ludus/Engine/Runtime/ApplicationHostBuilder.cpp
@@ -6,8 +6,8 @@
 #include <vector>
 
 #include <Ludus/Engine/Core/ExecutionFlags.h>
-#include <Ludus/Engine/Graphics/RenderingSystem2D.h>
 #include <Ludus/Engine/Graphics/RenderViewSystem.h>
+#include <Ludus/Engine/Graphics/RenderingSystem2D.h>
 #include <Ludus/Engine/Physics/Core/PhysicsSystem2D.h>
 #include <Ludus/Engine/Runtime/ApplicationHost.h>
 #include <Ludus/Engine/Runtime/ApplicationHostBuilder.h>
@@ -20,6 +20,7 @@ namespace Ludus::Engine::Runtime
 	std::unique_ptr<Ludus::Engine::Runtime::ApplicationHost> ApplicationHostBuilder::Build()
 	{
 		auto host = ApplicationHost::Create(
+			std::move(m_EnginePersistence),
 			m_RuntimeOptions,
 			m_WindowOptions
 		);
@@ -38,13 +39,19 @@ namespace Ludus::Engine::Runtime
 		return *this;
 	}
 
-	ApplicationHostBuilder& ApplicationHostBuilder::WithRuntimeOptions(const Ludus::Engine::Runtime::RuntimeOptions runtimeOptions)
+	ApplicationHostBuilder& ApplicationHostBuilder::WithEnginePersistence(Ludus::Engine::Persistence::EnginePersistence enginePersistence)
+	{
+		m_EnginePersistence = std::move(enginePersistence);
+		return *this;
+	}
+
+	ApplicationHostBuilder& ApplicationHostBuilder::WithRuntimeOptions(const Ludus::Engine::Runtime::RuntimeOptions& runtimeOptions)
 	{
 		m_RuntimeOptions = runtimeOptions;
 		return *this;
 	}
 
-	ApplicationHostBuilder& ApplicationHostBuilder::WithWindowOptions(const Ludus::Engine::Windowing::WindowOptions windowOptions)
+	ApplicationHostBuilder& ApplicationHostBuilder::WithWindowOptions(const Ludus::Engine::Windowing::WindowOptions& windowOptions)
 	{
 		m_WindowOptions = windowOptions;
 		return *this;

--- a/Engine/Source/Ludus/Engine/Runtime/RuntimeInstanceBuilder.cpp
+++ b/Engine/Source/Ludus/Engine/Runtime/RuntimeInstanceBuilder.cpp
@@ -9,8 +9,9 @@
 #include <Ludus/Engine/Core/ExecutionFlags.h>
 #include <Ludus/Engine/Core/Scene.h>
 #include <Ludus/Engine/Graphics/MainRenderViewSystem.h>
-#include <Ludus/Engine/Graphics/RenderingSystem2D.h>
 #include <Ludus/Engine/Graphics/RenderViewSystem.h>
+#include <Ludus/Engine/Graphics/RenderingSystem2D.h>
+#include <Ludus/Engine/Persistence/EnginePersistence.h>
 #include <Ludus/Engine/Physics/Core/PhysicsSystem2D.h>
 #include <Ludus/Engine/Runtime/ISystem.h>
 #include <Ludus/Engine/Runtime/RuntimeInstance.h>
@@ -81,7 +82,7 @@ namespace Ludus::Engine::Runtime
 
 			runtime->AddSystem(
 				{
-					Ludus::Engine::Runtime::SystemDescriptor { SystemPhase::BeginFrame, SystemPhaseOrder::Before },
+					Ludus::Engine::Runtime::SystemDescriptor { SystemPhase::BeginFrame, SystemPhaseOrder::Before, constraints },
 					Ludus::Engine::Runtime::SystemDescriptor { SystemPhase::Render, SystemPhaseOrder::Before, constraints }
 				},
 				std::move(renderViewSystem)
@@ -96,7 +97,7 @@ namespace Ludus::Engine::Runtime
 			);
 
 			runtime->AddSystem(
-				Ludus::Engine::Runtime::SystemDescriptor { SystemPhase::Render, SystemPhaseOrder::Before },
+				Ludus::Engine::Runtime::SystemDescriptor { SystemPhase::Render, SystemPhaseOrder::Before, constraints },
 				std::move(renderingSystem)
 			);
 		}
@@ -104,6 +105,7 @@ namespace Ludus::Engine::Runtime
 		if (m_UseDefaultSceneManagement)
 		{
 			auto sceneSystem = std::make_unique<Ludus::Engine::Runtime::SceneSystem>(
+				runtime->GetHostContext().GetEnginePersistence().Scene(),
 				runtime->GetSceneRegistry(),
 				runtime->GetSceneRuntimeState()
 			);

--- a/Engine/Source/Ludus/Engine/Runtime/RuntimeLauncher.cpp
+++ b/Engine/Source/Ludus/Engine/Runtime/RuntimeLauncher.cpp
@@ -6,16 +6,14 @@
 #include <vector>
 
 #include <Ludus/Engine/Debug/Debug.h>
-#include <Ludus/Engine/Persistence/LmlRuntimeLaunchSettingsPersistence.h>
-#include <Ludus/Engine/Persistence/LmlRuntimeManifestPersistence.h>
-#include <Ludus/Engine/Persistence/LmlScenePersistence.h>
+#include <Ludus/Engine/Persistence/EnginePersistence.h>
 #include <Ludus/Engine/Persistence/Paths.h>
 #include <Ludus/Engine/Platform/Paths.h>
 #include <Ludus/Engine/Runtime/ApplicationHostBuilder.h>
 #include <Ludus/Engine/Runtime/RuntimeEnvironment.h>
 #include <Ludus/Engine/Runtime/RuntimeInstanceBuilder.h>
-#include <Ludus/Engine/Runtime/RuntimeLauncher.h>
 #include <Ludus/Engine/Runtime/RuntimeLaunchSettings.h>
+#include <Ludus/Engine/Runtime/RuntimeLauncher.h>
 #include <Ludus/Engine/Runtime/RuntimeManifest.h>
 #include <Ludus/Engine/Windowing/WindowOptions.h>
 
@@ -38,7 +36,7 @@ namespace
 	}
 
 	Ludus::Engine::Core::Scene LoadEntryScene(
-		Ludus::Engine::Persistence::IScenePersistence& scenePersistence,
+		const Ludus::Engine::Persistence::IScenePersistence& scenePersistence,
 		const Ludus::Engine::Runtime::RuntimeEnvironment& runtimeEnvironment,
 		const Ludus::Engine::Runtime::RuntimeManifest& runtimeManifest
 	)
@@ -113,27 +111,28 @@ namespace
 
 namespace Ludus::Engine::Runtime
 {
-	int RunDefaultRuntime(std::string_view runtimeName)
+	int RuntimeLauncher::Run(std::string_view runtimeName)
 	{
 		auto runtimeEnvironment = BuildRuntimeEnvironment(runtimeName);
+		auto enginePersistence = Ludus::Engine::Persistence::EnginePersistence::DefaultText();
 
-		Ludus::Engine::Persistence::LmlRuntimeManifestPersistence runtimeManifestPersistence;
-		const auto runtimeManifest = runtimeManifestPersistence.Load(runtimeEnvironment.RuntimeManifestPath);
+		const auto runtimeManifest = enginePersistence
+			.RuntimeManifest()
+			.Load(runtimeEnvironment.RuntimeManifestPath);
 
-		Ludus::Engine::Persistence::LmlScenePersistence scenePersistence;
 		auto entryScene = ::LoadEntryScene(
-			scenePersistence,
+			enginePersistence.Scene(),
 			runtimeEnvironment,
 			runtimeManifest
 		);
 
-		Ludus::Engine::Persistence::LmlRuntimeLaunchSettingsPersistence runtimeLaunchSettingsPersistence;
-		const auto runtimeLaunchSettings = runtimeLaunchSettingsPersistence.Load(runtimeEnvironment.RuntimeLaunchSettingsPath);
-		auto windowOptions = ToWindowOptions(runtimeLaunchSettings, runtimeName);
-		auto renderPresentationSettings = ToRenderPresentationSettings(runtimeLaunchSettings);
+		const auto runtimeLaunchSettings = enginePersistence
+			.RuntimeLaunchSettings()
+			.Load(runtimeEnvironment.RuntimeLaunchSettingsPath);
 
 		auto host = Ludus::Engine::Runtime::ApplicationHostBuilder::Create()
-			.WithWindowOptions(std::move(windowOptions))
+			.WithEnginePersistence(std::move(enginePersistence))
+			.WithWindowOptions(ToWindowOptions(runtimeLaunchSettings, runtimeName))
 			.Build();
 
 		auto runtime = Ludus::Engine::Runtime::RuntimeInstanceBuilder::Create()
@@ -142,7 +141,7 @@ namespace Ludus::Engine::Runtime
 			.UseDefaultSceneManagement()
 			.UseDefaultScripting()
 			.UseDefaultMainRenderView()
-			.WithRenderPresentationSettings(std::move(renderPresentationSettings))
+			.WithRenderPresentationSettings(ToRenderPresentationSettings(runtimeLaunchSettings))
 			.WithRuntimeEnvironment(std::move(runtimeEnvironment))
 			.WithRuntimeManifest(runtimeManifest)
 			.WithEntryScene(std::move(entryScene))

--- a/Engine/Source/Ludus/Engine/Runtime/SceneSystem.cpp
+++ b/Engine/Source/Ludus/Engine/Runtime/SceneSystem.cpp
@@ -1,7 +1,6 @@
 #include "pch.h"
 
 #include <filesystem>
-#include <memory>
 #include <optional>
 #include <type_traits>
 #include <utility>
@@ -9,7 +8,6 @@
 
 #include <Ludus/Engine/Core/SceneRegistry.h>
 #include <Ludus/Engine/Persistence/IScenePersistence.h>
-#include <Ludus/Engine/Persistence/LmlScenePersistence.h>
 #include <Ludus/Engine/Runtime/PendingSceneTransition.h>
 #include <Ludus/Engine/Runtime/SceneRuntimeState.h>
 #include <Ludus/Engine/Runtime/SceneSystem.h>
@@ -37,25 +35,14 @@ namespace Ludus::Engine::Runtime
 	}
 
 	SceneSystem::SceneSystem(
+		const Ludus::Engine::Persistence::IScenePersistence& scenePersistence,
 		Ludus::Engine::Core::SceneRegistry& sceneRegistry,
 		Ludus::Engine::Runtime::SceneRuntimeState& sceneRuntimeState
 	) :
-		SceneSystem(
-			sceneRegistry,
-			sceneRuntimeState,
-			std::make_unique<Ludus::Engine::Persistence::LmlScenePersistence>()
-		)
-	{ }
-
-	SceneSystem::SceneSystem(
-		Ludus::Engine::Core::SceneRegistry& sceneRegistry,
-		Ludus::Engine::Runtime::SceneRuntimeState& sceneRuntimeState,
-		std::unique_ptr<Ludus::Engine::Persistence::IScenePersistence> scenePersistence
-	) :
+		m_ScenePersistence(scenePersistence),
 		m_SceneRegistry(sceneRegistry),
-		m_SceneRuntimeState(sceneRuntimeState),
-		m_ScenePersistence(std::move(scenePersistence))
-	{ }
+		m_SceneRuntimeState(sceneRuntimeState)
+	{}
 
 	SceneSystem::~SceneSystem() = default;
 
@@ -67,7 +54,7 @@ namespace Ludus::Engine::Runtime
 			return;
 		}
 
-		auto scene = m_ScenePersistence->Load(*path);
+		auto scene = m_ScenePersistence.Load(*path);
 		m_SceneRegistry.Clear();
 		const auto sceneId = m_SceneRegistry.AddScene(std::move(scene));
 

--- a/EngineTests/Ludus/EngineTests/Runtime/SceneSystemTests.cpp
+++ b/EngineTests/Ludus/EngineTests/Runtime/SceneSystemTests.cpp
@@ -37,21 +37,23 @@ namespace Ludus::EngineTests::Runtime
 	{
 	public:
 		Scene LoadedScene;
-		std::filesystem::path LastLoadedPath;
-		std::uint32_t LoadCallCount = 0;
+
+		// IScenePersistence is a const interface, which means we have to make the properties mutable explicitly.
+		mutable std::filesystem::path LastLoadedPath;
+		mutable std::uint32_t LoadCallCount = 0;
 
 		explicit TestScenePersistence(Scene loadedScene)
 			: LoadedScene(std::move(loadedScene))
-		{ }
+		{}
 
-		virtual void Save(const Scene& scene, const std::filesystem::path& path) override
+		virtual void Save(const Scene& scene, const std::filesystem::path& path) const override
 		{
 			(void)scene;
 			(void)path;
 			FAIL() << "Save should not be called by SceneSystem transition tests.";
 		}
 
-		virtual Scene Load(const std::filesystem::path& path) override
+		virtual Scene Load(const std::filesystem::path& path) const override
 		{
 			LastLoadedPath = path;
 			++LoadCallCount;
@@ -78,17 +80,16 @@ namespace Ludus::EngineTests::Runtime
 		sceneRuntimeState.Presentation.CurrentSceneId = initialSceneId;
 		sceneRuntimeState.PendingTransition = PendingSceneTransition::LoadScene("Scenes/Gameplay.scene.ludus");
 
-		auto testPersistence = std::make_unique<TestScenePersistence>(Scene { SceneId { 42 }, "Gameplay" });
-		auto* testPersistencePtr = testPersistence.get();
+		TestScenePersistence testPersistence(Scene { SceneId { 42 }, "Gameplay" });
 
-		SceneSystem sceneSystem(sceneRegistry, sceneRuntimeState, std::move(testPersistence));
+		SceneSystem sceneSystem(testPersistence, sceneRegistry, sceneRuntimeState);
 
 		// Act.
 		sceneSystem.BeginFrame();
 
 		// Assert.
-		ASSERT_EQ(testPersistencePtr->LoadCallCount, 1u);
-		ASSERT_EQ(testPersistencePtr->LastLoadedPath, std::filesystem::path("Scenes/Gameplay.scene.ludus"));
+		ASSERT_EQ(testPersistence.LoadCallCount, 1u);
+		ASSERT_EQ(testPersistence.LastLoadedPath, std::filesystem::path("Scenes/Gameplay.scene.ludus"));
 		ASSERT_TRUE(std::holds_alternative<PendingSceneTransition::None>(sceneRuntimeState.PendingTransition.Data));
 		ASSERT_EQ(sceneRuntimeState.Presentation.CurrentSceneId, SceneId { 42 });
 		ASSERT_EQ(sceneRegistry.View().size(), 1u);

--- a/UI/Include/Ludus/UI/Context/InputContext.h
+++ b/UI/Include/Ludus/UI/Context/InputContext.h
@@ -12,6 +12,7 @@ namespace Ludus::UI::Context::InputContext
 	bool WantCaptureMouse();
 	bool WantCaptureKeyboard();
 
+	bool IsItemActive();
 	bool IsAnyItemActive();
 	bool IsAnyItemHovered();
 	bool IsItemHovered();

--- a/UI/Include/Ludus/UI/Context/WindowContext.h
+++ b/UI/Include/Ludus/UI/Context/WindowContext.h
@@ -33,6 +33,8 @@ namespace Ludus::UI::Context::WindowContext
 
 	Ludus::Engine::Math::Vector2D GetCursorPosition();
 
+	Ludus::Engine::Math::Vector2D GetCursorScreenPosition();
+
 	Ludus::Engine::Math::Vector2D GetContentRegionAvailable();
 
 	Ludus::Engine::Math::Vector2D GetWindowContentRegionMin();

--- a/UI/Include/Ludus/UI/Flags/Flags.h
+++ b/UI/Include/Ludus/UI/Flags/Flags.h
@@ -4,6 +4,31 @@
 
 namespace Ludus::UI::Flags
 {
+
+	enum class Button : int
+	{
+		None = 0,
+		MouseButtonLeft = 1 << 0,
+		MouseButtonRight = 1 << 1,
+		MouseButtonMiddle = 1 << 2,
+		MouseButtonMask_ = static_cast<int>(MouseButtonLeft) | static_cast<int>(MouseButtonRight) | static_cast<int>(MouseButtonMiddle),
+		EnableNav = 1 << 3,
+	};
+
+	enum class Child : int
+	{
+		None = 0,
+		Borders = 1 << 0,
+		AlwaysUseWindowPadding = 1 << 1,
+		ResizeX = 1 << 2,
+		ResizeY = 1 << 3,
+		AutoResizeX = 1 << 4,
+		AutoResizeY = 1 << 5,
+		AlwaysAutoResize = 1 << 6,
+		FrameStyle = 1 << 7,
+		NavFlattened = 1 << 8,
+	};
+
 	enum class ColorEdit : int
 	{
 		None = 0,
@@ -71,6 +96,24 @@ namespace Ludus::UI::Flags
 
 		// Internal
 		NoWindowMenuButton = 1 << 14
+	};
+
+	enum class Draw : int
+	{
+		None = 0,
+		Closed = 1 << 0,
+		RoundCornersTopLeft = 1 << 4,
+		RoundCornersTopRight = 1 << 5,
+		RoundCornersBottomLeft = 1 << 6,
+		RoundCornersBottomRight = 1 << 7,
+		RoundCornersNone = 1 << 8,
+		RoundCornersTop = static_cast<int>(RoundCornersTopLeft) | static_cast<int>(RoundCornersTopRight),
+		RoundCornersBottom = static_cast<int>(RoundCornersBottomLeft) | static_cast<int>(RoundCornersBottomRight),
+		RoundCornersLeft = static_cast<int>(RoundCornersBottomLeft) | static_cast<int>(RoundCornersTopLeft),
+		RoundCornersRight = static_cast<int>(RoundCornersBottomRight) | static_cast<int>(RoundCornersTopRight),
+		RoundCornersAll = static_cast<int>(RoundCornersTopLeft) | static_cast<int>(RoundCornersTopRight) | static_cast<int>(RoundCornersBottomLeft) | static_cast<int>(RoundCornersBottomRight),
+		RoundCornersDefault_ = RoundCornersAll,
+		RoundCornersMask_ = static_cast<int>(RoundCornersAll) | static_cast<int>(RoundCornersNone),
 	};
 
 	enum class Hovered : int
@@ -358,43 +401,54 @@ namespace Ludus::UI::Flags
 namespace Ludus::Engine::Core::Enums
 {
 	template<>
-	struct EnableBitMaskOperators<Ludus::UI::Flags::ColorEdit> : std::true_type { };
+	struct EnableBitMaskOperators<Ludus::UI::Flags::Button> : std::true_type {};
+
 
 	template<>
-	struct EnableBitMaskOperators<Ludus::UI::Flags::Combo> : std::true_type { };
+	struct EnableBitMaskOperators<Ludus::UI::Flags::Child> : std::true_type {};
 
 	template<>
-	struct EnableBitMaskOperators<Ludus::UI::Flags::DockNode> : std::true_type { };
+	struct EnableBitMaskOperators<Ludus::UI::Flags::ColorEdit> : std::true_type {};
 
 	template<>
-	struct EnableBitMaskOperators<Ludus::UI::Flags::Hovered> : std::true_type { };
+	struct EnableBitMaskOperators<Ludus::UI::Flags::Combo> : std::true_type {};
 
 	template<>
-	struct EnableBitMaskOperators<Ludus::UI::Flags::InputText> : std::true_type { };
+	struct EnableBitMaskOperators<Ludus::UI::Flags::Draw> : std::true_type {};
+
 
 	template<>
-	struct EnableBitMaskOperators<Ludus::UI::Flags::Popup> : std::true_type { };
+	struct EnableBitMaskOperators<Ludus::UI::Flags::DockNode> : std::true_type {};
 
 	template<>
-	struct EnableBitMaskOperators<Ludus::UI::Flags::TabBar> : std::true_type { };
+	struct EnableBitMaskOperators<Ludus::UI::Flags::Hovered> : std::true_type {};
 
 	template<>
-	struct EnableBitMaskOperators<Ludus::UI::Flags::TabItem> : std::true_type { };
+	struct EnableBitMaskOperators<Ludus::UI::Flags::InputText> : std::true_type {};
 
 	template<>
-	struct EnableBitMaskOperators<Ludus::UI::Flags::Table> : std::true_type { };
+	struct EnableBitMaskOperators<Ludus::UI::Flags::Popup> : std::true_type {};
 
 	template<>
-	struct EnableBitMaskOperators<Ludus::UI::Flags::TableColumn> : std::true_type { };
+	struct EnableBitMaskOperators<Ludus::UI::Flags::TabBar> : std::true_type {};
 
 	template<>
-	struct EnableBitMaskOperators<Ludus::UI::Flags::TreeNode> : std::true_type { };
+	struct EnableBitMaskOperators<Ludus::UI::Flags::TabItem> : std::true_type {};
 
 	template<>
-	struct EnableBitMaskOperators<Ludus::UI::Flags::Viewport> : std::true_type { };
+	struct EnableBitMaskOperators<Ludus::UI::Flags::Table> : std::true_type {};
 
 	template<>
-	struct EnableBitMaskOperators<Ludus::UI::Flags::Window> : std::true_type { };
+	struct EnableBitMaskOperators<Ludus::UI::Flags::TableColumn> : std::true_type {};
+
+	template<>
+	struct EnableBitMaskOperators<Ludus::UI::Flags::TreeNode> : std::true_type {};
+
+	template<>
+	struct EnableBitMaskOperators<Ludus::UI::Flags::Viewport> : std::true_type {};
+
+	template<>
+	struct EnableBitMaskOperators<Ludus::UI::Flags::Window> : std::true_type {};
 }
 
 #pragma endregion

--- a/UI/Include/Ludus/UI/Scope/ChildScope.h
+++ b/UI/Include/Ludus/UI/Scope/ChildScope.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <Ludus/Engine/Math/Vector2D.h>
+#include <Ludus/UI/Flags/Flags.h>
+
+namespace Ludus::UI::Scope
+{
+	constexpr Ludus::UI::Flags::Child DefaultChildFlags = Ludus::UI::Flags::Child::None;
+	constexpr Ludus::UI::Flags::Window DefaultChildWindowFlags = Ludus::UI::Flags::Window::None;
+
+	class ChildScope
+	{
+	private:
+		bool m_Active = false;
+
+	public:
+		explicit ChildScope(
+			const char* id,
+			const Ludus::Engine::Math::Vector2D size,
+			Ludus::UI::Flags::Child childFlags = DefaultChildFlags,
+			Ludus::UI::Flags::Window windowFlags = DefaultChildWindowFlags
+		);
+
+		~ChildScope();
+
+		explicit operator bool() const { return m_Active; }
+	};
+}

--- a/UI/Include/Ludus/UI/Scope/StyleScope.h
+++ b/UI/Include/Ludus/UI/Scope/StyleScope.h
@@ -27,6 +27,7 @@ namespace Ludus::UI::Scope
 		int m_StyleCount = 0;
 
 	public:
+		explicit StyleVarScope(StyleVar style);
 		explicit StyleVarScope(std::initializer_list<StyleVar> styles);
 
 		~StyleVarScope();
@@ -93,6 +94,7 @@ namespace Ludus::UI::Scope
 		int m_StyleCount = 0;
 
 	public:
+		explicit StyleColorScope(StyleColor style);
 		explicit StyleColorScope(std::initializer_list<StyleColor> styles);
 
 		~StyleColorScope();

--- a/UI/Include/Ludus/UI/Theme/ThemeId.h
+++ b/UI/Include/Ludus/UI/Theme/ThemeId.h
@@ -1,5 +1,10 @@
 #pragma once
 
+#include <stdexcept>
+#include <string_view>
+
+#include <Ludus/Engine/Core/Enums/EnumTraits.h>
+
 namespace Ludus::UI::Theme
 {
 	enum class ThemeId
@@ -7,4 +12,31 @@ namespace Ludus::UI::Theme
 		LudusDark,
 		LudusLight
 	};
+
+	constexpr std::string_view ToString(ThemeId type)
+	{
+		switch (type)
+		{
+			case ThemeId::LudusDark:	return "LudusDark";
+			case ThemeId::LudusLight:	return "LudusLight";
+			default:					throw std::runtime_error("Unsupported theme id.");
+		}
+	}
+
+	constexpr bool TryParse(std::string_view text, ThemeId& out)
+	{
+		if (text == "LudusDark")
+		{
+			out = ThemeId::LudusDark;
+			return true;
+		}
+
+		if (text == "LudusLight")
+		{
+			out = ThemeId::LudusLight;
+			return true;
+		}
+
+		return false;
+	}
 }

--- a/UI/Include/Ludus/UI/Types/DrawList.h
+++ b/UI/Include/Ludus/UI/Types/DrawList.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <Ludus/Engine/Graphics/Color.h>
+#include <Ludus/Engine/Math/Vector2D.h>
+#include <Ludus/UI/Flags/Flags.h>
+#include <Ludus/UI/Types/DrawList.h>
+
+namespace Ludus::UI::Types
+{
+	struct DrawList
+	{
+		void AddRectFilled(
+			const Ludus::Engine::Math::Vector2D& min,
+			const Ludus::Engine::Math::Vector2D& max,
+			Ludus::Engine::Graphics::Color color,
+			float rounding = 0.0f,
+			Ludus::UI::Flags::Draw flags = Ludus::UI::Flags::Draw::None
+		);
+
+		void AddRect(
+			const Ludus::Engine::Math::Vector2D& min,
+			const Ludus::Engine::Math::Vector2D& max,
+			Ludus::Engine::Graphics::Color color,
+			float rounding = 0.0f,
+			Ludus::UI::Flags::Draw flags = Ludus::UI::Flags::Draw::None
+		);
+
+		void AddText(
+			const Ludus::Engine::Math::Vector2D& position,
+			Ludus::Engine::Graphics::Color color,
+			const char* text
+		);
+	};
+}
+

--- a/UI/Include/Ludus/UI/Widgets/Buttons.h
+++ b/UI/Include/Ludus/UI/Widgets/Buttons.h
@@ -1,10 +1,13 @@
 #pragma once
 
 #include <Ludus/Engine/Math/Vector2D.h>
+#include <Ludus/UI/Flags/Flags.h>
 
 namespace Ludus::UI::Widgets
 {
 	bool Button(const char* label);
-
 	bool Button(const char* label, Ludus::Engine::Math::Vector2D size);
+
+	bool InvisibleButton(const char* label);
+	bool InvisibleButton(const char* label, Ludus::Engine::Math::Vector2D size, Ludus::UI::Flags::Button flags = Ludus::UI::Flags::Button::None);
 }

--- a/UI/Source/Ludus/UI/Context/InputContext.cpp
+++ b/UI/Source/Ludus/UI/Context/InputContext.cpp
@@ -12,11 +12,11 @@ namespace
 	{
 		switch (mouseButton)
 		{
-		case Ludus::Engine::Windowing::MouseButton::Left:   return ImGuiMouseButton_Left;
-		case Ludus::Engine::Windowing::MouseButton::Right:  return ImGuiMouseButton_Right;
-		case Ludus::Engine::Windowing::MouseButton::Middle: return ImGuiMouseButton_Middle;
-		default:
-			throw std::runtime_error("Unexpected MouseButton value.");
+			case Ludus::Engine::Windowing::MouseButton::Left:   return ImGuiMouseButton_Left;
+			case Ludus::Engine::Windowing::MouseButton::Right:  return ImGuiMouseButton_Right;
+			case Ludus::Engine::Windowing::MouseButton::Middle: return ImGuiMouseButton_Middle;
+			default:
+				throw std::runtime_error("Unexpected MouseButton value.");
 		}
 	}
 }
@@ -39,6 +39,7 @@ namespace Ludus::UI::Context::InputContext
 	bool WantCaptureKeyboard() { return ImGui::GetIO().WantCaptureKeyboard; }
 
 	bool IsAnyItemHovered() { return ImGui::IsAnyItemHovered(); }
+	bool IsItemActive() { return ImGui::IsItemActive(); }
 	bool IsAnyItemActive() { return ImGui::IsAnyItemActive(); }
 	bool IsItemHovered() { return ImGui::IsItemHovered(); }
 	bool IsMouseClicked(Ludus::Engine::Windowing::MouseButton mouseButton) { return ImGui::IsMouseClicked(ToImGuiMouseButton(mouseButton)); }

--- a/UI/Source/Ludus/UI/Context/WindowContext.cpp
+++ b/UI/Source/Ludus/UI/Context/WindowContext.cpp
@@ -51,6 +51,12 @@ namespace Ludus::UI::Context::WindowContext
 		return { availableSpace.x, availableSpace.y };
 	}
 
+	Ludus::Engine::Math::Vector2D GetCursorScreenPosition()
+	{
+		const auto cursorScreenPosition = ImGui::GetCursorScreenPos();
+		return { cursorScreenPosition.x, cursorScreenPosition.y };
+	}
+
 	Ludus::Engine::Math::Vector2D GetWindowContentRegionMin()
 	{
 		const auto contentRegionMin = ImGui::GetWindowContentRegionMin();

--- a/UI/Source/Ludus/UI/Elements/ActionTreeNode.cpp
+++ b/UI/Source/Ludus/UI/Elements/ActionTreeNode.cpp
@@ -39,9 +39,9 @@ namespace Ludus::UI::Elements
 		const auto headerTopY = ImGui::GetItemRectMin().y;
 
 		{
-			Ludus::UI::Scope::StyleVarScope styleVar({
+			Ludus::UI::Scope::StyleVarScope styleVar(
 				Ludus::UI::Scope::StyleVar::Float(Ludus::UI::Scope::Variable::FrameBorderSize, 0.0f)
-				});
+			);
 
 			Ludus::UI::Scope::StyleColorScope colorScope({
 				{ Ludus::UI::Scope::Color::Button, Ludus::Engine::Graphics::Colors::Transparent },

--- a/UI/Source/Ludus/UI/Scope/ChildScope.cpp
+++ b/UI/Source/Ludus/UI/Scope/ChildScope.cpp
@@ -1,0 +1,28 @@
+#include "pch.h"
+
+#include <Ludus/Engine/Math/Vector2D.h>
+#include <Ludus/UI/Flags/Flags.h>
+#include <Ludus/UI/Scope/ChildScope.h>
+
+namespace Ludus::UI::Scope
+{
+	ChildScope::ChildScope(
+		const char* id,
+		const Ludus::Engine::Math::Vector2D size,
+		Ludus::UI::Flags::Child childFlags,
+		Ludus::UI::Flags::Window windowFlags
+	)
+	{
+		m_Active = ImGui::BeginChild(
+			id,
+			{ size.X, size.Y },
+			static_cast<int>(childFlags),
+			static_cast<int>(windowFlags)
+		);
+	}
+
+	ChildScope::~ChildScope()
+	{
+		ImGui::EndChild();
+	}
+}

--- a/UI/Source/Ludus/UI/Scope/StyleScope.cpp
+++ b/UI/Source/Ludus/UI/Scope/StyleScope.cpp
@@ -1,6 +1,7 @@
 #include "pch.h"
 
 #include <initializer_list>
+#include <utility>
 #include <variant>
 
 #include <Ludus/Engine/Graphics/Color.h>
@@ -14,6 +15,10 @@ namespace Ludus::UI::Scope
 
 		return { r, g, b, a };
 	}
+
+	StyleVarScope::StyleVarScope(StyleVar style)
+		: StyleVarScope({ std::move(style) })
+	{}
 
 	StyleVarScope::StyleVarScope(std::initializer_list<StyleVar> styles)
 	{
@@ -41,6 +46,10 @@ namespace Ludus::UI::Scope
 	{
 		ImGui::PopStyleVar(m_StyleCount);
 	}
+
+	StyleColorScope::StyleColorScope(StyleColor style)
+		: StyleColorScope({ std::move(style) })
+	{}
 
 	StyleColorScope::StyleColorScope(std::initializer_list<StyleColor> styles)
 	{

--- a/UI/Source/Ludus/UI/Types/DrawList.cpp
+++ b/UI/Source/Ludus/UI/Types/DrawList.cpp
@@ -1,0 +1,56 @@
+#include "pch.h"
+
+#include <Ludus/Engine/Graphics/Color.h>
+#include <Ludus/Engine/Math/Vector2D.h>
+#include <Ludus/UI/Flags/Flags.h>
+#include <Ludus/UI/Types/DrawList.h>
+
+namespace Ludus::UI::Types
+{
+	void DrawList::AddRectFilled(
+		const Ludus::Engine::Math::Vector2D& min,
+		const Ludus::Engine::Math::Vector2D& max,
+		Ludus::Engine::Graphics::Color color,
+		float rounding,
+		Ludus::UI::Flags::Draw flags
+	)
+	{
+		ImGui::GetWindowDrawList()->AddRectFilled(
+			{ min.X, min.Y },
+			{ max.X, max.Y },
+			ImGui::ColorConvertFloat4ToU32({ color.R, color.G, color.B, color.A }),
+			rounding,
+			static_cast<int>(flags)
+		);
+	}
+
+	void DrawList::AddRect(
+		const Ludus::Engine::Math::Vector2D& min,
+		const Ludus::Engine::Math::Vector2D& max,
+		Ludus::Engine::Graphics::Color color,
+		float rounding,
+		Ludus::UI::Flags::Draw flags
+	)
+	{
+		ImGui::GetWindowDrawList()->AddRect(
+			{ min.X, min.Y },
+			{ max.X, max.Y },
+			ImGui::ColorConvertFloat4ToU32({ color.R, color.G, color.B, color.A }),
+			rounding,
+			static_cast<int>(flags)
+		);
+	}
+
+	void DrawList::AddText(
+		const Ludus::Engine::Math::Vector2D& position,
+		Ludus::Engine::Graphics::Color color,
+		const char* text
+	)
+	{
+		ImGui::GetWindowDrawList()->AddText(
+			{ position.X, position.Y },
+			ImGui::ColorConvertFloat4ToU32({ color.R, color.G, color.B, color.A }),
+			text
+		);
+	}
+}

--- a/UI/Source/Ludus/UI/Widgets/Buttons.cpp
+++ b/UI/Source/Ludus/UI/Widgets/Buttons.cpp
@@ -1,5 +1,6 @@
 #include "pch.h"
 
+#include <Ludus/UI/Flags/Flags.h>
 #include <Ludus/UI/Widgets/Buttons.h>
 
 namespace Ludus::UI::Widgets
@@ -12,5 +13,15 @@ namespace Ludus::UI::Widgets
 	bool Button(const char* label, Ludus::Engine::Math::Vector2D size)
 	{
 		return ImGui::Button(label, { size.X, size.Y });
+	}
+
+	bool InvisibleButton(const char* label)
+	{
+		return ImGui::InvisibleButton(label, { 0.0f, 0.0f });
+	}
+
+	bool InvisibleButton(const char* label, Ludus::Engine::Math::Vector2D size, Ludus::UI::Flags::Button flags)
+	{
+		return ImGui::InvisibleButton(label, { size.X, size.Y }, static_cast<int>(flags));
 	}
 }

--- a/UI/UI.vcxproj
+++ b/UI/UI.vcxproj
@@ -22,6 +22,7 @@
     <ClInclude Include="Include\Ludus\UI\Elements\ActionTreeNode.h" />
     <ClInclude Include="Include\Ludus\UI\Elements\ContentBrowser.h" />
     <ClInclude Include="Include\Ludus\UI\Context\ThemeContext.h" />
+    <ClInclude Include="Include\Ludus\UI\Scope\ChildScope.h" />
     <ClInclude Include="Include\Ludus\UI\Scope\DisabledScope.h" />
     <ClInclude Include="Include\Ludus\UI\Backend\Fonts.h" />
     <ClInclude Include="Include\Ludus\UI\Context\ImageContext.h" />
@@ -37,6 +38,7 @@
     <ClInclude Include="Include\Ludus\UI\Theme\ThemeMetrics.h" />
     <ClInclude Include="Include\Ludus\UI\Theme\ThemePalette.h" />
     <ClInclude Include="Include\Ludus\UI\Theme\Themes.h" />
+    <ClInclude Include="Include\Ludus\UI\Types\DrawList.h" />
     <ClInclude Include="Include\Ludus\UI\Widgets\Demo.h" />
     <ClInclude Include="Include\Ludus\UI\Widgets\Headers.h" />
     <ClInclude Include="Include\Ludus\UI\Widgets\Color.h" />
@@ -90,6 +92,7 @@
     <ClCompile Include="Source\Ludus\UI\Elements\ContentBrowser.cpp" />
     <ClCompile Include="Source\Ludus\UI\Backend\ImGuiTheme.cpp" />
     <ClCompile Include="Source\Ludus\UI\Context\ThemeContext.cpp" />
+    <ClCompile Include="Source\Ludus\UI\Scope\ChildScope.cpp" />
     <ClCompile Include="Source\Ludus\UI\Scope\DisabledScope.cpp" />
     <ClCompile Include="Source\Ludus\UI\Context\PopupContext.cpp" />
     <ClCompile Include="Source\Ludus\UI\Scope\IDScope.cpp" />
@@ -105,6 +108,7 @@
     <ClCompile Include="Source\Ludus\UI\Scope\ComboScope.cpp" />
     <ClCompile Include="Source\Ludus\UI\Scope\StyleScope.cpp" />
     <ClCompile Include="Source\Ludus\UI\Theme\Themes.cpp" />
+    <ClCompile Include="Source\Ludus\UI\Types\DrawList.cpp" />
     <ClCompile Include="Source\Ludus\UI\Widgets\Demo.cpp" />
     <ClCompile Include="Source\Ludus\UI\Widgets\Headers.cpp" />
     <ClCompile Include="Source\Ludus\UI\Widgets\Color.cpp" />


### PR DESCRIPTION
# Summary
Added editor preferences persistence, recently opened project tracking, and welcome-screen recent project UI. 

Refactored editor/runtime persistence wiring to use persistence interfaces and loads editor preferences on startup. 

Also includes the new editor preferences schema/persistence implementation and theme preferences persistence.

# Linked
- Closes #237
- Closes #320
- Story: #318
