### PR TITLE
Feature: Added Include in Project for candidate textures

### DIFF
--- a/Editor/Include/Ludus/Editor/Commands/RequestCommand.h
+++ b/Editor/Include/Ludus/Editor/Commands/RequestCommand.h
@@ -46,6 +46,7 @@ namespace Ludus::Editor::Commands
 		struct SaveProject {};
 		struct CloseProject {};
 		struct RefreshAssets {};
+		struct IncludeAsset { std::filesystem::path Path; };
 
 		struct CreateScript { Ludus::Engine::Core::SceneId SceneId; EntityReference EntityReference; std::string Name; };
 
@@ -63,7 +64,7 @@ namespace Ludus::Editor::Commands
 		using Variant = std::variant<
 			AddViewport, SetExecutionMode, SetExecutionFlag, UnsetExecutionFlag, SetPanelVisibility, SetTheme, CloseApplication,
 			CreateScene, CreateSceneAs, OpenScene, SaveScene, SaveSceneAs, RenameScene,
-			CreateProject, CreateProjectAs, OpenProject, SaveProject, CloseProject, RefreshAssets,
+			CreateProject, CreateProjectAs, OpenProject, SaveProject, CloseProject, RefreshAssets, IncludeAsset,
 			CreateScript,
 			RunTargetBuildCommand, BuildRuntime, CleanRuntime,
 			ResolveUnsavedChanges

--- a/Editor/Include/Ludus/Editor/Commands/Requests/ProjectActions.h
+++ b/Editor/Include/Ludus/Editor/Commands/Requests/ProjectActions.h
@@ -15,4 +15,5 @@ namespace Ludus::Editor::Commands::Requests::Projects
 	void CloseProjectAction(ProjectSessionCommandContext& context);
 	void SaveProjectAction(ProjectSessionCommandContext& context);
 	void RefreshAssetsAction(ProjectSessionCommandContext& context);
+	void IncludeAssetAction(const std::filesystem::path& path, ProjectSessionCommandContext& context);
 }

--- a/Editor/Include/Ludus/Editor/Commands/Requests/Projects.h
+++ b/Editor/Include/Ludus/Editor/Commands/Requests/Projects.h
@@ -20,4 +20,5 @@ namespace Ludus::Editor::Commands::Requests::Projects
 	void SaveProject(ProjectSessionCommandContext& context);
 	void CloseProject(ProjectSessionCommandContext& context);
 	void RefreshAssets(ProjectSessionCommandContext& context);
+	void IncludeAsset(const RequestCommand::IncludeAsset& command, ProjectSessionCommandContext& context);
 }

--- a/Editor/Include/Ludus/Editor/Core/ProjectSession.h
+++ b/Editor/Include/Ludus/Editor/Core/ProjectSession.h
@@ -55,6 +55,7 @@ namespace Ludus::Editor::Core
 			Ludus::Engine::Core::AssetType type,
 			std::filesystem::path path
 		);
+		bool IncludeAsset(Ludus::Engine::Core::AssetType type, std::filesystem::path path);
 		AssetRefreshSummary RefreshAssets() const;
 
 		bool AddOrUpdateSceneReference(

--- a/Editor/Include/Ludus/Editor/Core/ProjectSessionPersistence.h
+++ b/Editor/Include/Ludus/Editor/Core/ProjectSessionPersistence.h
@@ -54,6 +54,7 @@ namespace Ludus::Editor::Core
 
 		const Ludus::Engine::Runtime::AssetReference* TryGetAssetReference(const std::filesystem::path& path) const;
 		bool AddOrUpdateAssetReference(Ludus::Engine::Core::AssetId id, Ludus::Engine::Core::AssetType type, std::filesystem::path path);
+		bool IncludeAsset(Ludus::Engine::Core::AssetType type, std::filesystem::path path);
 		bool RemoveAssetReference(Ludus::Engine::Core::AssetId id);
 		bool HasAssetReference(Ludus::Engine::Core::AssetId id) const;
 		bool HasAssetReference(const std::filesystem::path& path) const;

--- a/Editor/Include/Ludus/Editor/Core/ProjectSessionRuntimeState.h
+++ b/Editor/Include/Ludus/Editor/Core/ProjectSessionRuntimeState.h
@@ -2,6 +2,7 @@
 
 #include <memory>
 
+#include <Ludus/Engine/Core/AssetRegistry.h>
 #include <Ludus/Engine/Core/Id.h>
 #include <Ludus/Engine/Core/RenderViewRequestRegistry.h>
 #include <Ludus/Engine/Core/Scene.h>
@@ -47,6 +48,8 @@ namespace Ludus::Editor::Core
 		bool IsSimulationActive() const { return m_SimulationRuntime != nullptr; }
 
 		Ludus::Engine::Core::Scene& GetEditorScene(Ludus::Engine::Core::SceneId id) const;
+		Ludus::Engine::Core::AssetRegistry& GetEditorAssetRegistry() { return m_EditorRuntime->GetAssetRegistry(); }
+		const Ludus::Engine::Core::AssetRegistry& GetEditorAssetRegistry() const { return m_EditorRuntime->GetAssetRegistry(); }
 
 		Ludus::Engine::Core::SceneRegistry& GetEditorSceneRegistry() { return m_EditorRuntime->GetSceneRegistry(); }
 		const Ludus::Engine::Core::SceneRegistry& GetEditorSceneRegistry() const { return m_EditorRuntime->GetSceneRegistry(); }

--- a/Editor/Source/Ludus/Editor/Commands/RequestCommand.cpp
+++ b/Editor/Source/Ludus/Editor/Commands/RequestCommand.cpp
@@ -34,6 +34,7 @@ namespace Ludus::Editor::Commands
 			void operator()(const RequestCommand::SaveProject&) const { Requests::Projects::SaveProject(Context); }
 			void operator()(const RequestCommand::CloseProject&) const { Requests::Projects::CloseProject(Context); }
 			void operator()(const RequestCommand::RefreshAssets&) const { Requests::Projects::RefreshAssets(Context); }
+			void operator()(const RequestCommand::IncludeAsset& command) const { Requests::Projects::IncludeAsset(command, Context); }
 			void operator()(const RequestCommand::CreateScript& command) const { Requests::Scripts::CreateScript(command, Context); }
 			void operator()(const RequestCommand::RunTargetBuildCommand& command) const { Requests::Builds::RunTargetBuildCommand(command, Context); }
 			void operator()(const RequestCommand::BuildRuntime& command) const { Requests::Builds::BuildRuntime(command, Context); }
@@ -62,6 +63,7 @@ namespace Ludus::Editor::Commands
 			void operator()(const RequestCommand::OpenProject& command) const { Requests::Projects::OpenProject(command, Context); }
 			void operator()(const RequestCommand::SaveProject&) const { LUDUS_ASSERT(false, "SaveProject is unavailable during startup."); }
 			void operator()(const RequestCommand::RefreshAssets&) const { LUDUS_ASSERT(false, "RefreshAssets is unavailable during startup."); }
+			void operator()(const RequestCommand::IncludeAsset&) const { LUDUS_ASSERT(false, "IncludeAsset is unavailable during startup."); }
 			void operator()(const RequestCommand::AddViewport&) const { LUDUS_ASSERT(false, "AddViewport is unavailable during startup."); }
 			void operator()(const RequestCommand::CreateScene&) const { LUDUS_ASSERT(false, "CreateScene is unavailable during startup."); }
 			void operator()(const RequestCommand::CreateSceneAs&) const { LUDUS_ASSERT(false, "CreateSceneAs is unavailable during startup."); }

--- a/Editor/Source/Ludus/Editor/Commands/Requests/ProjectActions.cpp
+++ b/Editor/Source/Ludus/Editor/Commands/Requests/ProjectActions.cpp
@@ -242,4 +242,28 @@ namespace Ludus::Editor::Commands::Requests::Projects
 		LogAssetRefreshSummary(context.ProjectSession.RefreshAssets());
 		RefreshContentPanel(context);
 	}
+
+	void IncludeAssetAction(const std::filesystem::path& path, ProjectSessionCommandContext& context)
+	{
+		const auto classification = Ludus::Editor::Core::TryClassifyAssetFile(
+			context.ProjectSession.Persistence,
+			path
+		);
+		if (!classification || classification->Classification != Ludus::Editor::Core::AssetRefreshClassification::Candidate)
+		{
+			throw std::runtime_error("Asset is no longer a candidate for inclusion: " + path.string());
+		}
+
+		if (classification->Type != Ludus::Engine::Core::AssetType::Texture2D)
+		{
+			throw std::runtime_error("Only candidate texture assets can be included: " + path.string());
+		}
+
+		if (!context.ProjectSession.IncludeAsset(classification->Type, path))
+		{
+			throw std::runtime_error("Asset could not be included in the project: " + path.string());
+		}
+
+		RefreshContentPanel(context);
+	}
 }

--- a/Editor/Source/Ludus/Editor/Commands/Requests/Projects.cpp
+++ b/Editor/Source/Ludus/Editor/Commands/Requests/Projects.cpp
@@ -91,4 +91,9 @@ namespace Ludus::Editor::Commands::Requests::Projects
 	{
 		RefreshAssetsAction(context);
 	}
+
+	void IncludeAsset(const RequestCommand::IncludeAsset& command, ProjectSessionCommandContext& context)
+	{
+		IncludeAssetAction(command.Path, context);
+	}
 }

--- a/Editor/Source/Ludus/Editor/Core/ProjectSession.cpp
+++ b/Editor/Source/Ludus/Editor/Core/ProjectSession.cpp
@@ -134,6 +134,33 @@ namespace Ludus::Editor::Core
 		return changed;
 	}
 
+	bool ProjectSession::IncludeAsset(Ludus::Engine::Core::AssetType type, std::filesystem::path path)
+	{
+		if (!Persistence.IncludeAsset(type, path))
+		{
+			return false;
+		}
+
+		const auto* assetReference = Persistence.TryGetAssetReference(path);
+		if (assetReference == nullptr)
+		{
+			throw std::runtime_error("Included asset reference could not be resolved.");
+		}
+
+		try
+		{
+			RuntimeState.GetEditorAssetRegistry().RegisterAsset(*assetReference);
+		}
+		catch (...)
+		{
+			Persistence.RemoveAssetReference(assetReference->Id);
+			throw;
+		}
+
+		EditorState.SetRuntimeManifestDirty(true);
+		return true;
+	}
+
 	AssetRefreshSummary ProjectSession::RefreshAssets() const
 	{
 		return Persistence.RefreshAssets();

--- a/Editor/Source/Ludus/Editor/Core/ProjectSessionPersistence.cpp
+++ b/Editor/Source/Ludus/Editor/Core/ProjectSessionPersistence.cpp
@@ -211,6 +211,19 @@ namespace Ludus::Editor::Core
 		return true;
 	}
 
+	bool ProjectSessionPersistence::IncludeAsset(
+		Ludus::Engine::Core::AssetType type,
+		std::filesystem::path path
+	)
+	{
+		if (HasAssetReference(path))
+		{
+			return false;
+		}
+
+		return AddOrUpdateAssetReference(AllocateAssetId(), type, std::move(path));
+	}
+
 	bool ProjectSessionPersistence::RemoveAssetReference(Ludus::Engine::Core::AssetId id)
 	{
 		auto& assets = m_RuntimeManifest.Assets;

--- a/Editor/Source/Ludus/Editor/Panels/ContentPanel.cpp
+++ b/Editor/Source/Ludus/Editor/Panels/ContentPanel.cpp
@@ -22,6 +22,11 @@ namespace Ludus::Editor::Panels
 	{
 		namespace EditorCore = Ludus::Editor::Core;
 
+		bool IsCandidateAsset(const std::optional<EditorCore::AssetRefreshEntry>& classification)
+		{
+			return classification && classification->Classification == EditorCore::AssetRefreshClassification::Candidate;
+		}
+
 		Ludus::UI::Elements::ContentBrowser::EntryPresentation CreateAssetEntryPresentation(
 			const EditorCore::ProjectSessionPersistence& persistence,
 			const Ludus::UI::Elements::ContentBrowser::EntryContext& entry
@@ -69,14 +74,15 @@ namespace Ludus::Editor::Panels
 
 			}, [&](const Ludus::UI::Elements::ContentBrowser::EntryContext& entry)
 			{
-				// Callback to populate the context menu for an entry in the content browser.
+				const auto classification = EditorCore::TryClassifyAssetFile(
+					context.ProjectSession.Persistence,
+					entry.Path
+				);
 				const auto isSceneFile =
 					!entry.IsDirectory &&
-					Ludus::Engine::FileSystem::HasLogicalExtension(
-						entry.Path,
-						Ludus::Engine::Persistence::Paths::Constants::SceneExtension
-					);
+					Ludus::Engine::FileSystem::HasLogicalExtension(entry.Path, Ludus::Engine::Persistence::Paths::Constants::SceneExtension);
 				const auto canOpen = isSceneFile;
+				const auto canIncludeInProject = !entry.IsDirectory && IsCandidateAsset(classification);
 				const auto canDelete = !entry.IsDirectory && !isSceneFile;
 
 				if (Ludus::UI::Widgets::MenuItem("Open", nullptr, false, canOpen))
@@ -86,14 +92,17 @@ namespace Ludus::Editor::Panels
 					);
 				}
 
+				if (Ludus::UI::Widgets::MenuItem("Include in Project", nullptr, false, canIncludeInProject))
+				{
+					context.Shell.State.Commands.AddRequestCommand(
+						Ludus::Editor::Commands::RequestCommand::IncludeAsset { entry.Path }
+					);
+				}
+
 				if (Ludus::UI::Widgets::MenuItem("Delete", nullptr, false, canDelete))
 				{
 					pendingDeletePath = entry.Path;
 				}
-			}, [&](const Ludus::UI::Elements::ContentBrowser::DirectoryContext& directory)
-			{
-				// Callback to populate the background context menu for the current directory.
-				(void)directory;
 			});
 
 			if (pendingDeletePath)

--- a/EditorTests/Ludus/EditorTests/Core/ProjectSessionPersistenceTests.cpp
+++ b/EditorTests/Ludus/EditorTests/Core/ProjectSessionPersistenceTests.cpp
@@ -175,4 +175,72 @@ namespace Ludus::EditorTests::Core
 		ASSERT_EQ(persistence.GetAssets().size(), 1);
 		ASSERT_EQ(persistence.GetAssets().front().Path, std::filesystem::path("Assets") / "Missing.png");
 	}
+
+	TEST(ProjectSessionPersistence, IncludeAsset_RegistersCandidateAndRefreshClassifiesItAsRegistered)
+	{
+		// Arrange.
+		const auto tempDirectoryScope = CreateTestDirectory();
+		const auto projectRoot = tempDirectoryScope.Path / "Sandbox";
+		const auto candidatePath = Ludus::Engine::Persistence::Paths::AssetsDirectory(projectRoot) / "Candidate.png";
+		std::filesystem::create_directories(candidatePath.parent_path());
+		FileSystem::WriteAllText(candidatePath, "");
+
+		auto persistence = CreatePersistence(projectRoot, { });
+		const auto before = persistence.RefreshAssets();
+		ASSERT_NE(
+			FindEntry(
+				before,
+				EditorCore::AssetRefreshClassification::Candidate,
+				std::filesystem::path("Assets") / "Candidate.png"
+			),
+			nullptr
+		);
+
+		// Act.
+		const auto included = persistence.IncludeAsset(
+			Ludus::Engine::Core::AssetType::Texture2D,
+			candidatePath
+		);
+		const auto after = persistence.RefreshAssets();
+
+		// Assert.
+		ASSERT_TRUE(included);
+		ASSERT_EQ(persistence.GetAssets().size(), 1);
+		ASSERT_TRUE(persistence.GetAssets().front().Id.IsValid());
+		ASSERT_EQ(persistence.GetAssets().front().Type, Ludus::Engine::Core::AssetType::Texture2D);
+		ASSERT_EQ(persistence.GetAssets().front().Path, std::filesystem::path("Assets") / "Candidate.png");
+		ASSERT_EQ(after.RegisteredCount, 1);
+		ASSERT_EQ(after.CandidateCount, 0);
+		ASSERT_NE(
+			FindEntry(
+				after,
+				EditorCore::AssetRefreshClassification::Registered,
+				std::filesystem::path("Assets") / "Candidate.png"
+			),
+			nullptr
+		);
+	}
+
+	TEST(ProjectSessionPersistence, IncludeAsset_DoesNotRegisterDuplicatePath)
+	{
+		// Arrange.
+		const auto tempDirectoryScope = CreateTestDirectory();
+		const auto projectRoot = tempDirectoryScope.Path / "Sandbox";
+		const auto candidatePath = Ludus::Engine::Persistence::Paths::AssetsDirectory(projectRoot) / "Candidate.png";
+		std::filesystem::create_directories(candidatePath.parent_path());
+		FileSystem::WriteAllText(candidatePath, "");
+
+		auto persistence = CreatePersistence(projectRoot, { });
+		ASSERT_TRUE(persistence.IncludeAsset(Ludus::Engine::Core::AssetType::Texture2D, candidatePath));
+
+		// Act.
+		const auto includedAgain = persistence.IncludeAsset(
+			Ludus::Engine::Core::AssetType::Texture2D,
+			candidatePath
+		);
+
+		// Assert.
+		ASSERT_FALSE(includedAgain);
+		ASSERT_EQ(persistence.GetAssets().size(), 1);
+	}
 }

--- a/Engine/Include/Ludus/Engine/Core/AssetRegistry.h
+++ b/Engine/Include/Ludus/Engine/Core/AssetRegistry.h
@@ -63,6 +63,11 @@ namespace Ludus::Engine::Core
 			}
 		}
 
+		void RegisterAsset(Ludus::Engine::Runtime::AssetReference assetReference)
+		{
+			CommitAsset(std::move(assetReference));
+		}
+
 		std::span<const Ludus::Engine::Runtime::AssetReference> View() const
 		{
 			return { m_References.data(), m_References.size() };

--- a/EngineTests/Ludus/EngineTests/Core/AssetManagerTests.cpp
+++ b/EngineTests/Ludus/EngineTests/Core/AssetManagerTests.cpp
@@ -257,4 +257,23 @@ namespace Ludus::EngineTests::Core
 		// Act & Assert.
 		ASSERT_THROW((void)AssetRegistry { runtimeManifest }, std::runtime_error);
 	}
+
+	TEST(AssetRegistry, RegisterAsset_AddsReferenceAfterConstruction)
+	{
+		// Arrange.
+		const auto runtimeManifest = RuntimeManifest::Create();
+		auto assetRegistry = AssetRegistry(runtimeManifest);
+		const auto assetReference = MakeTextureAssetReference(
+			AssetId { 1 },
+			std::filesystem::path("Assets") / "Texture.png"
+		);
+
+		// Act.
+		assetRegistry.RegisterAsset(assetReference);
+
+		// Assert.
+		ASSERT_TRUE(assetRegistry.Contains(assetReference.Id));
+		ASSERT_EQ(assetRegistry.GetAsset(assetReference.Id).Type, AssetType::Texture2D);
+		ASSERT_EQ(assetRegistry.GetAsset(assetReference.Id).Path, assetReference.Path);
+	}
 }


### PR DESCRIPTION
# Summary
Adds an "Include in Project" command for candidate texture files. Included textures are registered in project persistence and the live editor asset registry, then reclassified as Registered. Includes error handling and simple regression tests.

# Linked
- Closes #364 
- Story: #338 

