### PR TITLE
Feature: Added editor keyboard shortcuts for save, build, and simulation

### DIFF
--- a/Editor/Editor.vcxproj
+++ b/Editor/Editor.vcxproj
@@ -98,6 +98,8 @@
     <ClInclude Include="Include\Ludus\Editor\Core\EditorPreferences.h" />
     <ClInclude Include="Include\Ludus\Editor\Core\EditorSession.h" />
     <ClInclude Include="Include\Ludus\Editor\Core\EditorShell.h" />
+    <ClInclude Include="Include\Ludus\Editor\Core\EditorShortcutContext.h" />
+    <ClInclude Include="Include\Ludus\Editor\Core\EditorShortcuts.h" />
     <ClInclude Include="Include\Ludus\Editor\Core\ProjectSession.h" />
     <ClInclude Include="Include\Ludus\Editor\Core\ProjectSessionContext.h" />
     <ClInclude Include="Include\Ludus\Editor\Core\PendingProjectTransition.h" />

--- a/Editor/Include/Ludus/Editor/Core/EditorShortcutContext.h
+++ b/Editor/Include/Ludus/Editor/Core/EditorShortcutContext.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <Ludus/Editor/Core/EditorShell.h>
+#include <Ludus/Editor/Core/ProjectSession.h>
+#include <Ludus/Editor/Panels/PanelRegistry.h>
+#include <Ludus/Engine/Runtime/IHostContext.h>
+
+namespace Ludus::Editor::Core
+{
+	struct EditorShortcutContext
+	{
+		Ludus::Editor::Core::EditorShell& Shell;
+		Ludus::Engine::Runtime::IHostContext& HostContext;
+		Ludus::Editor::Panels::PanelRegistry& PanelRegistry;
+		Ludus::Editor::Core::ProjectSession* ProjectSession = nullptr;
+	};
+}

--- a/Editor/Include/Ludus/Editor/Core/EditorShortcuts.h
+++ b/Editor/Include/Ludus/Editor/Core/EditorShortcuts.h
@@ -1,0 +1,220 @@
+#pragma once
+
+#include <array>
+
+#include <Ludus/Editor/Build/BuildCommand.h>
+#include <Ludus/Editor/Build/BuildConfiguration.h>
+#include <Ludus/Editor/Build/BuildTarget.h>
+#include <Ludus/Editor/Commands/RequestCommand.h>
+#include <Ludus/Editor/Core/EditorShortcutContext.h>
+#include <Ludus/Editor/Core/ExecutionMode.h>
+#include <Ludus/Engine/Windowing/Input.h>
+#include <Ludus/Engine/Windowing/Key.h>
+#include <Ludus/UI/Context/InputContext.h>
+
+namespace Ludus::Editor::Core
+{
+	struct ShortcutBinding
+	{
+		Ludus::Engine::Windowing::Key Key;
+		bool Control = false;
+		bool Shift = false;
+		bool Alt = false;
+	};
+
+	struct ShortcutDefinition
+	{
+		ShortcutBinding Binding;
+		bool (*IsEnabled)(const Ludus::Editor::Core::EditorShortcutContext& context);
+		void (*EnqueueCommand)(Ludus::Editor::Core::EditorShortcutContext& context);
+
+		static constexpr ShortcutDefinition Create(
+			ShortcutBinding binding,
+			bool(*isEnabled)(const Ludus::Editor::Core::EditorShortcutContext&),
+			void(*enqueueCommand)(Ludus::Editor::Core::EditorShortcutContext&)
+		)
+		{
+			return {
+				.Binding = binding,
+				.IsEnabled = isEnabled,
+				.EnqueueCommand = enqueueCommand
+			};
+		}
+	};
+
+#pragma region Input Helper
+
+	bool inline IsControlPressed(Ludus::Engine::Windowing::Input& input)
+	{
+		return input.GetKey(Ludus::Engine::Windowing::Key::LeftControl) || input.GetKey(Ludus::Engine::Windowing::Key::RightControl);
+	}
+
+	bool inline IsShiftPressed(Ludus::Engine::Windowing::Input& input)
+	{
+		return input.GetKey(Ludus::Engine::Windowing::Key::LeftShift) || input.GetKey(Ludus::Engine::Windowing::Key::RightShift);
+	}
+
+	bool inline IsAltPressed(Ludus::Engine::Windowing::Input& input)
+	{
+		return input.GetKey(Ludus::Engine::Windowing::Key::LeftAlt) || input.GetKey(Ludus::Engine::Windowing::Key::RightAlt);
+	}
+
+	inline bool IsShortcutPressed(Ludus::Engine::Windowing::Input& input, const ShortcutBinding& binding)
+	{
+		const auto isControlPressed = IsControlPressed(input);
+		const auto isShiftPressed = IsShiftPressed(input);
+		const auto isAltPressed = IsAltPressed(input);
+
+		if (binding.Control != isControlPressed)
+		{
+			return false;
+		}
+
+		if (binding.Shift != isShiftPressed)
+		{
+			return false;
+		}
+
+		if (binding.Alt != isAltPressed)
+		{
+			return false;
+		}
+
+		return input.GetKeyDown(binding.Key);
+	}
+
+#pragma endregion
+
+#pragma region Predicate Helpers
+
+	bool inline IsTextInputActive(const EditorShortcutContext&)
+	{
+		return Ludus::UI::Context::InputContext::WantTextInput();
+	}
+
+	bool inline HasProjectSession(const EditorShortcutContext& context)
+	{
+		return context.ProjectSession != nullptr;
+	}
+
+	bool inline IsSimulationActive(const EditorShortcutContext& context)
+	{
+		return context.Shell.State.Execution.ExecutionMode != Ludus::Editor::Core::ExecutionMode::Stop;
+	}
+
+	bool inline IsSimulationStopped(const EditorShortcutContext& context)
+	{
+		return context.Shell.State.Execution.ExecutionMode == Ludus::Editor::Core::ExecutionMode::Stop;
+	}
+
+	bool inline IsShortcutInputAllowed(const EditorShortcutContext& context)
+	{
+		return !IsTextInputActive(context);
+	}
+
+	bool inline IsProjectShortcutAllowed(const EditorShortcutContext& context)
+	{
+		return HasProjectSession(context) && IsShortcutInputAllowed(context);
+	}
+
+	bool inline IsEditingShortcutAllowed(const EditorShortcutContext& context)
+	{
+		return IsProjectShortcutAllowed(context) && IsSimulationStopped(context);
+	}
+
+#pragma endregion
+
+#pragma region Command Predicates
+
+	bool inline IsSaveSceneEnabled(const EditorShortcutContext& context)
+	{
+		return IsEditingShortcutAllowed(context);
+	}
+
+	bool inline IsSaveProjectEnabled(const EditorShortcutContext& context)
+	{
+		return IsProjectShortcutAllowed(context);
+	}
+
+	bool inline IsRebuildScriptsEnabled(const EditorShortcutContext& context)
+	{
+		return IsEditingShortcutAllowed(context);
+	}
+
+	bool inline IsStartSimulationEnabled(const EditorShortcutContext& context)
+	{
+		return IsProjectShortcutAllowed(context) && IsSimulationStopped(context);
+	}
+
+	bool inline IsStopSimulationEnabled(const EditorShortcutContext& context)
+	{
+		return IsProjectShortcutAllowed(context) && IsSimulationActive(context);
+	}
+
+#pragma endregion
+
+#pragma region Command Enqueues
+
+	void inline EnqueueSaveScene(Ludus::Editor::Core::EditorShortcutContext& context)
+	{
+		const auto activeSceneId = context.ProjectSession->EditorState.GetActiveSceneId();
+		context.Shell.State.Commands.AddRequestCommand(Ludus::Editor::Commands::RequestCommand::SaveScene { .SceneId = activeSceneId });
+	}
+
+	void inline EnqueueSaveProject(Ludus::Editor::Core::EditorShortcutContext& context)
+	{
+		context.Shell.State.Commands.AddRequestCommand(Ludus::Editor::Commands::RequestCommand::SaveProject { });
+	}
+
+	void inline EnqueueRebuildScripts(Ludus::Editor::Core::EditorShortcutContext& context)
+	{
+		context.Shell.State.Commands.AddRequestCommand(
+			Ludus::Editor::Commands::RequestCommand::RunTargetBuildCommand
+			{
+				.BuildTarget = Ludus::Editor::Build::BuildTarget::Scripts,
+				.BuildCommand = Ludus::Editor::Build::BuildCommand::Rebuild,
+				.BuildConfiguration = Ludus::Editor::Build::BuildConfiguration::Debug
+			});
+	}
+
+	void inline EnqueueStartSimulation(Ludus::Editor::Core::EditorShortcutContext& context)
+	{
+		context.Shell.State.Commands.AddRequestCommand(
+			Ludus::Editor::Commands::RequestCommand::SetExecutionMode
+			{
+				.Mode = Ludus::Editor::Core::ExecutionMode::Start
+			});
+	}
+
+	void inline EnqueueStopSimulation(Ludus::Editor::Core::EditorShortcutContext& context)
+	{
+		context.Shell.State.Commands.AddRequestCommand(
+			Ludus::Editor::Commands::RequestCommand::SetExecutionMode
+			{
+				.Mode = Ludus::Editor::Core::ExecutionMode::Stop
+			});
+	}
+
+#pragma endregion
+
+	inline constexpr std::array<ShortcutDefinition, 5> Shortcuts = {
+		ShortcutDefinition::Create({ .Key = Ludus::Engine::Windowing::Key::S, .Control = true }, &IsSaveSceneEnabled, &EnqueueSaveScene),
+		ShortcutDefinition::Create({ .Key = Ludus::Engine::Windowing::Key::S, .Control = true, .Shift = true }, &IsSaveProjectEnabled, &EnqueueSaveProject),
+		ShortcutDefinition::Create({ .Key = Ludus::Engine::Windowing::Key::B, .Control = true, .Shift = true }, &IsRebuildScriptsEnabled, &EnqueueRebuildScripts),
+		ShortcutDefinition::Create({ .Key = Ludus::Engine::Windowing::Key::F5 }, &IsStartSimulationEnabled, &EnqueueStartSimulation),
+		ShortcutDefinition::Create({ .Key = Ludus::Engine::Windowing::Key::F5, .Shift = true }, &IsStopSimulationEnabled, &EnqueueStopSimulation)
+	};
+
+	void inline DelegateShortcutCommands(Ludus::Editor::Core::EditorShortcutContext& context)
+	{
+		auto& input = context.HostContext.GetInput();
+
+		for (const auto& shortcut : Shortcuts)
+		{
+			if (shortcut.IsEnabled(context) && IsShortcutPressed(input, shortcut.Binding))
+			{
+				shortcut.EnqueueCommand(context);
+			}
+		}
+	}
+}

--- a/Editor/Include/Ludus/Editor/Core/EditorState.h
+++ b/Editor/Include/Ludus/Editor/Core/EditorState.h
@@ -17,7 +17,7 @@ namespace Ludus::Editor::Core
 		Ludus::Editor::Commands::CommandManager Commands;
 		Ludus::Editor::Dialogs::DialogManager Dialogs;
 		Ludus::Editor::Core::ExecutionManager Execution;
-		Ludus::Editor::Core::PendingProjectTransition PendingProjectTransition = PendingProjectTransition::NoneState();
 		Ludus::Editor::Core::EditorMode Mode = Ludus::Editor::Core::EditorMode::Startup;
+		Ludus::Editor::Core::PendingProjectTransition PendingProjectTransition = PendingProjectTransition::NoneState();
 	};
 }

--- a/Editor/Include/Ludus/Editor/Core/EditorSystem.h
+++ b/Editor/Include/Ludus/Editor/Core/EditorSystem.h
@@ -57,6 +57,7 @@ namespace Ludus::Editor::Core
 		void FlushCommands();
 		void UpdateDialogs();
 		void UpdatePanels();
+		void UpdateShortcuts();
 		void UpdateWindowTitle();
 
 		void UpdateStartup();

--- a/Editor/Source/Ludus/Editor/Core/EditorSystem.cpp
+++ b/Editor/Source/Ludus/Editor/Core/EditorSystem.cpp
@@ -13,7 +13,9 @@
 #include <Ludus/Editor/Core/EditorConfiguration.h>
 #include <Ludus/Editor/Core/EditorExecutionFlags.h>
 #include <Ludus/Editor/Core/EditorPreferences.h>
+#include <Ludus/Editor/Core/EditorShortcuts.h>
 #include <Ludus/Editor/Core/EditorSystem.h>
+#include <Ludus/Editor/Core/ProjectSessionContext.h>
 #include <Ludus/Editor/Persistence/EditorPersistence.h>
 #include <Ludus/Engine/Debug/Debug.h>
 #include <Ludus/Engine/Events/Event.h>
@@ -309,6 +311,18 @@ namespace Ludus::Editor::Core
 		return true;
 	}
 
+	void EditorSystem::UpdateShortcuts()
+	{
+		EditorShortcutContext shortcutContext {
+			.Shell = m_Shell,
+			.HostContext = m_HostContext,
+			.PanelRegistry = m_PanelRegistry,
+			.ProjectSession = m_ProjectSession ? &*m_ProjectSession : nullptr
+		};
+
+		Ludus::Editor::Core::DelegateShortcutCommands(shortcutContext);
+	}
+
 	void EditorSystem::UpdateStartup()
 	{
 		UpdateWindowTitle();
@@ -330,7 +344,7 @@ namespace Ludus::Editor::Core
 			throw std::runtime_error("No active project session available.");
 		}
 
-		// Resolve transition-based commands.
+		// Resolve transition-based and shortcut-based commands.
 		FlushCommands();
 		UpdateWindowTitle();
 
@@ -352,6 +366,8 @@ namespace Ludus::Editor::Core
 		(void)deltaTime;
 
 		m_Session.ApplyTransitions(m_Shell.State.PendingProjectTransition, m_ProjectSession);
+
+		UpdateShortcuts();
 
 		if (m_Shell.State.Mode == Ludus::Editor::Core::EditorMode::Startup)
 		{

--- a/Editor/Source/Ludus/Editor/Panels/DockPanel.cpp
+++ b/Editor/Source/Ludus/Editor/Panels/DockPanel.cpp
@@ -12,6 +12,7 @@
 #include <Ludus/Editor/Core/Constants.h>
 #include <Ludus/Editor/Core/EditorExecutionFlags.h>
 #include <Ludus/Editor/Core/ExecutionMode.h>
+#include <Ludus/Editor/Core/ProjectSessionContext.h>
 #include <Ludus/Editor/Panels/DockPanel.h>
 #include <Ludus/Editor/Panels/PanelRegistry.h>
 #include <Ludus/Editor/Persistence/ProjectPaths.h>
@@ -115,7 +116,7 @@ namespace Ludus::Editor::Panels
 
 					Ludus::UI::Context::LayoutContext::Separator();
 
-					if (Ludus::UI::Widgets::MenuItem("Save"))
+					if (Ludus::UI::Widgets::MenuItem("Save", "Ctrl+S"))
 					{
 						const auto activeSceneId = context.ProjectSession.EditorState.GetActiveSceneId();
 						if (!context.ProjectSession.RuntimeState.GetEditorSceneRegistry().Contains(activeSceneId))
@@ -166,7 +167,7 @@ namespace Ludus::Editor::Panels
 					}
 				}
 
-				if (Ludus::UI::Widgets::MenuItem("Save Project"))
+				if (Ludus::UI::Widgets::MenuItem("Save Project", "Ctrl+Shift+S"))
 				{
 					context.Shell.State.Commands.AddRequestCommand(Ludus::Editor::Commands::RequestCommand::SaveProject { });
 				}
@@ -232,7 +233,7 @@ namespace Ludus::Editor::Panels
 							);
 						}
 
-						if (Ludus::UI::Widgets::MenuItem("Rebuild"))
+						if (Ludus::UI::Widgets::MenuItem("Rebuild", "Ctrl+Shift+B"))
 						{
 							context.Shell.State.Commands.AddRequestCommand(Ludus::Editor::Commands::RequestCommand::RunTargetBuildCommand
 								{ Ludus::Editor::Build::BuildTarget::Scripts, Ludus::Editor::Build::BuildCommand::Rebuild, Ludus::Editor::Build::BuildConfiguration::Debug }

--- a/Editor/Source/Ludus/Editor/Panels/ImGuiDemoPanel.cpp
+++ b/Editor/Source/Ludus/Editor/Panels/ImGuiDemoPanel.cpp
@@ -1,6 +1,7 @@
 #include "pch.h"
 
 #include <Ludus/Editor/Core/EditorExecutionFlags.h>
+#include <Ludus/Editor/Core/ProjectSessionContext.h>
 #include <Ludus/Editor/Panels/ImGuiDemoPanel.h>
 #include <Ludus/UI/Widgets/Demo.h>
 

--- a/UI/Include/Ludus/UI/Context/InputContext.h
+++ b/UI/Include/Ludus/UI/Context/InputContext.h
@@ -11,6 +11,7 @@ namespace Ludus::UI::Context::InputContext
 
 	bool WantCaptureMouse();
 	bool WantCaptureKeyboard();
+	bool WantTextInput();
 
 	bool IsItemActive();
 	bool IsAnyItemActive();

--- a/UI/Include/Ludus/UI/Flags/Flags.h
+++ b/UI/Include/Ludus/UI/Flags/Flags.h
@@ -403,7 +403,6 @@ namespace Ludus::Engine::Core::Enums
 	template<>
 	struct EnableBitMaskOperators<Ludus::UI::Flags::Button> : std::true_type {};
 
-
 	template<>
 	struct EnableBitMaskOperators<Ludus::UI::Flags::Child> : std::true_type {};
 

--- a/UI/Source/Ludus/UI/Context/InputContext.cpp
+++ b/UI/Source/Ludus/UI/Context/InputContext.cpp
@@ -37,6 +37,7 @@ namespace Ludus::UI::Context::InputContext
 
 	bool WantCaptureMouse() { return ImGui::GetIO().WantCaptureMouse; }
 	bool WantCaptureKeyboard() { return ImGui::GetIO().WantCaptureKeyboard; }
+	bool WantTextInput() { return ImGui::GetIO().WantTextInput; }
 
 	bool IsAnyItemHovered() { return ImGui::IsAnyItemHovered(); }
 	bool IsItemActive() { return ImGui::IsItemActive(); }


### PR DESCRIPTION
# Summary
Added an editor shortcut pass with static shortcut definitions for save scene, save project, rebuild scripts, start simulation, and stop simulation.

# Linked
- Closes #210 
- Closes #325 
- Story: #318 

