### PR TITLE
Refactor: Added independent persistence schema revisions

### DIFF
--- a/Editor/Include/Ludus/Editor/Core/Constants.h
+++ b/Editor/Include/Ludus/Editor/Core/Constants.h
@@ -1,10 +1,13 @@
 #pragma once
 
+#include <Ludus/Engine/Core/Version.h>
 #include <Ludus/Engine/Math/Vector2D.h>
 #include <Ludus/UI/Flags/Flags.h>
 
 namespace Ludus::Editor::Core::Constants
 {
+	inline constexpr Ludus::Engine::Core::Version CurrentVersion { 0, 2, 0 };
+
 	namespace Shared
 	{
 		inline constexpr float StandardInlineSpacing = 6.0f;

--- a/Editor/Include/Ludus/Editor/Core/ProjectManifest.h
+++ b/Editor/Include/Ludus/Editor/Core/ProjectManifest.h
@@ -1,24 +1,23 @@
 #pragma once
 
+#include <cstdint>
 #include <filesystem>
 #include <utility>
-
-#include <Ludus/Engine/Core/Version.h>
 
 namespace Ludus::Editor::Core
 {
 	struct ProjectManifest
 	{
-		inline static constexpr Ludus::Engine::Core::Version CurrentVersion = { 0, 2, 0 };
+		inline static constexpr std::uint32_t CurrentSchemaRevision = 1;
 
-		Ludus::Engine::Core::Version Version = CurrentVersion;
+		std::uint32_t SchemaRevision = CurrentSchemaRevision;
 		std::filesystem::path ProjectRoot;
 		std::filesystem::path RuntimeManifestPath;
 
 		static ProjectManifest Create(std::filesystem::path projectRoot, std::filesystem::path runtimeManifestPath)
 		{
 			return {
-				.Version = CurrentVersion,
+				.SchemaRevision = CurrentSchemaRevision,
 				.ProjectRoot = std::move(projectRoot),
 				.RuntimeManifestPath = std::move(runtimeManifestPath)
 			};

--- a/Editor/Source/Ludus/Editor/Core/WelcomeWindow.cpp
+++ b/Editor/Source/Ludus/Editor/Core/WelcomeWindow.cpp
@@ -6,7 +6,6 @@
 #include <Ludus/Editor/Commands/RequestCommand.h>
 #include <Ludus/Editor/Commands/UICommand.h>
 #include <Ludus/Editor/Core/Constants.h>
-#include <Ludus/Editor/Core/ProjectManifest.h>
 #include <Ludus/Editor/Core/WelcomeWindow.h>
 #include <Ludus/Editor/Persistence/ProjectPaths.h>
 #include <Ludus/Editor/Widgets/Buttons.h>
@@ -316,7 +315,7 @@ namespace Ludus::Editor::Core
 		void DrawWelcomeFooter(const Ludus::Engine::Math::Vector2D& windowSize)
 		{
 			const std::string version = Ludus::Engine::Core::Version::ToString(
-				Ludus::Editor::Core::ProjectManifest::CurrentVersion
+				Ludus::Editor::Core::Constants::CurrentVersion
 			);
 
 			const auto footerTextColor = Ludus::UI::Scope::StyleColor(

--- a/Editor/Source/Ludus/Editor/Serialization/ProjectManifestSchema.cpp
+++ b/Editor/Source/Ludus/Editor/Serialization/ProjectManifestSchema.cpp
@@ -18,15 +18,8 @@ namespace Ludus::Editor::Serialization::Schemas
 	{
 		writer.Emit(Token::StartObject { });
 
-		writer.Emit(Token::Key { "Version" });
-		writer.Emit(Token::StartObject { });
-		writer.Emit(Token::Key { "Major" });
-		writer.Emit(Token::Uint { projectManifest.Version.Major });
-		writer.Emit(Token::Key { "Minor" });
-		writer.Emit(Token::Uint { projectManifest.Version.Minor });
-		writer.Emit(Token::Key { "Patch" });
-		writer.Emit(Token::Uint { projectManifest.Version.Patch });
-		writer.Emit(Token::EndObject { });
+		writer.Emit(Token::Key { "SchemaRevision" });
+		writer.Emit(Token::Uint { projectManifest.SchemaRevision });
 
 		writer.Emit(Token::Key { "ProjectRoot" });
 		const auto projectRoot = Ludus::Engine::FileSystem::ToPortablePathString(projectManifest.ProjectRoot);
@@ -45,48 +38,21 @@ namespace Ludus::Editor::Serialization::Schemas
 
 		try
 		{
-			bool hasVersion = false;
+			bool hasSchemaRevision = false;
 			bool hasProjectRoot = false;
 			bool hasRuntimeManifestPath = false;
 
 			Ludus::Engine::Serialization::Core::ReadObject(reader, [&](std::string_view key)
 			{
-				if (key == "Version")
+				if (key == "SchemaRevision")
 				{
-					bool hasMajor = false;
-					bool hasMinor = false;
-					bool hasPatch = false;
-
-					Ludus::Engine::Serialization::Core::ReadObject(reader, [&](std::string_view versionKey)
+					projectManifest.SchemaRevision = Ludus::Engine::Serialization::Core::ConsumeUint32Like(reader);
+					if (projectManifest.SchemaRevision != ProjectManifest::CurrentSchemaRevision)
 					{
-						if (versionKey == "Major")
-						{
-							projectManifest.Version.Major = Ludus::Engine::Serialization::Core::ConsumeUint32Like(reader);
-							hasMajor = true;
-							return;
-						}
-						if (versionKey == "Minor")
-						{
-							projectManifest.Version.Minor = Ludus::Engine::Serialization::Core::ConsumeUint32Like(reader);
-							hasMinor = true;
-							return;
-						}
-						if (versionKey == "Patch")
-						{
-							projectManifest.Version.Patch = Ludus::Engine::Serialization::Core::ConsumeUint32Like(reader);
-							hasPatch = true;
-							return;
-						}
-
-						Ludus::Engine::Serialization::Core::SkipValue(reader);
-					});
-
-					if (!hasMajor || !hasMinor || !hasPatch)
-					{
-						throw SerializationException("ProjectManifest version is incomplete.");
+						throw SerializationException("ProjectManifest schema revision is not supported.");
 					}
 
-					hasVersion = true;
+					hasSchemaRevision = true;
 					return;
 				}
 				if (key == "RuntimeManifestPath")
@@ -109,9 +75,9 @@ namespace Ludus::Editor::Serialization::Schemas
 				Ludus::Engine::Serialization::Core::SkipValue(reader);
 			});
 
-			if (!hasVersion)
+			if (!hasSchemaRevision)
 			{
-				throw SerializationException("ProjectManifest version not found.");
+				throw SerializationException("ProjectManifest schema revision not found.");
 			}
 
 			if (!hasRuntimeManifestPath)

--- a/EditorTests/Ludus/EditorTests/Serialization/Schemas/ProjectManifestSchemaTests.cpp
+++ b/EditorTests/Ludus/EditorTests/Serialization/Schemas/ProjectManifestSchemaTests.cpp
@@ -40,13 +40,13 @@ namespace Ludus::EditorTests::Serialization::Schemas
 		return nullptr;
 	}
 
-	TEST(ProjectManifestSchema, Serialize_WritesVersionProjectRootAndRuntimeManifestPath_When_ProjectManifestIsValid)
+	TEST(ProjectManifestSchema, Serialize_WritesSchemaRevisionProjectRootAndRuntimeManifestPath_When_ProjectManifestIsValid)
 	{
 		// Arrange.
 		DomDocument document;
 		DomTokenStreamWriter writer(document);
 		ProjectManifest manifest;
-		manifest.Version = { 7, 8, 9 };
+		manifest.SchemaRevision = 7;
 		manifest.ProjectRoot = std::filesystem::path("Projects/Game");
 		manifest.RuntimeManifestPath = std::filesystem::path("Game.runtime.ludus");
 
@@ -58,18 +58,18 @@ namespace Ludus::EditorTests::Serialization::Schemas
 		ASSERT_NE(root, nullptr);
 
 		const auto& manifestObject = AsObject(*root);
-		const auto* versionNode = FindMember(manifestObject, "Version");
+		const auto* schemaRevisionNode = FindMember(manifestObject, "SchemaRevision");
 		const auto* projectRootNode = FindMember(manifestObject, "ProjectRoot");
 		const auto* runtimeManifestPathNode = FindMember(manifestObject, "RuntimeManifestPath");
 
-		ASSERT_NE(versionNode, nullptr);
+		ASSERT_NE(schemaRevisionNode, nullptr);
 		ASSERT_NE(projectRootNode, nullptr);
 		ASSERT_NE(runtimeManifestPathNode, nullptr);
 
-		const auto& versionObject = AsObject(*versionNode);
-		ASSERT_EQ(std::get<uint64_t>(AsValue(*FindMember(versionObject, "Major"))), manifest.Version.Major);
-		ASSERT_EQ(std::get<uint64_t>(AsValue(*FindMember(versionObject, "Minor"))), manifest.Version.Minor);
-		ASSERT_EQ(std::get<uint64_t>(AsValue(*FindMember(versionObject, "Patch"))), manifest.Version.Patch);
+		ASSERT_EQ(
+			std::get<uint64_t>(AsValue(*schemaRevisionNode)),
+			manifest.SchemaRevision
+		);
 
 		const auto projectRoot = std::get<std::string>(AsValue(*projectRootNode));
 		ASSERT_EQ(projectRoot, "Projects/Game");
@@ -96,7 +96,7 @@ namespace Ludus::EditorTests::Serialization::Schemas
 
 		const auto& manifestObject = AsObject(*root);
 		ASSERT_EQ(manifestObject.size(), 3u);
-		ASSERT_NE(FindMember(manifestObject, "Version"), nullptr);
+		ASSERT_NE(FindMember(manifestObject, "SchemaRevision"), nullptr);
 		ASSERT_NE(FindMember(manifestObject, "ProjectRoot"), nullptr);
 		ASSERT_NE(FindMember(manifestObject, "RuntimeManifestPath"), nullptr);
 		ASSERT_EQ(FindMember(manifestObject, "Scenes"), nullptr);
@@ -104,21 +104,14 @@ namespace Ludus::EditorTests::Serialization::Schemas
 		ASSERT_EQ(FindMember(manifestObject, "EntrySceneId"), nullptr);
 	}
 
-	TEST(ProjectManifestSchema, Deserialize_ReadsVersionProjectRootAndRuntimeManifestPath_When_ArchiveIsValid)
+	TEST(ProjectManifestSchema, Deserialize_ReadsProjectRootAndRuntimeManifestPath_When_ArchiveIsValid)
 	{
 		// Arrange.
 		DomDocument document;
 		DomTokenStreamWriter writer(document);
 		writer.Emit(Token::StartObject { });
-		writer.Emit(Token::Key { "Version" });
-		writer.Emit(Token::StartObject { });
-		writer.Emit(Token::Key { "Major" });
-		writer.Emit(Token::Int { 7 });
-		writer.Emit(Token::Key { "Minor" });
-		writer.Emit(Token::Int { 8 });
-		writer.Emit(Token::Key { "Patch" });
-		writer.Emit(Token::Int { 9 });
-		writer.Emit(Token::EndObject { });
+		writer.Emit(Token::Key { "SchemaRevision" });
+		writer.Emit(Token::Int { ProjectManifest::CurrentSchemaRevision });
 		writer.Emit(Token::Key { "ProjectRoot" });
 		writer.Emit(Token::String { "Projects/Game" });
 		writer.Emit(Token::Key { "RuntimeManifestPath" });
@@ -133,9 +126,7 @@ namespace Ludus::EditorTests::Serialization::Schemas
 		ASSERT_TRUE(result.HasValue());
 
 		const auto& manifest = result.GetValue();
-		ASSERT_EQ(manifest.Version.Major, 7u);
-		ASSERT_EQ(manifest.Version.Minor, 8u);
-		ASSERT_EQ(manifest.Version.Patch, 9u);
+		ASSERT_EQ(manifest.SchemaRevision, ProjectManifest::CurrentSchemaRevision);
 		ASSERT_EQ(manifest.ProjectRoot, std::filesystem::path("Projects/Game"));
 		ASSERT_EQ(manifest.RuntimeManifestPath, std::filesystem::path("Game.runtime.ludus"));
 	}
@@ -158,9 +149,7 @@ namespace Ludus::EditorTests::Serialization::Schemas
 		ASSERT_TRUE(result.HasValue());
 
 		const auto& loadedManifest = result.GetValue();
-		ASSERT_EQ(loadedManifest.Version.Major, manifest.Version.Major);
-		ASSERT_EQ(loadedManifest.Version.Minor, manifest.Version.Minor);
-		ASSERT_EQ(loadedManifest.Version.Patch, manifest.Version.Patch);
+		ASSERT_EQ(loadedManifest.SchemaRevision, manifest.SchemaRevision);
 		ASSERT_EQ(loadedManifest.ProjectRoot, manifest.ProjectRoot);
 		ASSERT_EQ(loadedManifest.RuntimeManifestPath, manifest.RuntimeManifestPath);
 	}
@@ -180,12 +169,63 @@ namespace Ludus::EditorTests::Serialization::Schemas
 		ASSERT_FALSE(result.HasValue());
 	}
 
-	TEST(ProjectManifestSchema, Deserialize_Fails_When_VersionMissing)
+	TEST(ProjectManifestSchema, Deserialize_Fails_When_SchemaRevisionMissing)
 	{
 		// Arrange.
 		DomDocument document;
 		DomTokenStreamWriter writer(document);
 		writer.Emit(Token::StartObject { });
+		writer.Emit(Token::Key { "ProjectRoot" });
+		writer.Emit(Token::String { "Projects/Game" });
+		writer.Emit(Token::Key { "RuntimeManifestPath" });
+		writer.Emit(Token::String { "Game.runtime.ludus" });
+		writer.Emit(Token::EndObject { });
+		DomTokenStreamReader reader(document);
+
+		// Act.
+		const auto result = ProjectManifestSchema::Deserialize(reader);
+
+		// Assert.
+		ASSERT_FALSE(result.HasValue());
+	}
+
+	TEST(ProjectManifestSchema, Deserialize_Fails_When_SchemaRevisionIsUnsupported)
+	{
+		// Arrange.
+		DomDocument document;
+		DomTokenStreamWriter writer(document);
+		writer.Emit(Token::StartObject { });
+		writer.Emit(Token::Key { "SchemaRevision" });
+		writer.Emit(Token::Int { 2 });
+		writer.Emit(Token::Key { "ProjectRoot" });
+		writer.Emit(Token::String { "Projects/Game" });
+		writer.Emit(Token::Key { "RuntimeManifestPath" });
+		writer.Emit(Token::String { "Game.runtime.ludus" });
+		writer.Emit(Token::EndObject { });
+		DomTokenStreamReader reader(document);
+
+		// Act.
+		const auto result = ProjectManifestSchema::Deserialize(reader);
+
+		// Assert.
+		ASSERT_FALSE(result.HasValue());
+	}
+
+	TEST(ProjectManifestSchema, Deserialize_Fails_When_LegacyVersionIsUsed)
+	{
+		// Arrange.
+		DomDocument document;
+		DomTokenStreamWriter writer(document);
+		writer.Emit(Token::StartObject { });
+		writer.Emit(Token::Key { "Version" });
+		writer.Emit(Token::StartObject { });
+		writer.Emit(Token::Key { "Major" });
+		writer.Emit(Token::Int { 0 });
+		writer.Emit(Token::Key { "Minor" });
+		writer.Emit(Token::Int { 3 });
+		writer.Emit(Token::Key { "Patch" });
+		writer.Emit(Token::Int { 0 });
+		writer.Emit(Token::EndObject { });
 		writer.Emit(Token::Key { "ProjectRoot" });
 		writer.Emit(Token::String { "Projects/Game" });
 		writer.Emit(Token::Key { "RuntimeManifestPath" });
@@ -206,15 +246,8 @@ namespace Ludus::EditorTests::Serialization::Schemas
 		DomDocument document;
 		DomTokenStreamWriter writer(document);
 		writer.Emit(Token::StartObject { });
-		writer.Emit(Token::Key { "Version" });
-		writer.Emit(Token::StartObject { });
-		writer.Emit(Token::Key { "Major" });
-		writer.Emit(Token::Int { 0 });
-		writer.Emit(Token::Key { "Minor" });
-		writer.Emit(Token::Int { 2 });
-		writer.Emit(Token::Key { "Patch" });
-		writer.Emit(Token::Int { 0 });
-		writer.Emit(Token::EndObject { });
+		writer.Emit(Token::Key { "SchemaRevision" });
+		writer.Emit(Token::Int { ProjectManifest::CurrentSchemaRevision });
 		writer.Emit(Token::Key { "ProjectRoot" });
 		writer.Emit(Token::String { "Projects/Game" });
 		writer.Emit(Token::EndObject { });
@@ -233,15 +266,8 @@ namespace Ludus::EditorTests::Serialization::Schemas
 		DomDocument document;
 		DomTokenStreamWriter writer(document);
 		writer.Emit(Token::StartObject { });
-		writer.Emit(Token::Key { "Version" });
-		writer.Emit(Token::StartObject { });
-		writer.Emit(Token::Key { "Major" });
-		writer.Emit(Token::Int { 0 });
-		writer.Emit(Token::Key { "Minor" });
-		writer.Emit(Token::Int { 3 });
-		writer.Emit(Token::Key { "Patch" });
-		writer.Emit(Token::Int { 0 });
-		writer.Emit(Token::EndObject { });
+		writer.Emit(Token::Key { "SchemaRevision" });
+		writer.Emit(Token::Int { ProjectManifest::CurrentSchemaRevision });
 		writer.Emit(Token::Key { "RuntimeManifestPath" });
 		writer.Emit(Token::String { "Game.runtime.ludus" });
 		writer.Emit(Token::EndObject { });
@@ -260,15 +286,8 @@ namespace Ludus::EditorTests::Serialization::Schemas
 		DomDocument document;
 		DomTokenStreamWriter writer(document);
 		writer.Emit(Token::StartObject { });
-		writer.Emit(Token::Key { "Version" });
-		writer.Emit(Token::StartObject { });
-		writer.Emit(Token::Key { "Major" });
-		writer.Emit(Token::Int { 0 });
-		writer.Emit(Token::Key { "Minor" });
-		writer.Emit(Token::Int { 2 });
-		writer.Emit(Token::Key { "Patch" });
-		writer.Emit(Token::Int { 0 });
-		writer.Emit(Token::EndObject { });
+		writer.Emit(Token::Key { "SchemaRevision" });
+		writer.Emit(Token::Int { ProjectManifest::CurrentSchemaRevision });
 		writer.Emit(Token::Key { "ProjectRoot" });
 		writer.Emit(Token::String { "Projects/Game" });
 		writer.Emit(Token::Key { "RuntimeManifestPath" });
@@ -289,15 +308,8 @@ namespace Ludus::EditorTests::Serialization::Schemas
 		DomDocument document;
 		DomTokenStreamWriter writer(document);
 		writer.Emit(Token::StartObject { });
-		writer.Emit(Token::Key { "Version" });
-		writer.Emit(Token::StartObject { });
-		writer.Emit(Token::Key { "Major" });
-		writer.Emit(Token::Int { 0 });
-		writer.Emit(Token::Key { "Minor" });
-		writer.Emit(Token::Int { 3 });
-		writer.Emit(Token::Key { "Patch" });
-		writer.Emit(Token::Int { 0 });
-		writer.Emit(Token::EndObject { });
+		writer.Emit(Token::Key { "SchemaRevision" });
+		writer.Emit(Token::Int { ProjectManifest::CurrentSchemaRevision });
 		writer.Emit(Token::Key { "ProjectRoot" });
 		writer.Emit(Token::Int { 1 });
 		writer.Emit(Token::Key { "RuntimeManifestPath" });

--- a/Engine/Include/Ludus/Engine/Runtime/RuntimeManifest.h
+++ b/Engine/Include/Ludus/Engine/Runtime/RuntimeManifest.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <filesystem>
 #include <string>
 #include <utility>
@@ -7,7 +8,6 @@
 
 #include <Ludus/Engine/Core/AssetType.h>
 #include <Ludus/Engine/Core/Id.h>
-#include <Ludus/Engine/Core/Version.h>
 
 namespace Ludus::Engine::Runtime
 {
@@ -33,9 +33,9 @@ namespace Ludus::Engine::Runtime
 
 	struct RuntimeManifest
 	{
-		inline static constexpr Ludus::Engine::Core::Version CurrentVersion = { 0, 2, 0 };
+		inline static constexpr std::uint32_t CurrentSchemaRevision = 1;
 
-		Ludus::Engine::Core::Version Version = CurrentVersion;
+		std::uint32_t SchemaRevision = CurrentSchemaRevision;
 		Ludus::Engine::Core::SceneId EntrySceneId { Ludus::Engine::Core::SceneId::Invalid() };
 		std::vector<SceneReference> Scenes;
 		std::vector<ScriptReference> Scripts;
@@ -49,7 +49,7 @@ namespace Ludus::Engine::Runtime
 		)
 		{
 			return {
-				.Version = CurrentVersion,
+				.SchemaRevision = CurrentSchemaRevision,
 				.EntrySceneId = entrySceneId,
 				.Scenes = std::move(scenes),
 				.Scripts = std::move(scripts),

--- a/Engine/Source/Ludus/Engine/Serialization/Schemas/RuntimeManifestSchema.cpp
+++ b/Engine/Source/Ludus/Engine/Serialization/Schemas/RuntimeManifestSchema.cpp
@@ -22,15 +22,8 @@ namespace Ludus::Engine::Serialization::Schemas
 	{
 		writer.Emit(Token::StartObject { });
 
-		writer.Emit(Token::Key { "Version" });
-		writer.Emit(Token::StartObject { });
-		writer.Emit(Token::Key { "Major" });
-		writer.Emit(Token::Uint { runtimeManifest.Version.Major });
-		writer.Emit(Token::Key { "Minor" });
-		writer.Emit(Token::Uint { runtimeManifest.Version.Minor });
-		writer.Emit(Token::Key { "Patch" });
-		writer.Emit(Token::Uint { runtimeManifest.Version.Patch });
-		writer.Emit(Token::EndObject { });
+		writer.Emit(Token::Key { "SchemaRevision" });
+		writer.Emit(Token::Uint { runtimeManifest.SchemaRevision });
 
 		writer.Emit(Token::Key { "EntrySceneId" });
 		writer.Emit(Token::Uint { runtimeManifest.EntrySceneId.Value });
@@ -107,53 +100,20 @@ namespace Ludus::Engine::Serialization::Schemas
 
 		try
 		{
-			bool hasVersion = false;
+			bool hasSchemaRevision = false;
 			bool hasEntrySceneId = false;
 
 			Ludus::Engine::Serialization::Core::ReadObject(reader, [&](std::string_view key)
 			{
-				if (key == "Version")
+				if (key == "SchemaRevision")
 				{
-					bool hasMajor = false;
-					bool hasMinor = false;
-					bool hasPatch = false;
-
-					Ludus::Engine::Serialization::Core::ReadObject(reader, [&](std::string_view versionKey)
+					runtimeManifest.SchemaRevision = Ludus::Engine::Serialization::Core::ConsumeUint32Like(reader);
+					if (runtimeManifest.SchemaRevision != RuntimeManifest::CurrentSchemaRevision)
 					{
-						if (versionKey == "Major")
-						{
-							runtimeManifest.Version.Major = Ludus::Engine::Serialization::Core::ConsumeUint32Like(reader);
-							hasMajor = true;
-							return;
-						}
-						if (versionKey == "Minor")
-						{
-							runtimeManifest.Version.Minor = Ludus::Engine::Serialization::Core::ConsumeUint32Like(reader);
-							hasMinor = true;
-							return;
-						}
-						if (versionKey == "Patch")
-						{
-							runtimeManifest.Version.Patch = Ludus::Engine::Serialization::Core::ConsumeUint32Like(reader);
-							hasPatch = true;
-							return;
-						}
-
-						Ludus::Engine::Serialization::Core::SkipValue(reader);
-					});
-
-					if (!hasMajor || !hasMinor || !hasPatch)
-					{
-						throw SerializationException("RuntimeManifest version is incomplete.");
-					}
-					if (runtimeManifest.Version.Major != RuntimeManifest::CurrentVersion.Major ||
-						runtimeManifest.Version.Minor != RuntimeManifest::CurrentVersion.Minor ||
-						runtimeManifest.Version.Patch != RuntimeManifest::CurrentVersion.Patch)
-					{
-						throw SerializationException("RuntimeManifest version does not match the current schema version.");
+						throw SerializationException("RuntimeManifest schema revision is not supported.");
 					}
 
-					hasVersion = true;
+					hasSchemaRevision = true;
 					return;
 				}
 				if (key == "Scenes")
@@ -330,9 +290,9 @@ namespace Ludus::Engine::Serialization::Schemas
 				Ludus::Engine::Serialization::Core::SkipValue(reader);
 			});
 
-			if (!hasVersion)
+			if (!hasSchemaRevision)
 			{
-				throw SerializationException("RuntimeManifest version not found.");
+				throw SerializationException("RuntimeManifest schema revision not found.");
 			}
 			if (!hasEntrySceneId)
 			{

--- a/EngineTests/Ludus/EngineTests/Serialization/Schemas/RuntimeManifestSchemaTests.cpp
+++ b/EngineTests/Ludus/EngineTests/Serialization/Schemas/RuntimeManifestSchemaTests.cpp
@@ -103,35 +103,31 @@ namespace Ludus::EngineTests::Serialization::Schemas
 		);
 	}
 
-	static void WriteVersion(DomTokenStreamWriter& writer, int64_t major, int64_t minor, int64_t patch)
+	static void WriteSchemaRevision(
+		DomTokenStreamWriter& writer,
+		int64_t revision = RuntimeManifest::CurrentSchemaRevision
+	)
 	{
-		writer.Emit(Token::Key { "Version" });
-		writer.Emit(Token::StartObject { });
-		writer.Emit(Token::Key { "Major" });
-		writer.Emit(Token::Int { major });
-		writer.Emit(Token::Key { "Minor" });
-		writer.Emit(Token::Int { minor });
-		writer.Emit(Token::Key { "Patch" });
-		writer.Emit(Token::Int { patch });
-		writer.Emit(Token::EndObject { });
+		writer.Emit(Token::Key { "SchemaRevision" });
+		writer.Emit(Token::Int { revision });
 	}
 
-	TEST(RuntimeManifestSchema, Serialize_WritesVersion_When_RuntimeManifestIsSerialized)
+	TEST(RuntimeManifestSchema, Serialize_WritesSchemaRevision_When_RuntimeManifestIsSerialized)
 	{
 		// Arrange.
 		DomDocument document;
 		DomTokenStreamWriter writer(document);
-		const RuntimeManifest manifest = MakeRuntimeManifest();
+		const auto manifest = MakeRuntimeManifest();
 
 		// Act.
 		RuntimeManifestSchema::Serialize(writer, manifest);
 
 		// Assert.
 		const auto& manifestObject = AsObject(*document.GetRoot());
-		const auto& versionObject = AsObject(*FindMember(manifestObject, "Version"));
-		ASSERT_EQ(std::get<uint64_t>(AsValue(*FindMember(versionObject, "Major"))), manifest.Version.Major);
-		ASSERT_EQ(std::get<uint64_t>(AsValue(*FindMember(versionObject, "Minor"))), manifest.Version.Minor);
-		ASSERT_EQ(std::get<uint64_t>(AsValue(*FindMember(versionObject, "Patch"))), manifest.Version.Patch);
+		ASSERT_EQ(
+			std::get<uint64_t>(AsValue(*FindMember(manifestObject, "SchemaRevision"))),
+			manifest.SchemaRevision
+		);
 	}
 
 	TEST(RuntimeManifestSchema, Serialize_WritesIds_When_RuntimeManifestHasReferences)
@@ -172,6 +168,7 @@ namespace Ludus::EngineTests::Serialization::Schemas
 		// Assert.
 		ASSERT_TRUE(result.HasValue());
 		const auto& loadedManifest = result.GetValue();
+		ASSERT_EQ(loadedManifest.SchemaRevision, manifest.SchemaRevision);
 		ASSERT_EQ(loadedManifest.EntrySceneId, manifest.EntrySceneId);
 		ASSERT_EQ(loadedManifest.Scenes.size(), manifest.Scenes.size());
 		ASSERT_EQ(loadedManifest.Scripts.size(), manifest.Scripts.size());
@@ -198,7 +195,7 @@ namespace Ludus::EngineTests::Serialization::Schemas
 		}
 	}
 
-	TEST(RuntimeManifestSchema, Deserialize_Fails_When_VersionMissing)
+	TEST(RuntimeManifestSchema, Deserialize_Fails_When_SchemaRevisionMissing)
 	{
 		// Arrange.
 		DomDocument document;
@@ -222,13 +219,71 @@ namespace Ludus::EngineTests::Serialization::Schemas
 		ASSERT_FALSE(result.HasValue());
 	}
 
+	TEST(RuntimeManifestSchema, Deserialize_Fails_When_SchemaRevisionIsUnsupported)
+	{
+		// Arrange.
+		DomDocument document;
+		DomTokenStreamWriter writer(document);
+		writer.Emit(Token::StartObject { });
+		WriteSchemaRevision(writer, 2);
+		writer.Emit(Token::Key { "EntrySceneId" });
+		writer.Emit(Token::Uint { 0 });
+		writer.Emit(Token::Key { "Scenes" });
+		writer.Emit(Token::StartArray { });
+		writer.Emit(Token::EndArray { });
+		writer.Emit(Token::Key { "Scripts" });
+		writer.Emit(Token::StartArray { });
+		writer.Emit(Token::EndArray { });
+		writer.Emit(Token::EndObject { });
+		DomTokenStreamReader reader(document);
+
+		// Act.
+		const auto result = RuntimeManifestSchema::Deserialize(reader);
+
+		// Assert.
+		ASSERT_FALSE(result.HasValue());
+	}
+
+	TEST(RuntimeManifestSchema, Deserialize_Fails_When_LegacyVersionIsUsed)
+	{
+		// Arrange.
+		DomDocument document;
+		DomTokenStreamWriter writer(document);
+		writer.Emit(Token::StartObject { });
+		writer.Emit(Token::Key { "Version" });
+		writer.Emit(Token::StartObject { });
+		writer.Emit(Token::Key { "Major" });
+		writer.Emit(Token::Int { 0 });
+		writer.Emit(Token::Key { "Minor" });
+		writer.Emit(Token::Int { 3 });
+		writer.Emit(Token::Key { "Patch" });
+		writer.Emit(Token::Int { 0 });
+		writer.Emit(Token::EndObject { });
+		writer.Emit(Token::Key { "EntrySceneId" });
+		writer.Emit(Token::Uint { 0 });
+		writer.Emit(Token::Key { "Scenes" });
+		writer.Emit(Token::StartArray { });
+		writer.Emit(Token::EndArray { });
+		writer.Emit(Token::Key { "Scripts" });
+		writer.Emit(Token::StartArray { });
+		writer.Emit(Token::EndArray { });
+		writer.Emit(Token::EndObject { });
+		DomTokenStreamReader reader(document);
+
+		// Act.
+		const auto result = RuntimeManifestSchema::Deserialize(reader);
+
+		// Assert.
+		ASSERT_FALSE(result.HasValue());
+	}
+
 	TEST(RuntimeManifestSchema, Deserialize_Fails_When_EntrySceneIdDoesNotMatchSceneReference)
 	{
 		// Arrange.
 		DomDocument document;
 		DomTokenStreamWriter writer(document);
 		writer.Emit(Token::StartObject { });
-		WriteVersion(writer, RuntimeManifest::CurrentVersion.Major, RuntimeManifest::CurrentVersion.Minor, RuntimeManifest::CurrentVersion.Patch);
+		WriteSchemaRevision(writer);
 		writer.Emit(Token::Key { "EntrySceneId" });
 		writer.Emit(Token::Uint { 99 });
 		writer.Emit(Token::Key { "Scenes" });
@@ -261,7 +316,7 @@ namespace Ludus::EngineTests::Serialization::Schemas
 		DomDocument document;
 		DomTokenStreamWriter writer(document);
 		writer.Emit(Token::StartObject { });
-		WriteVersion(writer, RuntimeManifest::CurrentVersion.Major, RuntimeManifest::CurrentVersion.Minor, RuntimeManifest::CurrentVersion.Patch);
+		WriteSchemaRevision(writer);
 		writer.Emit(Token::Key { "EntrySceneId" });
 		writer.Emit(Token::Uint { 1 });
 		writer.Emit(Token::Key { "Scenes" });
@@ -295,7 +350,7 @@ namespace Ludus::EngineTests::Serialization::Schemas
 		DomDocument document;
 		DomTokenStreamWriter writer(document);
 		writer.Emit(Token::StartObject { });
-		WriteVersion(writer, RuntimeManifest::CurrentVersion.Major, RuntimeManifest::CurrentVersion.Minor, RuntimeManifest::CurrentVersion.Patch);
+		WriteSchemaRevision(writer);
 		writer.Emit(Token::Key { "EntrySceneId" });
 		writer.Emit(Token::Uint { 1 });
 		writer.Emit(Token::Key { "Scenes" });
@@ -339,7 +394,7 @@ namespace Ludus::EngineTests::Serialization::Schemas
 		DomDocument document;
 		DomTokenStreamWriter writer(document);
 		writer.Emit(Token::StartObject { });
-		WriteVersion(writer, RuntimeManifest::CurrentVersion.Major, RuntimeManifest::CurrentVersion.Minor, RuntimeManifest::CurrentVersion.Patch);
+		WriteSchemaRevision(writer);
 		writer.Emit(Token::Key { "EntrySceneId" });
 		writer.Emit(Token::Uint { 1 });
 		writer.Emit(Token::Key { "Scenes" });
@@ -383,7 +438,7 @@ namespace Ludus::EngineTests::Serialization::Schemas
 		DomDocument document;
 		DomTokenStreamWriter writer(document);
 		writer.Emit(Token::StartObject { });
-		WriteVersion(writer, RuntimeManifest::CurrentVersion.Major, RuntimeManifest::CurrentVersion.Minor, RuntimeManifest::CurrentVersion.Patch);
+		WriteSchemaRevision(writer);
 		writer.Emit(Token::Key { "EntrySceneId" });
 		writer.Emit(Token::Uint { 1 });
 		writer.Emit(Token::Key { "Scenes" });


### PR DESCRIPTION
# Summary
Separates the Ludus product version from persistence compatibility. Project and runtime manifests now use independent integer schema revisions, with revision 1 establishing a clean compatibility boundary.

# Linked
- Closes #378 
- Story: #338 
