### PR TITLE
Feature: Added runtime texture asset loading.

### DIFF
--- a/Editor/Source/Ludus/Editor/Core/ProjectSession.cpp
+++ b/Editor/Source/Ludus/Editor/Core/ProjectSession.cpp
@@ -47,7 +47,8 @@ namespace Ludus::Editor::Core
 		auto runtimeManifestCopy = Ludus::Engine::Runtime::RuntimeManifest::Create(
 			runtimeManifest.EntrySceneId,
 			runtimeManifest.Scenes,
-			runtimeManifest.Scripts
+			runtimeManifest.Scripts,
+			runtimeManifest.Assets
 		);
 
 		return ProjectSession(

--- a/Engine/Engine.vcxproj
+++ b/Engine/Engine.vcxproj
@@ -19,10 +19,16 @@
     <Text Include="Vendors\stb_image\LICENSE.txt" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="Include\Ludus\Engine\Core\AssetManager.h" />
     <ClInclude Include="Include\Ludus\Engine\Components\DisplayNameComponent.h" />
     <ClInclude Include="Include\Ludus\Engine\Components\ScriptComponent.h" />
     <ClInclude Include="Include\Ludus\Engine\Core\Enums\EnumBits.h" />
     <ClInclude Include="Include\Ludus\Engine\Core\Id.h" />
+    <ClInclude Include="Include\Ludus\Engine\Core\AssetRegistry.h" />
+    <ClInclude Include="Include\Ludus\Engine\Core\AssetType.h" />
+    <ClInclude Include="Include\Ludus\Engine\Graphics\Texture2DResult.h" />
+    <ClInclude Include="Include\Ludus\Engine\Graphics\ITextureLoader.h" />
+    <ClInclude Include="Include\Ludus\Engine\Graphics\TextureLoader.h" />
     <ClInclude Include="Include\Ludus\Engine\Persistence\EnginePersistence.h" />
     <ClInclude Include="Include\Ludus\Engine\Runtime\PendingSceneTransition.h" />
     <ClInclude Include="Include\Ludus\Engine\Runtime\SceneRuntimeState.h" />
@@ -196,6 +202,7 @@
     <ClInclude Include="Source\Ludus\Engine\pch.h" />
     <ClInclude Include="Source\Ludus\Engine\Platform\Windows\WinShellExecute.h" />
     <ClInclude Include="Source\Ludus\Engine\Platform\Windows\WinText.h" />
+    <ClInclude Include="Include\Ludus\Engine\Graphics\TextureCache.h" />
     <ClInclude Include="Vendors\glad\include\glad\glad.h" />
     <ClInclude Include="Vendors\glad\include\KHR\khrplatform.h" />
     <ClInclude Include="Vendors\glm\common.hpp" />
@@ -489,6 +496,7 @@
     <ClInclude Include="Vendors\stb_image\stb_image.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="Source\Ludus\Engine\Core\AssetManager.cpp" />
     <ClCompile Include="Source\Ludus\Engine\Persistence\LmlRuntimeLaunchSettingsPersistence.cpp" />
     <ClCompile Include="Source\Ludus\Engine\Platform\Windows\Guid.Windows.cpp" />
     <ClCompile Include="Source\Ludus\Engine\Runtime\ApplicationHostBuilder.cpp" />
@@ -539,6 +547,7 @@
     <ClCompile Include="Source\Ludus\Engine\Platform\Windows\WinText.cpp" />
     <ClCompile Include="Source\Ludus\Engine\Windowing\Input.cpp" />
     <ClCompile Include="Source\Ludus\Engine\Windowing\Window.cpp" />
+    <ClCompile Include="Source\Ludus\Engine\Graphics\TextureCache.cpp" />
     <ClCompile Include="Vendors\glad\src\glad.c">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>

--- a/Engine/Include/Ludus/Engine/Core/AssetManager.h
+++ b/Engine/Include/Ludus/Engine/Core/AssetManager.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <memory>
+#include <unordered_set>
+
+#include <Ludus/Engine/Core/AssetRegistry.h>
+#include <Ludus/Engine/Graphics/ITextureLoader.h>
+#include <Ludus/Engine/Graphics/Texture.h>
+#include <Ludus/Engine/Graphics/Texture2DResult.h>
+#include <Ludus/Engine/Graphics/TextureCache.h>
+#include <Ludus/Engine/Runtime/RuntimeManifest.h>
+
+namespace Ludus::Engine::Core
+{
+	class AssetManager
+	{
+	private:
+		const AssetRegistry& m_AssetRegistry;
+		std::filesystem::path m_RuntimeRootDirectory;
+		std::unique_ptr<Ludus::Engine::Graphics::ITextureLoader> m_TextureLoader;
+		Ludus::Engine::Graphics::TextureCache m_TextureCache;
+		std::unordered_set<AssetId> m_FailedTextureLoads;
+		Ludus::Engine::Graphics::Texture m_MissingTexture;
+
+	public:
+		AssetManager(
+			const AssetRegistry& assetRegistry,
+			std::filesystem::path runtimeRootDirectory
+		);
+
+		AssetManager(
+			const AssetRegistry& assetRegistry,
+			std::filesystem::path runtimeRootDirectory,
+			std::unique_ptr<Ludus::Engine::Graphics::ITextureLoader> textureLoader,
+			Ludus::Engine::Graphics::Texture missingTexture
+		);
+
+		Ludus::Engine::Graphics::Texture2DResult GetTexture2D(AssetId id);
+
+		const Ludus::Engine::Runtime::AssetReference* TryGetReference(AssetId id) const;
+		bool HasFailedTextureLoad(AssetId id) const;
+	};
+}

--- a/Engine/Include/Ludus/Engine/Core/AssetRegistry.h
+++ b/Engine/Include/Ludus/Engine/Core/AssetRegistry.h
@@ -1,0 +1,88 @@
+#pragma once
+
+#include <span>
+#include <stdexcept>
+#include <unordered_map>
+#include <vector>
+
+#include <Ludus/Engine/Core/AssetType.h>
+#include <Ludus/Engine/Core/Id.h>
+#include <Ludus/Engine/Runtime/RuntimeManifest.h>
+
+namespace Ludus::Engine::Core
+{
+	class AssetRegistry
+	{
+	private:
+		std::vector<Ludus::Engine::Runtime::AssetReference> m_References;
+		std::unordered_map<AssetId, size_t> m_IdToIndex;
+
+	private:
+		void CommitAsset(Ludus::Engine::Runtime::AssetReference assetReference)
+		{
+			if (!assetReference.Id.IsValid())
+			{
+				throw std::runtime_error("Cannot register an asset with an invalid id.");
+			}
+
+			if (assetReference.Type == Ludus::Engine::Core::AssetType::Unknown)
+			{
+				throw std::runtime_error("Cannot register an asset with unknown asset type.");
+			}
+
+			if (assetReference.Path.empty())
+			{
+				throw std::runtime_error("Cannot register an asset with an empty path.");
+			}
+
+			if (Contains(assetReference.Id))
+			{
+				throw std::runtime_error("Cannot register an asset with a duplicate id.");
+			}
+
+			const auto assetId = assetReference.Id;
+
+			m_References.push_back(std::move(assetReference));
+			m_IdToIndex[assetId] = m_References.size() - 1;
+		}
+
+	public:
+		explicit AssetRegistry(const Ludus::Engine::Runtime::RuntimeManifest& runtimeManifest)
+		{
+			m_References.reserve(runtimeManifest.Assets.size());
+			m_IdToIndex.reserve(runtimeManifest.Assets.size());
+
+			for (const auto& asset : runtimeManifest.Assets)
+			{
+				CommitAsset(asset);
+			}
+		}
+
+		std::span<const Ludus::Engine::Runtime::AssetReference> View() const
+		{
+			return { m_References.data(), m_References.size() };
+		}
+
+		bool Contains(AssetId id) const
+		{
+			return m_IdToIndex.contains(id);
+		}
+
+		const Ludus::Engine::Runtime::AssetReference* TryGetAsset(AssetId id) const
+		{
+			if (const auto iter = m_IdToIndex.find(id); iter != m_IdToIndex.end())
+			{
+				return &m_References[iter->second];
+			}
+
+			return nullptr;
+		}
+
+		const Ludus::Engine::Runtime::AssetReference& GetAsset(AssetId id) const
+		{
+			const auto* asset = TryGetAsset(id);
+			LUDUS_ASSERT(asset != nullptr, "Asset id does not exist.");
+			return *asset;
+		}
+	};
+}

--- a/Engine/Include/Ludus/Engine/Core/AssetType.h
+++ b/Engine/Include/Ludus/Engine/Core/AssetType.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <stdexcept>
+#include <string_view>
+
+#include <Ludus/Engine/Core/Enums/EnumTraits.h>
+
+namespace Ludus::Engine::Core
+{
+	enum class AssetType { Unknown, Texture2D };
+
+	constexpr std::string_view ToString(AssetType assetType)
+	{
+		switch (assetType)
+		{
+			case AssetType::Unknown:	return "Unknown";
+			case AssetType::Texture2D:	return "Texture2D";
+			default:					throw std::runtime_error("Unsupported asset type.");
+		}
+	}
+
+	constexpr bool TryParse(std::string_view text, AssetType& out)
+	{
+		if (text == "Unknown")
+		{
+			out = AssetType::Unknown;
+			return true;
+		}
+
+		if (text == "Texture2D")
+		{
+			out = AssetType::Texture2D;
+			return true;
+		}
+
+		return false;
+	}
+}

--- a/Engine/Include/Ludus/Engine/Core/Id.h
+++ b/Engine/Include/Ludus/Engine/Core/Id.h
@@ -27,10 +27,12 @@ namespace Ludus::Engine::Core
 	struct EntityIdTag;
 	struct SceneIdTag;
 	struct ScriptIdTag;
+	struct AssetIdTag;
 
 	using EntityId = Id<EntityIdTag>;
 	using SceneId = Id<SceneIdTag>;
 	using ScriptId = Id<ScriptIdTag>;
+	using AssetId = Id<AssetIdTag>;
 }
 
 template<>
@@ -55,6 +57,15 @@ template<>
 struct std::hash<Ludus::Engine::Core::ScriptId>
 {
 	std::size_t operator()(const Ludus::Engine::Core::ScriptId& id) const noexcept
+	{
+		return std::hash<std::uint64_t> {}(id.Value);
+	}
+};
+
+template<>
+struct std::hash<Ludus::Engine::Core::AssetId>
+{
+	std::size_t operator()(const Ludus::Engine::Core::AssetId& id) const noexcept
 	{
 		return std::hash<std::uint64_t> {}(id.Value);
 	}

--- a/Engine/Include/Ludus/Engine/Core/SceneRegistry.h
+++ b/Engine/Include/Ludus/Engine/Core/SceneRegistry.h
@@ -50,9 +50,10 @@ namespace Ludus::Engine::Core
 			{
 				sceneId = CreateUniqueId();
 			}
-			else
+
+			if (Contains(sceneId))
 			{
-				LUDUS_ASSERT(!Contains(sceneId), "Cannot add a scene with a duplicate id.");
+				throw std::exception("Cannot add a scene with a duplicate id.");
 			}
 
 			scene.Id = sceneId;

--- a/Engine/Include/Ludus/Engine/Graphics/Color.h
+++ b/Engine/Include/Ludus/Engine/Graphics/Color.h
@@ -6,9 +6,9 @@ namespace Ludus::Engine::Graphics
 	{
 		float R, G, B, A;
 
-		constexpr Color() : R(0.0f), G(0.0f), B(0.0f), A(0.0f) { }
-		constexpr Color(float r, float g, float b) : R(r), G(g), B(b), A(1.0f) { }
-		constexpr Color(float r, float g, float b, float a) : R(r), G(g), B(b), A(a) { }
+		constexpr Color() : R(0.0f), G(0.0f), B(0.0f), A(0.0f) {}
+		constexpr Color(float r, float g, float b) : R(r), G(g), B(b), A(1.0f) {}
+		constexpr Color(float r, float g, float b, float a) : R(r), G(g), B(b), A(a) {}
 
 		constexpr Color WithAlpha(float alpha) const
 		{

--- a/Engine/Include/Ludus/Engine/Graphics/ITextureLoader.h
+++ b/Engine/Include/Ludus/Engine/Graphics/ITextureLoader.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <filesystem>
+#include <optional>
+
+#include <Ludus/Engine/Graphics/Texture.h>
+
+namespace Ludus::Engine::Graphics
+{
+	class ITextureLoader
+	{
+	public:
+		virtual ~ITextureLoader() = default;
+
+		virtual std::optional<Texture> TryLoadTextureFromFile(const std::filesystem::path& path) const = 0;
+	};
+}

--- a/Engine/Include/Ludus/Engine/Graphics/Texture.h
+++ b/Engine/Include/Ludus/Engine/Graphics/Texture.h
@@ -1,5 +1,11 @@
 #pragma once
 
+#include <filesystem>
+#include <initializer_list>
+#include <optional>
+
+#include <Ludus/Engine/Graphics/Color.h>
+
 namespace Ludus::Engine::Graphics
 {
 	class Texture
@@ -20,13 +26,22 @@ namespace Ludus::Engine::Graphics
 
 		static Texture Empty(int width, int height);
 		static Texture FramebufferTexture(int width, int height);
-		static Texture FromFile(const std::string& path);
-		static Texture FromMemory(int width, int height, const void* data);
+
 		static Texture White();
+		static Texture Missing();
+
+		static Texture FromR8(int width, int height, const void* data);
+		static Texture FromRGBA(int width, int height, const void* data);
+		static Texture FromColor(int width, int height, const Color& color = Colors::White);
+		static Texture FromColor(int width, int height, std::initializer_list<Color> colors);
+
+		static std::optional<Texture> TryFromFile(const std::filesystem::path& path);
 
 		void Bind(unsigned int slot = 0) const;
 		void Unbind() const;
 
 		unsigned int Handle() const;
+		int Width() const;
+		int Height() const;
 	};
 }

--- a/Engine/Include/Ludus/Engine/Graphics/Texture2DResult.h
+++ b/Engine/Include/Ludus/Engine/Graphics/Texture2DResult.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <Ludus/Engine/Graphics/Texture.h>
+
+namespace Ludus::Engine::Graphics
+{
+	struct Texture2DResult
+	{
+		Texture* Texture = nullptr;
+		bool IsFallback = false;
+
+		bool HasTexture() const
+		{
+			return Texture != nullptr;
+		}
+	};
+}

--- a/Engine/Include/Ludus/Engine/Graphics/TextureCache.h
+++ b/Engine/Include/Ludus/Engine/Graphics/TextureCache.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <memory>
+#include <unordered_map>
+
+#include <Ludus/Engine/Core/Id.h>
+#include <Ludus/Engine/Graphics/Texture.h>
+
+namespace Ludus::Engine::Graphics
+{
+	class TextureCache
+	{
+	private:
+		std::unordered_map<Ludus::Engine::Core::AssetId, std::unique_ptr<Texture>> m_TexturesByAssetId;
+
+	public:
+		Texture* TryGet(Ludus::Engine::Core::AssetId id);
+		Texture& Add(Ludus::Engine::Core::AssetId id, std::unique_ptr<Texture> texture);
+		bool Contains(Ludus::Engine::Core::AssetId id) const;
+	};
+}

--- a/Engine/Include/Ludus/Engine/Graphics/TextureLoader.h
+++ b/Engine/Include/Ludus/Engine/Graphics/TextureLoader.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <filesystem>
+#include <optional>
+
+#include <Ludus/Engine/Graphics/ITextureLoader.h>
+
+namespace Ludus::Engine::Graphics
+{
+	class TextureLoader final : public ITextureLoader
+	{
+	public:
+		std::optional<Texture> TryLoadTextureFromFile(const std::filesystem::path& path) const override
+		{
+			if (!std::filesystem::exists(path))
+			{
+				return std::nullopt;
+			}
+
+			return Texture::TryFromFile(path);
+		}
+	};
+}

--- a/Engine/Include/Ludus/Engine/Runtime/RuntimeInstance.h
+++ b/Engine/Include/Ludus/Engine/Runtime/RuntimeInstance.h
@@ -4,12 +4,14 @@
 #include <memory>
 #include <utility>
 
+#include <Ludus/Engine/Core/AssetManager.h>
+#include <Ludus/Engine/Core/AssetRegistry.h>
 #include <Ludus/Engine/Core/Enums/FlagSet.h>
 #include <Ludus/Engine/Core/RenderViewRegistry.h>
 #include <Ludus/Engine/Core/RenderViewRequestRegistry.h>
 #include <Ludus/Engine/Core/Scene.h>
-#include <Ludus/Engine/Graphics/RenderingConfiguration2D.h>
 #include <Ludus/Engine/Graphics/RenderPresentationSettings.h>
+#include <Ludus/Engine/Graphics/RenderingConfiguration2D.h>
 #include <Ludus/Engine/Physics/Core/PhysicsConfiguration2D.h>
 #include <Ludus/Engine/Runtime/IHostContext.h>
 #include <Ludus/Engine/Runtime/InitialSceneMode.h>
@@ -28,6 +30,8 @@ namespace Ludus::Engine::Runtime
 		const RuntimeEnvironment m_RuntimeEnvironment;
 		IHostContext& m_HostContext;
 
+		Ludus::Engine::Core::AssetRegistry m_AssetRegistry;
+		Ludus::Engine::Core::AssetManager m_AssetManager;
 		Ludus::Engine::Graphics::RenderPresentationSettings m_RenderPresentationSettings;
 		Ludus::Engine::Graphics::RenderingConfiguration2D m_RenderingConfiguration;
 		Ludus::Engine::Physics::Core::PhysicsConfiguration2D m_PhysicsConfiguration;
@@ -73,6 +77,12 @@ namespace Ludus::Engine::Runtime
 		void Run(SystemPhase phase, Ludus::Engine::Core::Enums::FlagSet& executionFlags, float time = 0.0f);
 
 #pragma region Getters
+
+		Ludus::Engine::Core::AssetRegistry& GetAssetRegistry() { return m_AssetRegistry; }
+		const Ludus::Engine::Core::AssetRegistry& GetAssetRegistry() const { return m_AssetRegistry; }
+
+		Ludus::Engine::Core::AssetManager& GetAssetManager() { return m_AssetManager; }
+		const Ludus::Engine::Core::AssetManager& GetAssetManager() const { return m_AssetManager; }
 
 		Ludus::Engine::Physics::Core::PhysicsConfiguration2D& GetPhysicsConfiguration() { return m_PhysicsConfiguration; }
 		const Ludus::Engine::Physics::Core::PhysicsConfiguration2D& GetPhysicsConfiguration() const { return m_PhysicsConfiguration; }

--- a/Engine/Include/Ludus/Engine/Runtime/RuntimeManifest.h
+++ b/Engine/Include/Ludus/Engine/Runtime/RuntimeManifest.h
@@ -5,6 +5,7 @@
 #include <utility>
 #include <vector>
 
+#include <Ludus/Engine/Core/AssetType.h>
 #include <Ludus/Engine/Core/Id.h>
 #include <Ludus/Engine/Core/Version.h>
 
@@ -23,6 +24,13 @@ namespace Ludus::Engine::Runtime
 		std::string Name;
 	};
 
+	struct AssetReference
+	{
+		Ludus::Engine::Core::AssetId Id { Ludus::Engine::Core::AssetId::Invalid() };
+		Ludus::Engine::Core::AssetType Type { Ludus::Engine::Core::AssetType::Unknown };
+		std::filesystem::path Path;
+	};
+
 	struct RuntimeManifest
 	{
 		inline static constexpr Ludus::Engine::Core::Version CurrentVersion = { 0, 2, 0 };
@@ -31,18 +39,21 @@ namespace Ludus::Engine::Runtime
 		Ludus::Engine::Core::SceneId EntrySceneId { Ludus::Engine::Core::SceneId::Invalid() };
 		std::vector<SceneReference> Scenes;
 		std::vector<ScriptReference> Scripts;
+		std::vector<AssetReference> Assets;
 
 		static RuntimeManifest Create(
 			Ludus::Engine::Core::SceneId entrySceneId = Ludus::Engine::Core::SceneId::Invalid(),
 			std::vector<SceneReference> scenes = { },
-			std::vector<ScriptReference> scripts = { }
+			std::vector<ScriptReference> scripts = { },
+			std::vector<AssetReference> assets = { }
 		)
 		{
 			return {
 				.Version = CurrentVersion,
 				.EntrySceneId = entrySceneId,
 				.Scenes = std::move(scenes),
-				.Scripts = std::move(scripts)
+				.Scripts = std::move(scripts),
+				.Assets = std::move(assets)
 			};
 		}
 

--- a/Engine/Source/Ludus/Engine/Core/AssetManager.cpp
+++ b/Engine/Source/Ludus/Engine/Core/AssetManager.cpp
@@ -1,0 +1,110 @@
+#include "pch.h"
+
+#include <filesystem>
+#include <format>
+
+#include <Ludus/Engine/Core/AssetManager.h>
+#include <Ludus/Engine/Core/AssetType.h>
+#include <Ludus/Engine/Debug/Debug.h>
+#include <Ludus/Engine/Graphics/Texture.h>
+#include <Ludus/Engine/Graphics/TextureLoader.h>
+
+namespace Ludus::Engine::Core
+{
+	AssetManager::AssetManager(
+		const AssetRegistry& assetRegistry,
+		std::filesystem::path runtimeRootDirectory
+	) :
+		AssetManager(
+			assetRegistry,
+			std::move(runtimeRootDirectory),
+			std::make_unique<Ludus::Engine::Graphics::TextureLoader>(),
+			Ludus::Engine::Graphics::Texture::Missing()
+		)
+	{}
+
+	AssetManager::AssetManager(
+		const AssetRegistry& assetRegistry,
+		std::filesystem::path runtimeRootDirectory,
+		std::unique_ptr<Ludus::Engine::Graphics::ITextureLoader> textureLoader,
+		Ludus::Engine::Graphics::Texture missingTexture
+	) :
+		m_AssetRegistry(assetRegistry),
+		m_RuntimeRootDirectory(std::move(runtimeRootDirectory)),
+		m_TextureLoader(std::move(textureLoader)),
+		m_TextureCache(),
+		m_FailedTextureLoads(),
+		m_MissingTexture(std::move(missingTexture))
+	{
+		LUDUS_ASSERT(m_TextureLoader != nullptr, "AssetManager requires a texture loader.");
+	}
+
+	Ludus::Engine::Graphics::Texture2DResult AssetManager::GetTexture2D(AssetId id)
+	{
+		if (!id.IsValid())
+		{
+			return { nullptr, false };
+		}
+
+		auto* cachedTexture = m_TextureCache.TryGet(id);
+		if (cachedTexture != nullptr)
+		{
+			return { cachedTexture, false };
+		}
+
+		if (HasFailedTextureLoad(id))
+		{
+			return { &m_MissingTexture, true };
+		}
+
+		auto* assetReference = TryGetReference(id);
+		if (assetReference == nullptr)
+		{
+			LUDUS_LOG_WARN(std::format("Asset reference with ID {} missing.", id.Value));
+			m_FailedTextureLoads.emplace(id);
+
+			return { &m_MissingTexture, true };
+		}
+
+		if (assetReference->Type != AssetType::Texture2D)
+		{
+			LUDUS_LOG_WARN(std::format("Asset reference with ID {} is not a texture.", id.Value));
+			m_FailedTextureLoads.emplace(id);
+
+			return { &m_MissingTexture, true };
+		}
+
+		const auto& texturePath = m_RuntimeRootDirectory / assetReference->Path;
+		if (!std::filesystem::exists(texturePath))
+		{
+			LUDUS_LOG_WARN(std::format("Asset reference with ID {} has an invalid path.", id.Value));
+			m_FailedTextureLoads.emplace(id);
+
+			return { &m_MissingTexture, true };
+		}
+
+		auto loadedTextureResult = m_TextureLoader->TryLoadTextureFromFile(texturePath);
+		if (!loadedTextureResult)
+		{
+			LUDUS_LOG_WARN(std::format("Asset reference with ID {} failed to load its texture.", id.Value));
+			m_FailedTextureLoads.emplace(id);
+
+			return { &m_MissingTexture, true };
+		}
+
+		auto texture = std::make_unique<Ludus::Engine::Graphics::Texture>(std::move(*loadedTextureResult));
+		auto& storedTexture = m_TextureCache.Add(id, std::move(texture));
+
+		return { &storedTexture, false };
+	}
+
+	const Ludus::Engine::Runtime::AssetReference* AssetManager::TryGetReference(AssetId id) const
+	{
+		return m_AssetRegistry.TryGetAsset(id);
+	}
+
+	bool AssetManager::HasFailedTextureLoad(AssetId id) const
+	{
+		return m_FailedTextureLoads.contains(id);
+	}
+}

--- a/Engine/Source/Ludus/Engine/Graphics/Font.cpp
+++ b/Engine/Source/Ludus/Engine/Graphics/Font.cpp
@@ -53,7 +53,7 @@ namespace Ludus::Engine::Graphics
 		auto slot = m_Face->glyph;
 		auto bitmap = m_Face->glyph->bitmap;
 
-		auto texture = Texture::FromMemory(bitmap.width, bitmap.rows, bitmap.buffer);
+		auto texture = Texture::FromR8(bitmap.width, bitmap.rows, bitmap.buffer);
 
 		Glyph glyph
 		{

--- a/Engine/Source/Ludus/Engine/Graphics/Renderer2D.cpp
+++ b/Engine/Source/Ludus/Engine/Graphics/Renderer2D.cpp
@@ -50,7 +50,7 @@ namespace Ludus::Engine::Graphics
 	}
 
 	Renderer2D::~Renderer2D()
-	{ }
+	{}
 
 #pragma endregion
 

--- a/Engine/Source/Ludus/Engine/Graphics/Texture.cpp
+++ b/Engine/Source/Ludus/Engine/Graphics/Texture.cpp
@@ -1,6 +1,10 @@
 #include "pch.h"
 
-#include <format>
+#include <algorithm>
+#include <cmath>
+#include <filesystem>
+#include <optional>
+#include <vector>
 
 #include <stb_image/stb_image.h>
 
@@ -10,13 +14,31 @@
 
 namespace Ludus::Engine::Graphics
 {
-	Texture::Texture(unsigned int handle, int width, int height)
-		: m_Handle(handle), m_Width(width), m_Height(height)
-	{ }
+	namespace
+	{
+		unsigned char ToByte(float value)
+		{
+			value = std::clamp(value, 0.0f, 1.0f);
+			return static_cast<unsigned char>(std::round(value * 255));
+		}
+	}
+
+	Texture::Texture(
+		unsigned int handle,
+		int width,
+		int height
+	) :
+		m_Handle(handle),
+		m_Width(width),
+		m_Height(height)
+	{}
 
 	Texture::~Texture()
 	{
-		glDeleteTextures(1, &m_Handle);
+		if (m_Handle)
+		{
+			glDeleteTextures(1, &m_Handle);
+		}
 	}
 
 	Texture::Texture(Texture&& other) noexcept
@@ -46,8 +68,7 @@ namespace Ludus::Engine::Graphics
 
 	Texture Texture::Empty(int width, int height)
 	{
-		Texture texture(0, width, height);
-		return texture;
+		return Texture(0, width, height);
 	}
 
 	Texture Texture::FramebufferTexture(int width, int height)
@@ -60,65 +81,36 @@ namespace Ludus::Engine::Graphics
 
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-
-		Texture texture(handle, width, height);
-		return texture;
-	}
-
-	Texture Texture::FromFile(const std::string& path)
-	{
-		unsigned int handle;
-		int width, height, _;
-
-		stbi_set_flip_vertically_on_load(1);
-		auto m_Data = stbi_load(path.c_str(), &width, &height, &_, 4);
-		if (!m_Data)
-		{
-			LUDUS_LOG_ERROR(
-				std::format("Failed to load texture: {}", path)
-			);
-
-			return Texture::White();
-		}
-
-		glGenTextures(1, &handle);
-		glBindTexture(GL_TEXTURE_2D, handle);
-
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 
-		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, m_Data);
 		glBindTexture(GL_TEXTURE_2D, 0);
 
-		stbi_image_free(m_Data);
-		m_Data = nullptr;
-
-		Texture texture(handle, width, height);
-		return texture;
+		return Texture(handle, width, height);
 	}
 
-	Texture Texture::FromMemory(int width, int height, const void* data)
+	Texture Texture::White()
 	{
+		return FromColor(1, 1, Colors::White);
+	}
+
+	Texture Texture::Missing()
+	{
+		return FromColor(2, 2, { Colors::Black, Colors::Magenta, Colors::Magenta, Colors::Black });
+	}
+
+	Texture Texture::FromR8(int width, int height, const void* data)
+	{
+		LUDUS_ASSERT(width > 0 && height > 0, "Texture dimensions must be positive.");
+		LUDUS_ASSERT(data != nullptr, "Cannot create R8 texture from null data.");
+
 		unsigned int handle;
 		glGenTextures(1, &handle);
 		glBindTexture(GL_TEXTURE_2D, handle);
 
 		glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
 
-		glTexImage2D(
-			GL_TEXTURE_2D,
-			0,
-			GL_R8,
-			width,
-			height,
-			0,
-			GL_RED,
-			GL_UNSIGNED_BYTE,
-			data
-		);
+		glTexImage2D(GL_TEXTURE_2D, 0, GL_R8, width, height, 0, GL_RED, GL_UNSIGNED_BYTE, data);
 
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
@@ -135,25 +127,89 @@ namespace Ludus::Engine::Graphics
 		return Texture(handle, width, height);
 	}
 
-	Texture Texture::White()
+	Texture Texture::FromRGBA(int width, int height, const void* data)
 	{
+		LUDUS_ASSERT(width > 0 && height > 0, "Texture dimensions must be positive.");
+		LUDUS_ASSERT(data != nullptr, "Cannot create RGBA texture from null data.");
+
 		unsigned int handle;
 
 		glGenTextures(1, &handle);
 		glBindTexture(GL_TEXTURE_2D, handle);
 
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+		glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 
-		unsigned char whitePixel[4] = { 255, 255, 255, 255 };
-		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, 1, 1, 0,
-			GL_RGBA, GL_UNSIGNED_BYTE, whitePixel);
+		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, data);
 
 		glBindTexture(GL_TEXTURE_2D, 0);
 
-		Texture texture(handle, 1, 1);
+		return Texture(handle, width, height);
+	}
+
+	Texture Texture::FromColor(int width, int height, const Color& color)
+	{
+		LUDUS_ASSERT(width > 0 && height > 0, "Texture dimensions must be positive.");
+
+		const auto pixelCount = static_cast<size_t>(width) * static_cast<size_t>(height);
+
+		std::vector<unsigned char> pixels;
+		pixels.resize(pixelCount * 4);
+
+		const auto r = ToByte(color.R);
+		const auto g = ToByte(color.G);
+		const auto b = ToByte(color.B);
+		const auto a = ToByte(color.A);
+
+		for (size_t i = 0; i < pixelCount; i++)
+		{
+			pixels[i * 4 + 0] = r;
+			pixels[i * 4 + 1] = g;
+			pixels[i * 4 + 2] = b;
+			pixels[i * 4 + 3] = a;
+		}
+
+		return FromRGBA(width, height, pixels.data());
+	}
+
+	Texture Texture::FromColor(int width, int height, std::initializer_list<Color> colors)
+	{
+		LUDUS_ASSERT(width > 0 && height > 0, "Texture dimensions must be positive.");
+
+		const auto pixelCount = static_cast<size_t>(width) * static_cast<size_t>(height);
+		LUDUS_ASSERT(colors.size() == pixelCount, "The texture dimensions do not match the size of the color list.");
+
+		std::vector<unsigned char> bytes;
+		bytes.reserve(pixelCount * 4);
+
+		for (const auto& color : colors)
+		{
+			bytes.push_back(ToByte(color.R));
+			bytes.push_back(ToByte(color.G));
+			bytes.push_back(ToByte(color.B));
+			bytes.push_back(ToByte(color.A));
+		}
+
+		return FromRGBA(width, height, bytes.data());
+	}
+
+	std::optional<Texture> Texture::TryFromFile(const std::filesystem::path& path)
+	{
+		int width, height, _;
+		auto data = stbi_load(path.string().c_str(), &width, &height, &_, 4);
+		if (!data)
+		{
+			return std::nullopt;
+		}
+
+		auto texture = FromRGBA(width, height, data);
+
+		stbi_image_free(data);
+
 		return texture;
 	}
 
@@ -171,5 +227,15 @@ namespace Ludus::Engine::Graphics
 	unsigned int Texture::Handle() const
 	{
 		return m_Handle;
+	}
+
+	int Texture::Width() const
+	{
+		return m_Width;
+	}
+
+	int Texture::Height() const
+	{
+		return m_Height;
 	}
 }

--- a/Engine/Source/Ludus/Engine/Graphics/TextureCache.cpp
+++ b/Engine/Source/Ludus/Engine/Graphics/TextureCache.cpp
@@ -1,0 +1,31 @@
+#include "pch.h"
+
+#include <Ludus/Engine/Graphics/TextureCache.h>
+
+namespace Ludus::Engine::Graphics
+{
+	Texture* TextureCache::TryGet(Ludus::Engine::Core::AssetId id)
+	{
+		if (auto iter = m_TexturesByAssetId.find(id); iter != m_TexturesByAssetId.end())
+		{
+			return iter->second.get();
+		}
+
+		return nullptr;
+	}
+
+	Texture& TextureCache::Add(Ludus::Engine::Core::AssetId id, std::unique_ptr<Texture> texture)
+	{
+		LUDUS_ASSERT(texture != nullptr, "Cannot add a null texture in the texture cache.");
+		LUDUS_ASSERT(!Contains(id), "Cannot add a duplicate texture asset id in the texture cache.");
+
+		m_TexturesByAssetId[id] = std::move(texture);
+
+		return *m_TexturesByAssetId.at(id);
+	}
+
+	bool TextureCache::Contains(Ludus::Engine::Core::AssetId id) const
+	{
+		return m_TexturesByAssetId.contains(id);
+	}
+}

--- a/Engine/Source/Ludus/Engine/Runtime/RuntimeInstance.cpp
+++ b/Engine/Source/Ludus/Engine/Runtime/RuntimeInstance.cpp
@@ -6,12 +6,12 @@
 #include <Ludus/Engine/Core/RenderViewRegistry.h>
 #include <Ludus/Engine/Core/RenderViewRequestRegistry.h>
 #include <Ludus/Engine/Debug/Debug.h>
-#include <Ludus/Engine/Graphics/RenderingConfiguration2D.h>
 #include <Ludus/Engine/Graphics/RenderPresentationSettings.h>
+#include <Ludus/Engine/Graphics/RenderingConfiguration2D.h>
 #include <Ludus/Engine/Physics/Core/PhysicsConfiguration2D.h>
 #include <Ludus/Engine/Runtime/IHostContext.h>
-#include <Ludus/Engine/Runtime/InitialSceneMode.h>
 #include <Ludus/Engine/Runtime/ISystem.h>
+#include <Ludus/Engine/Runtime/InitialSceneMode.h>
 #include <Ludus/Engine/Runtime/RuntimeEnvironment.h>
 #include <Ludus/Engine/Runtime/RuntimeInstance.h>
 #include <Ludus/Engine/Runtime/SystemScheduler.h>
@@ -31,6 +31,8 @@ namespace Ludus::Engine::Runtime
 		m_RuntimeManifest(std::move(runtimeManifest)),
 		m_RuntimeEnvironment(std::move(runtimeEnvironment)),
 		m_HostContext(hostContext),
+		m_AssetRegistry(m_RuntimeManifest),
+		m_AssetManager(m_AssetRegistry, m_RuntimeEnvironment.RuntimeRootDirectory),
 		m_RenderPresentationSettings(std::move(renderPresentationSettings)),
 		m_RenderingConfiguration(std::move(renderingConfiguration)),
 		m_PhysicsConfiguration(std::move(physicsConfiguration)),

--- a/Engine/Source/Ludus/Engine/Serialization/Schemas/RuntimeManifestSchema.cpp
+++ b/Engine/Source/Ludus/Engine/Serialization/Schemas/RuntimeManifestSchema.cpp
@@ -5,6 +5,7 @@
 #include <string_view>
 #include <utility>
 
+#include <Ludus/Engine/Core/AssetType.h>
 #include <Ludus/Engine/FileSystem/FileSystem.h>
 #include <Ludus/Engine/Runtime/RuntimeManifest.h>
 #include <Ludus/Engine/Serialization/Core/TokenRead.h>
@@ -15,6 +16,7 @@ namespace Ludus::Engine::Serialization::Schemas
 	using Token = Ludus::Engine::Serialization::Core::Token;
 	using SceneReference = Ludus::Engine::Runtime::SceneReference;
 	using ScriptReference = Ludus::Engine::Runtime::ScriptReference;
+	using AssetReference = Ludus::Engine::Runtime::AssetReference;
 
 	void RuntimeManifestSchema::Serialize(ITokenStreamWriter& writer, const RuntimeManifest& runtimeManifest)
 	{
@@ -42,6 +44,7 @@ namespace Ludus::Engine::Serialization::Schemas
 
 			writer.Emit(Token::Key { "Id" });
 			writer.Emit(Token::Uint { scene.Id.Value });
+
 			writer.Emit(Token::Key { "Name" });
 			writer.Emit(Token::String { scene.Name });
 
@@ -63,8 +66,32 @@ namespace Ludus::Engine::Serialization::Schemas
 
 			writer.Emit(Token::Key { "Id" });
 			writer.Emit(Token::Uint { script.Id.Value });
+
 			writer.Emit(Token::Key { "Name" });
 			writer.Emit(Token::String { script.Name });
+
+			writer.Emit(Token::EndObject { });
+		}
+
+		writer.Emit(Token::EndArray { });
+
+		writer.Emit(Token::Key { "Assets" });
+		writer.Emit(Token::StartArray { });
+
+		for (const auto& asset : runtimeManifest.Assets)
+		{
+			writer.Emit(Token::StartObject { });
+
+			writer.Emit(Token::Key { "Id" });
+			writer.Emit(Token::Uint { asset.Id.Value });
+
+			const std::string assetType = Ludus::Engine::Core::Enums::GetDisplayName(asset.Type);
+			writer.Emit(Token::Key { "Type" });
+			writer.Emit(Token::String { assetType });
+
+			writer.Emit(Token::Key { "Path" });
+			const auto assetPath = Ludus::Engine::FileSystem::ToPortablePathString(asset.Path);
+			writer.Emit(Token::String { assetPath });
 
 			writer.Emit(Token::EndObject { });
 		}
@@ -225,6 +252,71 @@ namespace Ludus::Engine::Serialization::Schemas
 						}
 
 						runtimeManifest.Scripts.emplace_back(std::move(script));
+					}
+
+					Ludus::Engine::Serialization::Core::ConsumeAs<Token::EndArray>(reader);
+					return;
+				}
+				if (key == "Assets")
+				{
+					Ludus::Engine::Serialization::Core::ConsumeAs<Token::StartArray>(reader);
+
+					while (!Ludus::Engine::Serialization::Core::Is<Token::EndArray>(reader.Peek()))
+					{
+						AssetReference asset;
+						bool hasId = false;
+						bool hasType = false;
+						bool hasPath = false;
+
+						Ludus::Engine::Serialization::Core::ReadObject(reader, [&](std::string_view assetKey)
+						{
+							if (assetKey == "Id")
+							{
+								asset.Id = { Ludus::Engine::Serialization::Core::ConsumeUint64Like(reader) };
+								if (!asset.Id.IsValid())
+								{
+									throw SerializationException("RuntimeManifest asset id is invalid.");
+								}
+								hasId = true;
+								return;
+							}
+							if (assetKey == "Type")
+							{
+								std::string assetTypeValue = std::string(
+									Ludus::Engine::Serialization::Core::ConsumeAs<Token::String>(reader).Data);
+								Ludus::Engine::Core::AssetType parsed;
+								if (!Ludus::Engine::Core::TryParse(assetTypeValue, parsed))
+								{
+									throw SerializationException("RuntimeManifest asset type is invalid.");
+								}
+
+								if (parsed == Ludus::Engine::Core::AssetType::Unknown)
+								{
+									throw SerializationException("RuntimeManifest asset type cannot be Unknown.");
+								}
+
+								asset.Type = parsed;
+								hasType = true;
+								return;
+							}
+							if (assetKey == "Path")
+							{
+								asset.Path = std::filesystem::path(
+									std::string(Ludus::Engine::Serialization::Core::ConsumeAs<Token::String>(reader).Data)
+								);
+								hasPath = true;
+								return;
+							}
+
+							Ludus::Engine::Serialization::Core::SkipValue(reader);
+						});
+
+						if (!hasId || !hasType || !hasPath)
+						{
+							throw SerializationException("RuntimeManifest asset entry is incomplete.");
+						}
+
+						runtimeManifest.Assets.emplace_back(std::move(asset));
 					}
 
 					Ludus::Engine::Serialization::Core::ConsumeAs<Token::EndArray>(reader);

--- a/EngineTests/EngineTests.vcxproj
+++ b/EngineTests/EngineTests.vcxproj
@@ -74,6 +74,7 @@
     <ClInclude Include="pch.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="Ludus\EngineTests\Core\AssetManagerTests.cpp" />
     <ClCompile Include="Ludus\EngineTests\Core\ExpectedTests.cpp" />
     <ClCompile Include="Ludus\EngineTests\Core\RandomTests.cpp" />
     <ClCompile Include="Ludus\EngineTests\Events\EventBusTests.cpp" />

--- a/EngineTests/Ludus/EngineTests/Core/AssetManagerTests.cpp
+++ b/EngineTests/Ludus/EngineTests/Core/AssetManagerTests.cpp
@@ -1,0 +1,228 @@
+#include "pch.h"
+
+#include <filesystem>
+#include <memory>
+#include <optional>
+#include <unordered_map>
+
+#include <Ludus/Engine/Core/AssetManager.h>
+#include <Ludus/Engine/Core/AssetRegistry.h>
+#include <Ludus/Engine/Core/AssetType.h>
+#include <Ludus/Engine/FileSystem/FileSystem.h>
+#include <Ludus/Engine/Graphics/ITextureLoader.h>
+#include <Ludus/Engine/Runtime/RuntimeManifest.h>
+
+namespace Ludus::EngineTests::Core
+{
+	using AssetId = Ludus::Engine::Core::AssetId;
+	using AssetManager = Ludus::Engine::Core::AssetManager;
+	using AssetRegistry = Ludus::Engine::Core::AssetRegistry;
+	using AssetType = Ludus::Engine::Core::AssetType;
+	using DirectoryDeleteScope = Ludus::Engine::FileSystem::DirectoryDeleteScope;
+	using ITextureLoader = Ludus::Engine::Graphics::ITextureLoader;
+	using RuntimeManifest = Ludus::Engine::Runtime::RuntimeManifest;
+	using AssetReference = Ludus::Engine::Runtime::AssetReference;
+	using Texture = Ludus::Engine::Graphics::Texture;
+
+	namespace
+	{
+		class TestTextureLoader final : public ITextureLoader
+		{
+		private:
+			struct TestTextureData
+			{
+				int Width = 1;
+				int Height = 1;
+			};
+
+			std::unordered_map<std::filesystem::path, TestTextureData> m_TexturesByPath;
+			mutable std::unordered_map<std::filesystem::path, int> m_LoadCountsByPath;
+
+		public:
+			TestTextureLoader() = default;
+
+			void SetTexture(std::filesystem::path path, int width, int height)
+			{
+				m_TexturesByPath.insert_or_assign(
+					std::move(path),
+					TestTextureData { .Width = width, .Height = height }
+				);
+			}
+
+			int GetLoadCount(const std::filesystem::path& path) const
+			{
+				const auto iterator = m_LoadCountsByPath.find(path);
+				if (iterator == m_LoadCountsByPath.end())
+				{
+					return 0;
+				}
+
+				return iterator->second;
+			}
+
+			std::optional<Texture> TryLoadTextureFromFile(const std::filesystem::path& path) const override
+			{
+				m_LoadCountsByPath[path]++;
+
+				const auto iterator = m_TexturesByPath.find(path);
+				if (iterator == m_TexturesByPath.end())
+				{
+					return std::nullopt;
+				}
+
+				return Texture::Empty(iterator->second.Width, iterator->second.Height);
+			}
+		};
+
+		struct TestAssetManager
+		{
+			std::unique_ptr<AssetManager> Manager;
+			TestTextureLoader* Loader = nullptr;
+		};
+
+		AssetReference MakeTextureAssetReference(AssetId id, std::filesystem::path path)
+		{
+			return {
+				.Id = id,
+				.Type = AssetType::Texture2D,
+				.Path = std::move(path)
+			};
+		}
+
+		class AssetManagerFixture : public ::testing::Test
+		{
+		protected:
+			std::filesystem::path m_RuntimeRootDirectory;
+			DirectoryDeleteScope m_RuntimeRootDirectoryScope;
+
+			virtual void SetUp() override
+			{
+				m_RuntimeRootDirectory = std::filesystem::temp_directory_path()
+					/ Ludus::Engine::FileSystem::GenerateUniqueName("Ludus-AssetManagerTests-", "");
+				std::filesystem::create_directories(m_RuntimeRootDirectory);
+				m_RuntimeRootDirectoryScope.Path = m_RuntimeRootDirectory;
+			}
+
+			std::filesystem::path CreateRuntimeFile(const std::filesystem::path& relativePath)
+			{
+				const auto fullPath = m_RuntimeRootDirectory / relativePath;
+				std::filesystem::create_directories(fullPath.parent_path());
+				Ludus::Engine::FileSystem::WriteAllText(fullPath, "test");
+				return fullPath;
+			}
+
+			TestAssetManager CreateAssetManager(const AssetRegistry& assetRegistry)
+			{
+				auto loader = std::make_unique<TestTextureLoader>();
+				auto* loaderPtr = loader.get();
+
+				auto manager = std::make_unique<AssetManager>(
+					assetRegistry,
+					m_RuntimeRootDirectory,
+					std::move(loader),
+					Texture::Empty(2, 2)
+				);
+
+				return {
+					.Manager = std::move(manager),
+					.Loader = loaderPtr
+				};
+			}
+		};
+	}
+
+	TEST_F(AssetManagerFixture, GetTexture2D_When_AssetIdIsInvalid_ReturnsNullWithoutFallback)
+	{
+		// Arrange.
+		const auto runtimeManifest = RuntimeManifest::Create();
+		const auto assetRegistry = AssetRegistry(runtimeManifest);
+		auto assetManager = CreateAssetManager(assetRegistry);
+
+		// Act.
+		const auto result = assetManager.Manager->GetTexture2D(AssetId::Invalid());
+
+		// Assert.
+		ASSERT_EQ(result.Texture, nullptr);
+		ASSERT_FALSE(result.IsFallback);
+	}
+
+	TEST_F(AssetManagerFixture, GetTexture2D_When_RegistryEntryIsMissing_ReturnsFallbackAndCachesFailure)
+	{
+		// Arrange.
+		const auto runtimeManifest = RuntimeManifest::Create();
+		const auto assetRegistry = AssetRegistry(runtimeManifest);
+		auto assetManager = CreateAssetManager(assetRegistry);
+		const auto assetId = AssetId { 101 };
+
+		// Act.
+		const auto first = assetManager.Manager->GetTexture2D(assetId);
+		const auto second = assetManager.Manager->GetTexture2D(assetId);
+
+		// Assert.
+		ASSERT_NE(first.Texture, nullptr);
+		ASSERT_TRUE(first.IsFallback);
+		ASSERT_TRUE(assetManager.Manager->HasFailedTextureLoad(assetId));
+		ASSERT_EQ(first.Texture, second.Texture);
+		ASSERT_TRUE(second.IsFallback);
+		ASSERT_EQ(first.Texture->Width(), 2);
+		ASSERT_EQ(first.Texture->Height(), 2);
+		ASSERT_EQ(assetManager.Loader->GetLoadCount(m_RuntimeRootDirectory / "Assets/Missing.png"), 0);
+	}
+
+	TEST_F(AssetManagerFixture, GetTexture2D_When_TextureFileIsMissing_ReturnsFallbackAndCachesFailure)
+	{
+		// Arrange.
+		const auto assetId = AssetId { 202 };
+		const auto runtimeManifest = RuntimeManifest::Create(
+			Ludus::Engine::Core::SceneId::Invalid(),
+			std::vector<Ludus::Engine::Runtime::SceneReference> { },
+			std::vector<Ludus::Engine::Runtime::ScriptReference> { },
+			std::vector<AssetReference> { MakeTextureAssetReference(assetId, "Assets/DoesNotExist.png") }
+		);
+		const auto assetRegistry = AssetRegistry(runtimeManifest);
+		auto assetManager = CreateAssetManager(assetRegistry);
+
+		// Act.
+		const auto first = assetManager.Manager->GetTexture2D(assetId);
+		const auto second = assetManager.Manager->GetTexture2D(assetId);
+
+		// Assert.
+		ASSERT_NE(first.Texture, nullptr);
+		ASSERT_TRUE(first.IsFallback);
+		ASSERT_TRUE(assetManager.Manager->HasFailedTextureLoad(assetId));
+		ASSERT_EQ(first.Texture, second.Texture);
+		ASSERT_TRUE(second.IsFallback);
+		ASSERT_EQ(assetManager.Loader->GetLoadCount(m_RuntimeRootDirectory / "Assets/DoesNotExist.png"), 0);
+	}
+
+	TEST_F(AssetManagerFixture, GetTexture2D_When_TextureLoadsSuccessfully_CachesTexture)
+	{
+		// Arrange.
+		const auto assetId = AssetId { 303 };
+		const auto assetPath = std::filesystem::path("Assets/Texture.png");
+		const auto fullPath = CreateRuntimeFile(assetPath);
+		const auto runtimeManifest = RuntimeManifest::Create(
+			Ludus::Engine::Core::SceneId::Invalid(),
+			std::vector<Ludus::Engine::Runtime::SceneReference> { },
+			std::vector<Ludus::Engine::Runtime::ScriptReference> { },
+			std::vector<AssetReference> { MakeTextureAssetReference(assetId, assetPath) }
+		);
+		const auto assetRegistry = AssetRegistry(runtimeManifest);
+		auto assetManager = CreateAssetManager(assetRegistry);
+		assetManager.Loader->SetTexture(fullPath, 64, 32);
+
+		// Act.
+		const auto first = assetManager.Manager->GetTexture2D(assetId);
+		const auto second = assetManager.Manager->GetTexture2D(assetId);
+
+		// Assert.
+		ASSERT_NE(first.Texture, nullptr);
+		ASSERT_FALSE(first.IsFallback);
+		ASSERT_FALSE(assetManager.Manager->HasFailedTextureLoad(assetId));
+		ASSERT_EQ(first.Texture, second.Texture);
+		ASSERT_FALSE(second.IsFallback);
+		ASSERT_EQ(first.Texture->Width(), 64);
+		ASSERT_EQ(first.Texture->Height(), 32);
+		ASSERT_EQ(assetManager.Loader->GetLoadCount(fullPath), 1);
+	}
+}

--- a/EngineTests/Ludus/EngineTests/Serialization/Schemas/RuntimeManifestSchemaTests.cpp
+++ b/EngineTests/Ludus/EngineTests/Serialization/Schemas/RuntimeManifestSchemaTests.cpp
@@ -24,8 +24,11 @@ namespace Ludus::EngineTests::Serialization::Schemas
 	using RuntimeManifestSchema = Ludus::Engine::Serialization::Schemas::RuntimeManifestSchema;
 	using SceneReference = Ludus::Engine::Runtime::SceneReference;
 	using ScriptReference = Ludus::Engine::Runtime::ScriptReference;
+	using AssetReference = Ludus::Engine::Runtime::AssetReference;
+	using AssetType = Ludus::Engine::Core::AssetType;
 	using SceneId = Ludus::Engine::Core::SceneId;
 	using ScriptId = Ludus::Engine::Core::ScriptId;
+	using AssetId = Ludus::Engine::Core::AssetId;
 	using Token = Ludus::Engine::Serialization::Core::Token;
 
 	using Ludus::Engine::Serialization::Core::AsArray;
@@ -69,6 +72,19 @@ namespace Ludus::EngineTests::Serialization::Schemas
 		};
 	}
 
+	static AssetReference MakeAssetReference(
+		AssetId id,
+		AssetType type,
+		std::string_view path
+	)
+	{
+		return {
+			.Id = id,
+			.Type = type,
+			.Path = std::filesystem::path(path)
+		};
+	}
+
 	static RuntimeManifest MakeRuntimeManifest()
 	{
 		return RuntimeManifest::Create(
@@ -80,6 +96,9 @@ namespace Ludus::EngineTests::Serialization::Schemas
 			{
 				MakeScriptReference({ 10 }, "PlayerScript"),
 				MakeScriptReference({ 20 }, "CameraScript")
+			},
+			{
+				MakeAssetReference({ 100 }, AssetType::Texture2D, "Assets/Sprites/Player.png")
 			}
 		);
 	}
@@ -156,6 +175,7 @@ namespace Ludus::EngineTests::Serialization::Schemas
 		ASSERT_EQ(loadedManifest.EntrySceneId, manifest.EntrySceneId);
 		ASSERT_EQ(loadedManifest.Scenes.size(), manifest.Scenes.size());
 		ASSERT_EQ(loadedManifest.Scripts.size(), manifest.Scripts.size());
+		ASSERT_EQ(loadedManifest.Assets.size(), manifest.Assets.size());
 
 		for (size_t i = 0; i < manifest.Scenes.size(); ++i)
 		{
@@ -168,6 +188,13 @@ namespace Ludus::EngineTests::Serialization::Schemas
 		{
 			ASSERT_EQ(loadedManifest.Scripts[i].Id, manifest.Scripts[i].Id);
 			ASSERT_EQ(loadedManifest.Scripts[i].Name, manifest.Scripts[i].Name);
+		}
+
+		for (size_t i = 0; i < manifest.Assets.size(); ++i)
+		{
+			ASSERT_EQ(loadedManifest.Assets[i].Id, manifest.Assets[i].Id);
+			ASSERT_EQ(loadedManifest.Assets[i].Type, manifest.Assets[i].Type);
+			ASSERT_EQ(loadedManifest.Assets[i].Path, manifest.Assets[i].Path);
 		}
 	}
 
@@ -217,6 +244,128 @@ namespace Ludus::EngineTests::Serialization::Schemas
 		writer.Emit(Token::EndArray { });
 		writer.Emit(Token::Key { "Scripts" });
 		writer.Emit(Token::StartArray { });
+		writer.Emit(Token::EndArray { });
+		writer.Emit(Token::EndObject { });
+		DomTokenStreamReader reader(document);
+
+		// Act.
+		const auto result = RuntimeManifestSchema::Deserialize(reader);
+
+		// Assert.
+		ASSERT_FALSE(result.HasValue());
+	}
+
+	TEST(RuntimeManifestSchema, Deserialize_LoadsEmptyAssets_When_AssetsKeyIsMissing)
+	{
+		// Arrange.
+		DomDocument document;
+		DomTokenStreamWriter writer(document);
+		writer.Emit(Token::StartObject { });
+		WriteVersion(writer, RuntimeManifest::CurrentVersion.Major, RuntimeManifest::CurrentVersion.Minor, RuntimeManifest::CurrentVersion.Patch);
+		writer.Emit(Token::Key { "EntrySceneId" });
+		writer.Emit(Token::Uint { 1 });
+		writer.Emit(Token::Key { "Scenes" });
+		writer.Emit(Token::StartArray { });
+		writer.Emit(Token::StartObject { });
+		writer.Emit(Token::Key { "Id" });
+		writer.Emit(Token::Uint { 1 });
+		writer.Emit(Token::Key { "Name" });
+		writer.Emit(Token::String { "Scene" });
+		writer.Emit(Token::Key { "Path" });
+		writer.Emit(Token::String { "Scenes/Scene.scene.ludus" });
+		writer.Emit(Token::EndObject { });
+		writer.Emit(Token::EndArray { });
+		writer.Emit(Token::Key { "Scripts" });
+		writer.Emit(Token::StartArray { });
+		writer.Emit(Token::EndArray { });
+		writer.Emit(Token::EndObject { });
+		DomTokenStreamReader reader(document);
+
+		// Act.
+		const auto result = RuntimeManifestSchema::Deserialize(reader);
+
+		// Assert.
+		ASSERT_TRUE(result.HasValue());
+		ASSERT_TRUE(result.GetValue().Assets.empty());
+	}
+
+	TEST(RuntimeManifestSchema, Deserialize_Fails_When_AssetTypeIsUnknown)
+	{
+		// Arrange.
+		DomDocument document;
+		DomTokenStreamWriter writer(document);
+		writer.Emit(Token::StartObject { });
+		WriteVersion(writer, RuntimeManifest::CurrentVersion.Major, RuntimeManifest::CurrentVersion.Minor, RuntimeManifest::CurrentVersion.Patch);
+		writer.Emit(Token::Key { "EntrySceneId" });
+		writer.Emit(Token::Uint { 1 });
+		writer.Emit(Token::Key { "Scenes" });
+		writer.Emit(Token::StartArray { });
+		writer.Emit(Token::StartObject { });
+		writer.Emit(Token::Key { "Id" });
+		writer.Emit(Token::Uint { 1 });
+		writer.Emit(Token::Key { "Name" });
+		writer.Emit(Token::String { "Scene" });
+		writer.Emit(Token::Key { "Path" });
+		writer.Emit(Token::String { "Scenes/Scene.scene.ludus" });
+		writer.Emit(Token::EndObject { });
+		writer.Emit(Token::EndArray { });
+		writer.Emit(Token::Key { "Scripts" });
+		writer.Emit(Token::StartArray { });
+		writer.Emit(Token::EndArray { });
+		writer.Emit(Token::Key { "Assets" });
+		writer.Emit(Token::StartArray { });
+		writer.Emit(Token::StartObject { });
+		writer.Emit(Token::Key { "Id" });
+		writer.Emit(Token::Uint { 100 });
+		writer.Emit(Token::Key { "Type" });
+		writer.Emit(Token::String { "Unknown" });
+		writer.Emit(Token::Key { "Path" });
+		writer.Emit(Token::String { "Assets/Sprites/Player.png" });
+		writer.Emit(Token::EndObject { });
+		writer.Emit(Token::EndArray { });
+		writer.Emit(Token::EndObject { });
+		DomTokenStreamReader reader(document);
+
+		// Act.
+		const auto result = RuntimeManifestSchema::Deserialize(reader);
+
+		// Assert.
+		ASSERT_FALSE(result.HasValue());
+	}
+
+	TEST(RuntimeManifestSchema, Deserialize_Fails_When_AssetTypeStringIsInvalid)
+	{
+		// Arrange.
+		DomDocument document;
+		DomTokenStreamWriter writer(document);
+		writer.Emit(Token::StartObject { });
+		WriteVersion(writer, RuntimeManifest::CurrentVersion.Major, RuntimeManifest::CurrentVersion.Minor, RuntimeManifest::CurrentVersion.Patch);
+		writer.Emit(Token::Key { "EntrySceneId" });
+		writer.Emit(Token::Uint { 1 });
+		writer.Emit(Token::Key { "Scenes" });
+		writer.Emit(Token::StartArray { });
+		writer.Emit(Token::StartObject { });
+		writer.Emit(Token::Key { "Id" });
+		writer.Emit(Token::Uint { 1 });
+		writer.Emit(Token::Key { "Name" });
+		writer.Emit(Token::String { "Scene" });
+		writer.Emit(Token::Key { "Path" });
+		writer.Emit(Token::String { "Scenes/Scene.scene.ludus" });
+		writer.Emit(Token::EndObject { });
+		writer.Emit(Token::EndArray { });
+		writer.Emit(Token::Key { "Scripts" });
+		writer.Emit(Token::StartArray { });
+		writer.Emit(Token::EndArray { });
+		writer.Emit(Token::Key { "Assets" });
+		writer.Emit(Token::StartArray { });
+		writer.Emit(Token::StartObject { });
+		writer.Emit(Token::Key { "Id" });
+		writer.Emit(Token::Uint { 100 });
+		writer.Emit(Token::Key { "Type" });
+		writer.Emit(Token::String { "Texture3D" });
+		writer.Emit(Token::Key { "Path" });
+		writer.Emit(Token::String { "Assets/Sprites/Player.png" });
+		writer.Emit(Token::EndObject { });
 		writer.Emit(Token::EndArray { });
 		writer.Emit(Token::EndObject { });
 		DomTokenStreamReader reader(document);


### PR DESCRIPTION
# Summary
Runtime manifests can now declare texture assets by `AssetId`, and the engine can load, cache, and return those textures through `AssetManager`. Failed or missing texture assets return a generated missing-texture fallback.

# Linked
- Closes #354
- Story: #353

