### PR TITLE
Refactor: Added asset refresh classification

### DIFF
--- a/Editor/Editor.vcxproj
+++ b/Editor/Editor.vcxproj
@@ -129,6 +129,7 @@
     <ClInclude Include="Include\Ludus\Editor\Commands\Requests\Scenes.h" />
     <ClInclude Include="Include\Ludus\Editor\Commands\UICommand.h" />
     <ClInclude Include="Include\Ludus\Editor\Commands\UI\Dialogs.h" />
+    <ClInclude Include="Include\Ludus\Editor\Core\AssetRefresh.h" />
     <ClInclude Include="Include\Ludus\Editor\Core\ActivePanelState.h" />
     <ClInclude Include="Include\Ludus\Editor\Core\ActiveThemeState.h" />
     <ClInclude Include="Include\Ludus\Editor\Core\Axis.h" />

--- a/Editor/Include/Ludus/Editor/Commands/RequestCommand.h
+++ b/Editor/Include/Ludus/Editor/Commands/RequestCommand.h
@@ -45,6 +45,7 @@ namespace Ludus::Editor::Commands
 		struct OpenProject { std::filesystem::path Path; };
 		struct SaveProject {};
 		struct CloseProject {};
+		struct RefreshAssets {};
 
 		struct CreateScript { Ludus::Engine::Core::SceneId SceneId; EntityReference EntityReference; std::string Name; };
 
@@ -62,7 +63,7 @@ namespace Ludus::Editor::Commands
 		using Variant = std::variant<
 			AddViewport, SetExecutionMode, SetExecutionFlag, UnsetExecutionFlag, SetPanelVisibility, SetTheme, CloseApplication,
 			CreateScene, CreateSceneAs, OpenScene, SaveScene, SaveSceneAs, RenameScene,
-			CreateProject, CreateProjectAs, OpenProject, SaveProject, CloseProject,
+			CreateProject, CreateProjectAs, OpenProject, SaveProject, CloseProject, RefreshAssets,
 			CreateScript,
 			RunTargetBuildCommand, BuildRuntime, CleanRuntime,
 			ResolveUnsavedChanges

--- a/Editor/Include/Ludus/Editor/Commands/Requests/ProjectActions.h
+++ b/Editor/Include/Ludus/Editor/Commands/Requests/ProjectActions.h
@@ -14,4 +14,5 @@ namespace Ludus::Editor::Commands::Requests::Projects
 	void OpenProjectAction(const std::filesystem::path& path, ProjectTransitionContext context);
 	void CloseProjectAction(ProjectSessionCommandContext& context);
 	void SaveProjectAction(ProjectSessionCommandContext& context);
+	void RefreshAssetsAction(ProjectSessionCommandContext& context);
 }

--- a/Editor/Include/Ludus/Editor/Commands/Requests/Projects.h
+++ b/Editor/Include/Ludus/Editor/Commands/Requests/Projects.h
@@ -19,4 +19,5 @@ namespace Ludus::Editor::Commands::Requests::Projects
 	void OpenProject(const RequestCommand::OpenProject& command, ProjectSessionCommandContext& context);
 	void SaveProject(ProjectSessionCommandContext& context);
 	void CloseProject(ProjectSessionCommandContext& context);
+	void RefreshAssets(ProjectSessionCommandContext& context);
 }

--- a/Editor/Include/Ludus/Editor/Core/AssetRefresh.h
+++ b/Editor/Include/Ludus/Editor/Core/AssetRefresh.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <cstddef>
+#include <filesystem>
+#include <optional>
+#include <vector>
+
+#include <Ludus/Engine/Core/AssetType.h>
+#include <Ludus/Engine/Core/Id.h>
+
+namespace Ludus::Editor::Core
+{
+	class ProjectSessionPersistence;
+
+	enum class AssetRefreshClassification
+	{
+		Registered,
+		Candidate,
+		MissingSource,
+		Unsupported
+	};
+
+	struct AssetRefreshEntry
+	{
+		std::filesystem::path Path;
+		std::filesystem::path ManifestPath;
+		Ludus::Engine::Core::AssetId Id { Ludus::Engine::Core::AssetId::Invalid() };
+		Ludus::Engine::Core::AssetType Type { Ludus::Engine::Core::AssetType::Unknown };
+		AssetRefreshClassification Classification { AssetRefreshClassification::Unsupported };
+	};
+
+	struct AssetRefreshSummary
+	{
+		std::vector<AssetRefreshEntry> Entries;
+		std::size_t RegisteredCount = 0;
+		std::size_t CandidateCount = 0;
+		std::size_t MissingSourceCount = 0;
+		std::size_t UnsupportedCount = 0;
+	};
+
+	std::optional<AssetRefreshEntry> TryClassifyAssetFile(
+		const ProjectSessionPersistence& persistence,
+		const std::filesystem::path& path
+	);
+}

--- a/Editor/Include/Ludus/Editor/Core/ProjectSession.h
+++ b/Editor/Include/Ludus/Editor/Core/ProjectSession.h
@@ -19,6 +19,8 @@
 
 namespace Ludus::Editor::Core
 {
+	struct AssetRefreshSummary;
+
 	struct ProjectSession
 	{
 		ProjectSessionPersistence Persistence;
@@ -53,6 +55,7 @@ namespace Ludus::Editor::Core
 			Ludus::Engine::Core::AssetType type,
 			std::filesystem::path path
 		);
+		AssetRefreshSummary RefreshAssets() const;
 
 		bool AddOrUpdateSceneReference(
 			Ludus::Engine::Core::SceneId id,

--- a/Editor/Include/Ludus/Editor/Core/ProjectSessionPersistence.h
+++ b/Editor/Include/Ludus/Editor/Core/ProjectSessionPersistence.h
@@ -13,6 +13,8 @@
 
 namespace Ludus::Editor::Core
 {
+	struct AssetRefreshSummary;
+
 	class ProjectSessionPersistence
 	{
 	private:
@@ -50,11 +52,13 @@ namespace Ludus::Editor::Core
 
 #pragma region Assets
 
+		const Ludus::Engine::Runtime::AssetReference* TryGetAssetReference(const std::filesystem::path& path) const;
 		bool AddOrUpdateAssetReference(Ludus::Engine::Core::AssetId id, Ludus::Engine::Core::AssetType type, std::filesystem::path path);
 		bool RemoveAssetReference(Ludus::Engine::Core::AssetId id);
 		bool HasAssetReference(Ludus::Engine::Core::AssetId id) const;
 		bool HasAssetReference(const std::filesystem::path& path) const;
 		Ludus::Engine::Core::AssetId AllocateAssetId() const;
+		AssetRefreshSummary RefreshAssets() const;
 
 #pragma endregion
 

--- a/Editor/Source/Ludus/Editor/Commands/RequestCommand.cpp
+++ b/Editor/Source/Ludus/Editor/Commands/RequestCommand.cpp
@@ -33,6 +33,7 @@ namespace Ludus::Editor::Commands
 			void operator()(const RequestCommand::OpenProject& command) const { Requests::Projects::OpenProject(command, Context); }
 			void operator()(const RequestCommand::SaveProject&) const { Requests::Projects::SaveProject(Context); }
 			void operator()(const RequestCommand::CloseProject&) const { Requests::Projects::CloseProject(Context); }
+			void operator()(const RequestCommand::RefreshAssets&) const { Requests::Projects::RefreshAssets(Context); }
 			void operator()(const RequestCommand::CreateScript& command) const { Requests::Scripts::CreateScript(command, Context); }
 			void operator()(const RequestCommand::RunTargetBuildCommand& command) const { Requests::Builds::RunTargetBuildCommand(command, Context); }
 			void operator()(const RequestCommand::BuildRuntime& command) const { Requests::Builds::BuildRuntime(command, Context); }
@@ -60,6 +61,7 @@ namespace Ludus::Editor::Commands
 			void operator()(const RequestCommand::CreateProjectAs& command) const { Requests::Projects::CreateProjectAs(command, Context); }
 			void operator()(const RequestCommand::OpenProject& command) const { Requests::Projects::OpenProject(command, Context); }
 			void operator()(const RequestCommand::SaveProject&) const { LUDUS_ASSERT(false, "SaveProject is unavailable during startup."); }
+			void operator()(const RequestCommand::RefreshAssets&) const { LUDUS_ASSERT(false, "RefreshAssets is unavailable during startup."); }
 			void operator()(const RequestCommand::AddViewport&) const { LUDUS_ASSERT(false, "AddViewport is unavailable during startup."); }
 			void operator()(const RequestCommand::CreateScene&) const { LUDUS_ASSERT(false, "CreateScene is unavailable during startup."); }
 			void operator()(const RequestCommand::CreateSceneAs&) const { LUDUS_ASSERT(false, "CreateSceneAs is unavailable during startup."); }

--- a/Editor/Source/Ludus/Editor/Commands/Requests/ProjectActions.cpp
+++ b/Editor/Source/Ludus/Editor/Commands/Requests/ProjectActions.cpp
@@ -1,16 +1,19 @@
 #include "pch.h"
 
 #include <filesystem>
+#include <format>
 #include <string>
 #include <string_view>
 
 #include <Ludus/Editor/Commands/ProjectSessionCommandContext.h>
 #include <Ludus/Editor/Commands/Requests/ProjectTransitionContext.h>
+#include <Ludus/Editor/Core/AssetRefresh.h>
 #include <Ludus/Editor/Core/ProjectTemplates.h>
 #include <Ludus/Editor/Core/RecentlyOpenedProject.h>
 #include <Ludus/Editor/Core/SceneQueries.h>
 #include <Ludus/Editor/Panels/PanelHelpers.h>
 #include <Ludus/Editor/Persistence/ProjectPaths.h>
+#include <Ludus/Engine/Debug/Debug.h>
 #include <Ludus/Engine/FileSystem/FileSystem.h>
 #include <Ludus/Engine/Persistence/Paths.h>
 
@@ -80,6 +83,25 @@ namespace Ludus::Editor::Commands::Requests::Projects
 		)
 		{
 			Ludus::Editor::Panels::RefreshContentPanel(projectRoot, context.PanelRegistry);
+		}
+
+		void RefreshContentPanel(ProjectSessionCommandContext& context)
+		{
+			Ludus::Editor::Panels::RefreshContentPanel(
+				context.ProjectSession.Persistence.GetProjectRoot(),
+				context.PanelRegistry
+			);
+		}
+
+		void LogAssetRefreshSummary(const Ludus::Editor::Core::AssetRefreshSummary& summary)
+		{
+			LUDUS_LOG_INFO(std::format(
+				"Asset refresh: {} registered, {} candidates, {} missing source, {} unsupported.",
+				summary.RegisteredCount,
+				summary.CandidateCount,
+				summary.MissingSourceCount,
+				summary.UnsupportedCount
+			));
 		}
 
 		void RefreshRecentlyOpenedProjects(
@@ -213,5 +235,11 @@ namespace Ludus::Editor::Commands::Requests::Projects
 
 			editorState.SetRuntimeLaunchSettingsDirty(false);
 		}
+	}
+
+	void RefreshAssetsAction(ProjectSessionCommandContext& context)
+	{
+		LogAssetRefreshSummary(context.ProjectSession.RefreshAssets());
+		RefreshContentPanel(context);
 	}
 }

--- a/Editor/Source/Ludus/Editor/Commands/Requests/Projects.cpp
+++ b/Editor/Source/Ludus/Editor/Commands/Requests/Projects.cpp
@@ -86,4 +86,9 @@ namespace Ludus::Editor::Commands::Requests::Projects
 
 		ExecuteDeferredAction(action, context);
 	}
+
+	void RefreshAssets(ProjectSessionCommandContext& context)
+	{
+		RefreshAssetsAction(context);
+	}
 }

--- a/Editor/Source/Ludus/Editor/Core/ProjectSession.cpp
+++ b/Editor/Source/Ludus/Editor/Core/ProjectSession.cpp
@@ -5,6 +5,7 @@
 #include <stdexcept>
 #include <utility>
 
+#include <Ludus/Editor/Core/AssetRefresh.h>
 #include <Ludus/Editor/Core/ProjectSession.h>
 #include <Ludus/Editor/Core/ProjectSessionEditorState.h>
 #include <Ludus/Editor/Core/ProjectSessionPersistence.h>
@@ -131,6 +132,11 @@ namespace Ludus::Editor::Core
 		}
 
 		return changed;
+	}
+
+	AssetRefreshSummary ProjectSession::RefreshAssets() const
+	{
+		return Persistence.RefreshAssets();
 	}
 
 	bool ProjectSession::AddOrUpdateSceneReference(

--- a/Editor/Source/Ludus/Editor/Core/ProjectSessionPersistence.cpp
+++ b/Editor/Source/Ludus/Editor/Core/ProjectSessionPersistence.cpp
@@ -3,9 +3,11 @@
 #include <filesystem>
 #include <optional>
 #include <string>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
+#include <Ludus/Editor/Core/AssetRefresh.h>
 #include <Ludus/Editor/Core/ProjectManifest.h>
 #include <Ludus/Editor/Core/ProjectSessionPersistence.h>
 #include <Ludus/Editor/Persistence/ProjectPaths.h>
@@ -19,6 +21,87 @@
 namespace Ludus::Editor::Core
 {
 	namespace FileSystem = Ludus::Engine::FileSystem;
+
+	namespace
+	{
+		void AddRefreshEntry(AssetRefreshSummary& summary, AssetRefreshEntry entry)
+		{
+			switch (entry.Classification)
+			{
+				case AssetRefreshClassification::Registered:
+					++summary.RegisteredCount;
+					break;
+				case AssetRefreshClassification::Candidate:
+					++summary.CandidateCount;
+					break;
+				case AssetRefreshClassification::MissingSource:
+					++summary.MissingSourceCount;
+					break;
+				case AssetRefreshClassification::Unsupported:
+					++summary.UnsupportedCount;
+					break;
+				default:
+					throw std::runtime_error("Unsupported asset refresh classification.");
+			}
+
+			summary.Entries.push_back(std::move(entry));
+		}
+		std::optional<Ludus::Engine::Core::AssetType> TryGetSupportedAssetType(const std::filesystem::path& path)
+		{
+			using Ludus::Engine::Core::AssetType;
+
+			if (FileSystem::HasLogicalExtension(path, ".png")
+				|| FileSystem::HasLogicalExtension(path, ".jpg")
+				|| FileSystem::HasLogicalExtension(path, ".jpeg")
+				|| FileSystem::HasLogicalExtension(path, ".bmp"))
+			{
+				return AssetType::Texture2D;
+			}
+
+			return std::nullopt;
+		}
+
+	}
+
+	std::optional<AssetRefreshEntry> TryClassifyAssetFile(
+		const ProjectSessionPersistence& persistence,
+		const std::filesystem::path& path
+	)
+	{
+		const auto manifestPath = Ludus::Engine::Persistence::Paths::NormalizeRuntimeAssetPathOrEmpty(
+			persistence.GetProjectRoot(),
+			path
+		);
+		if (manifestPath.empty())
+		{
+			return std::nullopt;
+		}
+
+		if (const auto* assetReference = persistence.TryGetAssetReference(path))
+		{
+			return AssetRefreshEntry {
+				.Path = path,
+				.ManifestPath = manifestPath,
+				.Id = assetReference->Id,
+				.Type = assetReference->Type,
+				.Classification = AssetRefreshClassification::Registered
+			};
+		}
+
+		if (FileSystem::HasLogicalExtension(path, ".ludus"))
+		{
+			return std::nullopt;
+		}
+
+		const auto supportedType = TryGetSupportedAssetType(path);
+
+		return AssetRefreshEntry {
+			.Path = path,
+			.ManifestPath = manifestPath,
+			.Type = supportedType.value_or(Ludus::Engine::Core::AssetType::Unknown),
+			.Classification = supportedType ? AssetRefreshClassification::Candidate : AssetRefreshClassification::Unsupported
+		};
+	}
 
 	ProjectSessionPersistence::ProjectSessionPersistence(
 		Ludus::Editor::Core::ProjectManifest projectManifest,
@@ -156,7 +239,7 @@ namespace Ludus::Editor::Core
 		return false;
 	}
 
-	bool ProjectSessionPersistence::HasAssetReference(const std::filesystem::path& path) const
+	const Ludus::Engine::Runtime::AssetReference* ProjectSessionPersistence::TryGetAssetReference(const std::filesystem::path& path) const
 	{
 		const auto normalizedPath = Ludus::Engine::Persistence::Paths::NormalizeRuntimeAssetPathOrEmpty(
 			GetProjectRoot(),
@@ -164,18 +247,23 @@ namespace Ludus::Editor::Core
 		);
 		if (normalizedPath.empty())
 		{
-			return false;
+			return nullptr;
 		}
 
 		for (const auto& assetReference : m_RuntimeManifest.Assets)
 		{
 			if (FileSystem::NormalizePortablePath(assetReference.Path) == normalizedPath)
 			{
-				return true;
+				return &assetReference;
 			}
 		}
 
-		return false;
+		return nullptr;
+	}
+
+	bool ProjectSessionPersistence::HasAssetReference(const std::filesystem::path& path) const
+	{
+		return TryGetAssetReference(path) != nullptr;
 	}
 
 	Ludus::Engine::Core::AssetId ProjectSessionPersistence::AllocateAssetId() const
@@ -189,6 +277,61 @@ namespace Ludus::Editor::Core
 		}
 
 		return id;
+	}
+
+	AssetRefreshSummary ProjectSessionPersistence::RefreshAssets() const
+	{
+		AssetRefreshSummary summary;
+		const auto& projectRoot = GetProjectRoot();
+		const auto assetsDirectory = Ludus::Engine::Persistence::Paths::AssetsDirectory(projectRoot);
+		const auto options = std::filesystem::directory_options::skip_permission_denied;
+		std::unordered_set<std::string> existingManifestPaths;
+
+		if (std::filesystem::exists(assetsDirectory) && std::filesystem::is_directory(assetsDirectory))
+		{
+			for (const auto& entry : std::filesystem::recursive_directory_iterator(assetsDirectory, options))
+			{
+				if (!entry.is_regular_file())
+				{
+					continue;
+				}
+
+				auto classification = TryClassifyAssetFile(*this, entry.path());
+				if (!classification)
+				{
+					continue;
+				}
+
+				if (classification->Classification == AssetRefreshClassification::Registered)
+				{
+					existingManifestPaths.insert(FileSystem::NormalizePortablePath(classification->ManifestPath).generic_string());
+				}
+
+				AddRefreshEntry(summary, std::move(*classification));
+			}
+		}
+
+		for (const auto& assetReference : m_RuntimeManifest.Assets)
+		{
+			const auto manifestPath = FileSystem::NormalizePortablePath(assetReference.Path);
+			if (existingManifestPaths.contains(manifestPath.generic_string()))
+			{
+				continue;
+			}
+
+			AddRefreshEntry(
+				summary,
+				{
+					.Path = FileSystem::ResolvePathFromRoot(projectRoot, manifestPath),
+					.ManifestPath = manifestPath,
+					.Id = assetReference.Id,
+					.Type = assetReference.Type,
+					.Classification = AssetRefreshClassification::MissingSource
+				}
+			);
+		}
+
+		return summary;
 	}
 
 #pragma endregion

--- a/Editor/Source/Ludus/Editor/Panels/ContentPanel.cpp
+++ b/Editor/Source/Ludus/Editor/Panels/ContentPanel.cpp
@@ -4,9 +4,11 @@
 #include <system_error>
 
 #include <Ludus/Editor/Commands/RequestCommand.h>
+#include <Ludus/Editor/Core/AssetRefresh.h>
 #include <Ludus/Editor/Core/Constants.h>
 #include <Ludus/Editor/Panels/ContentPanel.h>
 #include <Ludus/Engine/FileSystem/FileSystem.h>
+#include <Ludus/Engine/Graphics/Color.h>
 #include <Ludus/Engine/Persistence/Paths.h>
 #include <Ludus/UI/Context/ScrollContext.h>
 #include <Ludus/UI/Icons/FontAwesome.h>
@@ -16,6 +18,42 @@
 
 namespace Ludus::Editor::Panels
 {
+	namespace
+	{
+		namespace EditorCore = Ludus::Editor::Core;
+
+		Ludus::UI::Elements::ContentBrowser::EntryPresentation CreateAssetEntryPresentation(
+			const EditorCore::ProjectSessionPersistence& persistence,
+			const Ludus::UI::Elements::ContentBrowser::EntryContext& entry
+		)
+		{
+			Ludus::UI::Elements::ContentBrowser::EntryPresentation presentation;
+			if (entry.IsDirectory)
+			{
+				return presentation;
+			}
+
+			const auto classification = EditorCore::TryClassifyAssetFile(persistence, entry.Path);
+			if (!classification)
+			{
+				return presentation;
+			}
+
+			if (classification->Classification == EditorCore::AssetRefreshClassification::Candidate)
+			{
+				presentation.TextColor = Ludus::Engine::Graphics::Colors::Orange;
+				presentation.Tooltip = "Not included in project";
+			}
+			else if (classification->Classification == EditorCore::AssetRefreshClassification::Unsupported)
+			{
+				presentation.TextColor = Ludus::Engine::Graphics::Colors::Gray;
+				presentation.Tooltip = "Unsupported asset file";
+			}
+
+			return presentation;
+		}
+	}
+
 	bool ContentPanel::UpdateImpl(Ludus::Editor::Core::ProjectSessionContext& context)
 	{
 		const auto flags = Ludus::Editor::Core::Constants::Flags::Panel | Ludus::UI::Flags::Window::HorizontalScrollbar;
@@ -27,9 +65,7 @@ namespace Ludus::Editor::Panels
 
 			m_ContentBrowser.Update([&](const Ludus::UI::Elements::ContentBrowser::EntryContext& entry)
 			{
-				// Callback to customize how each content browser entry is presented.
-				Ludus::UI::Elements::ContentBrowser::EntryPresentation presentation;
-				return presentation;
+				return CreateAssetEntryPresentation(context.ProjectSession.Persistence, entry);
 
 			}, [&](const Ludus::UI::Elements::ContentBrowser::EntryContext& entry)
 			{

--- a/Editor/Source/Ludus/Editor/Panels/DockPanel.cpp
+++ b/Editor/Source/Ludus/Editor/Panels/DockPanel.cpp
@@ -199,6 +199,15 @@ namespace Ludus::Editor::Panels
 			// Assets.
 			if (Ludus::UI::Scope::MenuScope assetsMenu("Assets"); assetsMenu)
 			{
+				if (Ludus::UI::Widgets::MenuItem("Refresh Assets"))
+				{
+					context.Shell.State.Commands.AddRequestCommand(
+						Ludus::Editor::Commands::RequestCommand::RefreshAssets { }
+					);
+				}
+
+				Ludus::UI::Context::LayoutContext::Separator();
+
 				if (Ludus::UI::Widgets::MenuItem("Show in Explorer"))
 				{
 					Ludus::Engine::Platform::Paths::OpenFolder(

--- a/EditorTests/EditorTests.vcxproj
+++ b/EditorTests/EditorTests.vcxproj
@@ -73,6 +73,7 @@
     <ClInclude Include="pch.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="Ludus\EditorTests\Core\ProjectSessionPersistenceTests.cpp" />
     <ClCompile Include="Ludus\EditorTests\Persistence\BuildPathsTests.cpp" />
     <ClCompile Include="Ludus\EditorTests\Persistence\LmlProjectManifestPersistenceTests.cpp" />
     <ClCompile Include="Ludus\EditorTests\Persistence\ProjectPathsTests.cpp" />

--- a/EditorTests/Ludus/EditorTests/Core/ProjectSessionPersistenceTests.cpp
+++ b/EditorTests/Ludus/EditorTests/Core/ProjectSessionPersistenceTests.cpp
@@ -1,0 +1,178 @@
+#include "pch.h"
+
+#include <filesystem>
+#include <utility>
+#include <vector>
+
+#include <Ludus/Editor/Core/AssetRefresh.h>
+#include <Ludus/Editor/Core/ProjectManifest.h>
+#include <Ludus/Editor/Core/ProjectSessionPersistence.h>
+#include <Ludus/Editor/Persistence/ProjectPaths.h>
+#include <Ludus/Engine/Core/AssetType.h>
+#include <Ludus/Engine/Core/Id.h>
+#include <Ludus/Engine/FileSystem/FileSystem.h>
+#include <Ludus/Engine/Persistence/Paths.h>
+#include <Ludus/Engine/Runtime/RuntimeLaunchSettings.h>
+#include <Ludus/Engine/Runtime/RuntimeManifest.h>
+
+namespace Ludus::EditorTests::Core
+{
+	namespace EditorCore = Ludus::Editor::Core;
+	namespace FileSystem = Ludus::Engine::FileSystem;
+	namespace Runtime = Ludus::Engine::Runtime;
+
+	static std::filesystem::path MakeUniqueTempDir()
+	{
+		return std::filesystem::temp_directory_path() / FileSystem::GenerateUniqueName("Ludus_Editor_ProjectSessionPersistence_Tests_", "");
+	}
+
+	static FileSystem::DirectoryDeleteScope CreateTestDirectory()
+	{
+		const auto path = MakeUniqueTempDir();
+		std::filesystem::create_directories(path);
+		return FileSystem::DirectoryDeleteScope { path };
+	}
+
+	static EditorCore::ProjectSessionPersistence CreatePersistence(
+		const std::filesystem::path& projectRoot,
+		std::vector<Runtime::AssetReference> assets
+	)
+	{
+		return EditorCore::ProjectSessionPersistence::Create(
+			EditorCore::ProjectManifest::Create(projectRoot, projectRoot / "Sandbox.runtime.ludus"),
+			Runtime::RuntimeManifest::Create(
+				Ludus::Engine::Core::SceneId::Invalid(),
+				{ },
+				{ },
+				std::move(assets)
+			),
+			Runtime::RuntimeLaunchSettings()
+		);
+	}
+
+	static const EditorCore::AssetRefreshEntry* FindEntry(
+		const EditorCore::AssetRefreshSummary& summary,
+		EditorCore::AssetRefreshClassification classification,
+		const std::filesystem::path& manifestPath
+	)
+	{
+		for (const auto& entry : summary.Entries)
+		{
+			if (
+				entry.Classification == classification
+				&& FileSystem::NormalizePortablePath(entry.ManifestPath) == FileSystem::NormalizePortablePath(manifestPath)
+				)
+			{
+				return &entry;
+			}
+		}
+
+		return nullptr;
+	}
+
+	TEST(ProjectSessionPersistence, RefreshAssets_ClassifiesRegisteredCandidateMissingSourceAndUnsupportedFiles)
+	{
+		// Arrange.
+		const auto tempDirectoryScope = CreateTestDirectory();
+		const auto projectRoot = tempDirectoryScope.Path / "Sandbox";
+		const auto assetsDirectory = Ludus::Engine::Persistence::Paths::AssetsDirectory(projectRoot);
+		std::filesystem::create_directories(assetsDirectory);
+		FileSystem::WriteAllText(assetsDirectory / "Registered.png", "");
+		FileSystem::WriteAllText(assetsDirectory / "Candidate.png", "");
+		FileSystem::WriteAllText(assetsDirectory / "Unsupported.txt", "");
+		FileSystem::WriteAllText(assetsDirectory / "Sandbox.project.ludus", "");
+		FileSystem::WriteAllText(assetsDirectory / "Sandbox.runtime.ludus", "");
+		FileSystem::WriteAllText(assetsDirectory / "Sandbox.settings.ludus", "");
+		FileSystem::WriteAllText(assetsDirectory / "Main.scene.ludus", "");
+		FileSystem::WriteAllText(projectRoot / "Outside.png", "");
+		FileSystem::WriteAllText(projectRoot / "Sandbox.runtime.ludus", "");
+		std::filesystem::create_directories(projectRoot / "Scenes");
+		FileSystem::WriteAllText(projectRoot / "Scenes" / "Main.scene.ludus", "");
+
+		const auto persistence = CreatePersistence(projectRoot, {
+			{
+				Ludus::Engine::Core::AssetId { 1 },
+				Ludus::Engine::Core::AssetType::Texture2D,
+				std::filesystem::path("Assets") / "Registered.png"
+			},
+			{
+				Ludus::Engine::Core::AssetId { 2 },
+				Ludus::Engine::Core::AssetType::Texture2D,
+				std::filesystem::path("Assets") / "Missing.png"
+			}
+			});
+
+		// Act.
+		const auto summary = persistence.RefreshAssets();
+
+		// Assert.
+		ASSERT_EQ(summary.RegisteredCount, 1);
+		ASSERT_EQ(summary.CandidateCount, 1);
+		ASSERT_EQ(summary.MissingSourceCount, 1);
+		ASSERT_EQ(summary.UnsupportedCount, 1);
+		ASSERT_NE(FindEntry(summary, EditorCore::AssetRefreshClassification::Registered, std::filesystem::path("Assets") / "Registered.png"), nullptr);
+		ASSERT_NE(FindEntry(summary, EditorCore::AssetRefreshClassification::Candidate, std::filesystem::path("Assets") / "Candidate.png"), nullptr);
+		ASSERT_NE(FindEntry(summary, EditorCore::AssetRefreshClassification::MissingSource, std::filesystem::path("Assets") / "Missing.png"), nullptr);
+		ASSERT_NE(FindEntry(summary, EditorCore::AssetRefreshClassification::Unsupported, std::filesystem::path("Assets") / "Unsupported.txt"), nullptr);
+		ASSERT_EQ(summary.Entries.size(), 4);
+		ASSERT_EQ(persistence.GetAssets().size(), 2);
+	}
+
+	TEST(ProjectSessionPersistence, RefreshAssets_TreatsExternalRenameAsMissingSourceAndCandidate)
+	{
+		// Arrange.
+		const auto tempDirectoryScope = CreateTestDirectory();
+		const auto projectRoot = tempDirectoryScope.Path / "Sandbox";
+		const auto assetsDirectory = Ludus::Engine::Persistence::Paths::AssetsDirectory(projectRoot);
+		std::filesystem::create_directories(assetsDirectory);
+		FileSystem::WriteAllText(assetsDirectory / "Renamed.png", "");
+
+		const auto persistence = CreatePersistence(projectRoot, {
+			{
+				Ludus::Engine::Core::AssetId { 1 },
+				Ludus::Engine::Core::AssetType::Texture2D,
+				std::filesystem::path("Assets") / "Original.png"
+			}
+			});
+
+		// Act.
+		const auto summary = persistence.RefreshAssets();
+
+		// Assert.
+		ASSERT_EQ(summary.CandidateCount, 1);
+		ASSERT_EQ(summary.MissingSourceCount, 1);
+		ASSERT_NE(FindEntry(summary, EditorCore::AssetRefreshClassification::Candidate, std::filesystem::path("Assets") / "Renamed.png"), nullptr);
+		ASSERT_NE(FindEntry(summary, EditorCore::AssetRefreshClassification::MissingSource, std::filesystem::path("Assets") / "Original.png"), nullptr);
+		ASSERT_EQ(persistence.GetAssets().size(), 1);
+	}
+
+	TEST(ProjectSessionPersistence, RefreshAssets_IsSafeToRunRepeatedlyWithoutChangingManifestState)
+	{
+		// Arrange.
+		const auto tempDirectoryScope = CreateTestDirectory();
+		const auto projectRoot = tempDirectoryScope.Path / "Sandbox";
+		const auto assetsDirectory = Ludus::Engine::Persistence::Paths::AssetsDirectory(projectRoot);
+		std::filesystem::create_directories(assetsDirectory);
+		FileSystem::WriteAllText(assetsDirectory / "Candidate.png", "");
+
+		const auto persistence = CreatePersistence(projectRoot, {
+			{
+				Ludus::Engine::Core::AssetId { 1 },
+				Ludus::Engine::Core::AssetType::Texture2D,
+				std::filesystem::path("Assets") / "Missing.png"
+			}
+			});
+
+		// Act.
+		const auto firstSummary = persistence.RefreshAssets();
+		const auto secondSummary = persistence.RefreshAssets();
+
+		// Assert.
+		ASSERT_EQ(firstSummary.CandidateCount, 1);
+		ASSERT_EQ(firstSummary.MissingSourceCount, 1);
+		ASSERT_EQ(secondSummary.CandidateCount, 1);
+		ASSERT_EQ(secondSummary.MissingSourceCount, 1);
+		ASSERT_EQ(persistence.GetAssets().size(), 1);
+		ASSERT_EQ(persistence.GetAssets().front().Path, std::filesystem::path("Assets") / "Missing.png");
+	}
+}


### PR DESCRIPTION
# Summary
The project asset folder can now be refreshed from the menu bar. All assets will be classified and displayed in the content browser panel according to their classification.

Updates:
  - classify project assets as Registered, Candidate, MissingSource, or Unsupported
  - keep asset refresh read-only without modifying RuntimeManifest
  - surface candidate and unsupported files in the content browser
  - log refresh classification totals
  - add coverage for deletion, rename, and repeated refresh behavior

# Linked
- Closes #360 
- Story: #338   
